### PR TITLE
fix: exec + discover_namespaces — join container PID namespace correctly

### DIFF
--- a/ONGOING_TASKS.md
+++ b/ONGOING_TASKS.md
@@ -1,155 +1,37 @@
 # Ongoing Tasks
 
-## Current task: Async TCP port proxy — multi-threaded runtime (2026-02-28)
+## Completed: remora exec PID namespace join (2026-02-28)
 
 ### Context
 
-Replace thread-per-connection TCP proxy with a tokio multi-threaded runtime.
-All accept loops and relay tasks run as async tasks distributed across a small
-worker thread pool (capped at `min(available_parallelism, 4)`). UDP unchanged.
+`remora exec` did not join the container's PID namespace. When a PID namespace is
+active, `state.pid` is the intermediate process P whose `/proc/P/ns/pid` is the host
+PID namespace. The fix uses `/proc/P/ns/pid_for_children` as a fallback in
+`discover_namespaces`, and implements a double-fork in `container.rs` step 1.65 to
+actually enter the target namespace (since `setns(CLONE_NEWPID)` alone only updates
+`pid_for_children` — the calling process is not moved; only a subsequent fork enters
+the new namespace, followed by exec).
 
-Reference: `docs/WATCHER_PROCESS_MODEL.md` § "Port-forward proxy threads".
+GitHub issue: #1 (closed by this work).
 
----
+### Files changed
 
-### Thread count change
-
-| Scenario | Before | After |
-|----------|--------|-------|
-| 1 TCP port, idle | 1 thread | W worker threads (W = min(cpus, 4)) |
-| 1 TCP port, N connections | 1 + 2N threads | W threads |
-| 1 TCP + 1 UDP port, N TCP connections | 2 + 2N threads | W + 1 threads |
-
----
-
-### Cargo.toml change
-
-Add `rt-multi-thread` to tokio features:
-
-```toml
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "net", "time", "io-util"] }
-```
+- `src/cli/exec.rs`: `discover_namespaces` — `pid_for_children` fallback
+- `src/container.rs`: step 1.65 Case B — PID namespace join double-fork (both
+  `spawn()` and `spawn_interactive()` pre-exec hooks)
+- `tests/integration_tests.rs`:
+  - `build_exec_command` helper updated with `pid_for_children` fallback
+  - new test `exec::test_exec_joins_pid_namespace`
+- `docs/WATCHER_PROCESS_MODEL.md`: updated caveat section, marked limitation fixed
+- `docs/INTEGRATION_TESTS.md`: added `test_exec_joins_pid_namespace` entry
 
 ---
 
-### `NetworkSetup` struct changes (`src/network.rs`)
+## Open GitHub issues (remaining work)
 
-Remove `proxy_stop: Option<Arc<AtomicBool>>`.
-Add two separate fields:
-
-```rust
-/// Tokio multi-thread runtime owning all TCP proxy tasks. Dropped (shutdown_background)
-/// during teardown to cancel accept loops and in-flight relay tasks.
-proxy_tcp_runtime: Option<tokio::runtime::Runtime>,
-/// Stop flag for UDP proxy threads (std threads, unchanged).
-proxy_udp_stop: Option<Arc<AtomicBool>>,
-```
-
-`Runtime` doesn't impl `Debug`, so update the manual `Debug` impl for
-`NetworkSetup` accordingly (replace `proxy_active` field with
-`proxy_tcp_active` and `proxy_udp_active`).
-
----
-
-### Functions removed from `src/network.rs`
-
-| Removed | Reason |
-|---------|--------|
-| `start_tcp_proxy_listener` | Replaced by `tcp_accept_loop` async fn |
-| `proxy_relay` | Replaced by `tcp_relay` async fn; also kills the raw-pointer `stop_flag` cast |
-| `copy_until_done` | Replaced by `tokio::io::copy_bidirectional` |
-
----
-
-### Functions added / changed in `src/network.rs`
-
-#### `fn start_tcp_proxies_async` (new)
-
-```rust
-fn start_tcp_proxies_async(
-    container_ip: Ipv4Addr,
-    tcp_forwards: &[(u16, u16)],
-) -> tokio::runtime::Runtime
-```
-
-Builds a `new_multi_thread()` runtime capped at `min(available_parallelism, 4)`
-workers. Spawns one `tcp_accept_loop` task per port. Returns the `Runtime` —
-the caller stores it; dropping it calls `shutdown_background`.
-
-#### `async fn tcp_accept_loop` (new)
-
-```rust
-async fn tcp_accept_loop(host_port: u16, target: SocketAddr)
-```
-
-Binds `tokio::net::TcpListener`. Loops on `listener.accept().await`. For each
-connection spawns a `tcp_relay` task. No stop flag — cancelled by runtime drop.
-
-#### `async fn tcp_relay` (new)
-
-```rust
-async fn tcp_relay(mut client: tokio::net::TcpStream, target: SocketAddr)
-```
-
-Connects to `target` with a 5 s timeout. Calls
-`tokio::io::copy_bidirectional(&mut client, &mut upstream)`.
-
-#### `start_port_proxies` (changed)
-
-Returns `(Option<tokio::runtime::Runtime>, Option<Arc<AtomicBool>>)` instead of
-`Arc<AtomicBool>`. TCP ports → `start_tcp_proxies_async`. UDP ports → existing
-`start_udp_proxy` threads unchanged.
-
----
-
-### `setup_bridge_network` and `teardown_network` changes
-
-`setup_bridge_network`: unpack tuple from `start_port_proxies`, store into
-`proxy_tcp_runtime` and `proxy_udp_stop`.
-
-`teardown_network`:
-```rust
-// TCP — drop runtime (shutdown_background cancels all tasks + worker threads)
-if let Some(rt) = setup.proxy_tcp_runtime.take() {
-    rt.shutdown_background();
-}
-// UDP — signal stop flag as before
-if let Some(ref stop) = setup.proxy_udp_stop {
-    stop.store(true, Ordering::Relaxed);
-}
-```
-
----
-
-### New integration test: `test_port_proxy_concurrent_connections`
-
-**Module:** `port_proxy`  **Requires:** root, alpine-rootfs.
-
-Spawn container with port 19192→8080 running an HTTP-ish TCP server that echoes
-back a unique token per connection. Open 5 simultaneous `TcpStream` connections
-from the host. Write a unique payload on each; read response; assert each gets
-its own payload back. Verifies the multi-threaded runtime schedules concurrent
-connections correctly.
-
----
-
-### Docs updates
-
-- `docs/WATCHER_PROCESS_MODEL.md`: update TCP thread inventory (one-thread-per-
-  connection → W async worker threads); update thread count formula.
-- `docs/INTEGRATION_TESTS.md`: add entry for `test_port_proxy_concurrent_connections`.
-
----
-
-### Implementation order
-
-1. `Cargo.toml`: add `rt-multi-thread`
-2. `src/network.rs`: add `tcp_accept_loop`, `tcp_relay`, `start_tcp_proxies_async`
-3. `src/network.rs`: change `start_port_proxies` return type
-4. `src/network.rs`: update `NetworkSetup`, its `Debug` impl, `setup_bridge_network`,
-   `teardown_network`
-5. `cargo test --lib` + integration tests — no regressions
-6. Add `test_port_proxy_concurrent_connections`
-7. Update docs
-8. `cargo clippy -- -D warnings` + `cargo fmt`
-9. Commit
+| # | Title |
+|---|-------|
+| #2 | Health probe timeout: hung probe child is not SIGKILL'd |
+| #3 | Log relay: thread-per-fd model wastes 2 threads per container |
+| #4 | UDP proxy: reply threads never explicitly joined |
+| #5 | Watcher death does not propagate SIGKILL to container PID 1 |

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -953,6 +953,22 @@ uses to reject exec into stopped containers.
 
 Failure indicates a kernel or procfs anomaly where dead PIDs still appear alive.
 
+### `test_exec_joins_pid_namespace`
+**Requires:** root, rootfs
+
+Starts a detached container with `remora run -d --rootfs alpine /bin/sleep 30`.
+The `--rootfs` path always enables `Namespace::PID`, so `state.pid` is the
+intermediate process P whose `/proc/P/ns/pid` is the host PID namespace, but
+`/proc/P/ns/pid_for_children` points to the container's PID namespace.
+
+Runs `remora exec <name> readlink /proc/self/ns/pid` and asserts the output
+matches `readlink /proc/{intermediate_pid}/ns/pid_for_children` read from the host.
+
+Failure indicates `discover_namespaces` is not using the `pid_for_children` fallback
+or the double-fork in `container.rs` step 1.65 is not putting the exec'd process in
+the target PID namespace. A failing test means `ps` inside exec'd shells shows host
+PIDs instead of container-scoped PIDs.
+
 ---
 
 ## Minimal /dev Tests (`dev` module)

--- a/docs/WATCHER_PROCESS_MODEL.md
+++ b/docs/WATCHER_PROCESS_MODEL.md
@@ -260,14 +260,15 @@ work as expected.
 - `/proc/P/ns/pid` — **host PID namespace** — same inode as `/proc/1/ns/pid` because P
   itself is in the host PID namespace (only P's *children* enter the new namespace)
 
-As a result, `remora exec` currently does **not** join the container's PID namespace.
-The exec'd process sees the container's filesystem, network, and UTS, but its PID
-namespace is the host's. Inside an exec'd shell, `ps` will show host PIDs.
+After the fix (GitHub issue #1), `remora exec` **does** join the container's PID
+namespace. `discover_namespaces` checks `/proc/P/ns/pid_for_children` (Linux ≥ 3.8)
+as a fallback when the regular `pid` check finds no difference.
 
-**Future improvement:** to join the container's PID namespace, `discover_namespaces`
-should also check `/proc/P/ns/pid_for_children` (available since Linux 3.8), which
-points to the new PID namespace that C inhabits. This would allow exec'd processes to
-be proper members of the container's PID namespace.
+Because `setns(CLONE_NEWPID)` only updates `pid_for_children` (it does not move the
+calling process), the join requires a **double-fork**: setns → fork → grandchild is
+born into the target PID namespace → grandchild execs. This is implemented in
+`container.rs` step 1.65 as the "Case B" branch (joining an existing PID namespace),
+mirroring how `nsenter --pid` works internally.
 
 ---
 
@@ -300,7 +301,7 @@ address it. This is documented as future work.
 
 | Limitation | Impact | Planned fix |
 |-----------|--------|-------------|
-| `remora exec` does not join container PID namespace | `ps` in exec'd shell shows host PIDs | Check `pid_for_children` in `discover_namespaces` |
+| ~~`remora exec` does not join container PID namespace~~ | ~~`ps` in exec'd shell shows host PIDs~~ | **Fixed** — `pid_for_children` + double-fork (issue #1) |
 | Probe timeout does not SIGKILL the probe child | Hung probes consume a thread until OS reaps them | Explicit SIGKILL on timeout |
 | Thread-per-fd log relay | O(2) threads per container for I/O | epoll-based relay (future) |
 | UDP reply threads are never explicitly reaped | Thread joins on stop flag only; idle sessions may linger until stop | Migrate UDP to async (tokio already used for TCP) |

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -284,6 +284,15 @@ fn find_root_pid(pid: i32) -> i32 {
 
 /// Compare `/proc/{pid}/ns/{type}` inodes against `/proc/1/ns/{type}` to discover
 /// which namespaces the container process is in (i.e., different from init).
+///
+/// PID namespace special case: when a PID namespace is active, `pid` may be the
+/// intermediate process P (which lives in the host PID namespace). P's
+/// `/proc/P/ns/pid` matches init, so the normal check misses it. P's children
+/// (the container's PID 1) inhabit the namespace pointed to by
+/// `/proc/P/ns/pid_for_children`. We check that symlink after the main loop and
+/// add it as `Namespace::PID` if it differs from init's PID namespace. Calling
+/// `setns(pid_for_children_fd, CLONE_NEWPID)` in pre_exec followed by `exec()`
+/// then moves the exec'd process into the container's PID namespace.
 pub fn discover_namespaces(
     pid: i32,
 ) -> Result<Vec<(PathBuf, Namespace)>, Box<dyn std::error::Error>> {
@@ -320,6 +329,29 @@ pub fn discover_namespaces(
 
         if container_ino != init_ino {
             result.push((PathBuf::from(container_ns), ns_flag));
+        }
+    }
+
+    // If PID namespace was not found above (because `pid` is the intermediate
+    // process P that lives in the host PID namespace), check pid_for_children.
+    // This symlink points to the namespace that P's children (the container's
+    // PID 1) actually inhabit.
+    let pid_already_found = result.iter().any(|(_, ns)| *ns == Namespace::PID);
+    if !pid_already_found {
+        let pfc_path = format!("/proc/{}/ns/pid_for_children", pid);
+        let init_pid_path = "/proc/1/ns/pid";
+        let pfc_ino = std::fs::metadata(&pfc_path).ok().map(|m| {
+            use std::os::unix::fs::MetadataExt;
+            m.ino()
+        });
+        let init_pid_ino = std::fs::metadata(init_pid_path).ok().map(|m| {
+            use std::os::unix::fs::MetadataExt;
+            m.ino()
+        });
+        if let (Some(pfc), Some(init)) = (pfc_ino, init_pid_ino) {
+            if pfc != init {
+                result.push((PathBuf::from(pfc_path), Namespace::PID));
+            }
         }
     }
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -2208,16 +2208,27 @@ impl Command {
 
                 // Step 1.65: PID namespace double-fork.
                 //
-                // unshare(CLONE_NEWPID) puts our CHILDREN into a new PID namespace —
-                // we ourselves stay in the parent namespace.  This means:
-                //   (a) we are NOT PID 1 in the new namespace
-                //   (b) the first child we fork becomes PID 1
-                //   (c) when that PID 1 exits, the kernel marks the namespace defunct
-                //   (d) every subsequent fork() fails with ENOMEM
+                // Two cases handled here:
                 //
-                // Fix: fork once more so the child IS PID 1 in the new namespace.
-                // The intermediate process (us) just waits and propagates the exit
-                // status.  PR_SET_PDEATHSIG ensures PID 1 is killed if we die.
+                // A. Creating a new PID namespace (namespaces contains Namespace::PID):
+                //    unshare(CLONE_NEWPID) puts our CHILDREN into a new PID namespace —
+                //    we ourselves stay in the parent namespace.  This means:
+                //      (a) we are NOT PID 1 in the new namespace
+                //      (b) the first child we fork becomes PID 1
+                //      (c) when that PID 1 exits, the kernel marks the namespace defunct
+                //      (d) every subsequent fork() fails with ENOMEM
+                //    Fix: fork once more so the child IS PID 1 in the new namespace.
+                //
+                // B. Joining an existing PID namespace (join_ns_fds contains PID):
+                //    setns(CLONE_NEWPID) only updates pid_for_children for the calling
+                //    process — it does NOT move the calling process into the namespace.
+                //    exec() alone does not trigger the transition; only a subsequent
+                //    fork() puts children into the new namespace.  So we must double-fork:
+                //    setns → fork → grandchild is in the target namespace → grandchild execs.
+                //
+                // In both cases the intermediate (us, inner_pid > 0) waits for the child
+                // and propagates the exit status.  PR_SET_PDEATHSIG on the child ensures
+                // it dies if the intermediate is killed.
                 if namespaces.contains(Namespace::PID) {
                     let inner_pid = libc::fork();
                     if inner_pid < 0 {
@@ -2260,6 +2271,44 @@ impl Command {
                     }
                     // Child: we are now PID 1 in the new PID namespace.
                     // Ensure we die if the intermediate (our parent) is killed.
+                    libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL);
+                } else if let Some(&(pid_join_fd, _)) =
+                    join_ns_fds.iter().find(|(_, ns)| *ns == Namespace::PID)
+                {
+                    // Case B: joining an existing PID namespace via setns.
+                    // setns changes pid_for_children; the grandchild (born after the fork
+                    // below) is the first process created under the new pid_for_children
+                    // and therefore enters the target PID namespace.
+                    if libc::setns(pid_join_fd, 0) != 0 {
+                        return Err(io::Error::last_os_error());
+                    }
+                    let inner_pid = libc::fork();
+                    if inner_pid < 0 {
+                        return Err(io::Error::last_os_error());
+                    }
+                    if inner_pid > 0 {
+                        for fd in 3..1024 {
+                            libc::close(fd);
+                        }
+                        let mut status: libc::c_int = 0;
+                        loop {
+                            let r = libc::waitpid(inner_pid, &mut status, 0);
+                            if r == inner_pid {
+                                break;
+                            }
+                            let e = std::io::Error::last_os_error().raw_os_error().unwrap_or(-1);
+                            if e != libc::EINTR {
+                                libc::_exit(1);
+                            }
+                        }
+                        if libc::WIFEXITED(status) {
+                            libc::_exit(libc::WEXITSTATUS(status));
+                        } else {
+                            libc::_exit(128 + libc::WTERMSIG(status));
+                        }
+                    }
+                    // Grandchild: now in the target PID namespace.
+                    // Die if our parent (the intermediate) dies unexpectedly.
                     libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL);
                 }
 
@@ -2988,8 +3037,14 @@ impl Command {
                 }
 
                 // Step 6: Join existing namespaces AFTER chroot and filesystem setup
-                // This ensures paths are resolved correctly before namespace transitions
-                for (fd, _ns) in &join_ns_fds {
+                // This ensures paths are resolved correctly before namespace transitions.
+                // PID namespace entries are skipped here — they are handled at step 1.65
+                // via double-fork (see below).
+                for (fd, ns) in &join_ns_fds {
+                    if *ns == Namespace::PID {
+                        // Handled at step 1.65 via double-fork.
+                        continue;
+                    }
                     let result = libc::setns(*fd, 0);
                     if result != 0 {
                         return Err(io::Error::last_os_error());
@@ -3762,7 +3817,7 @@ impl Command {
                 }
 
                 // PID namespace double-fork (same as spawn() Step 1.65).
-                // See spawn() for detailed explanation.
+                // See spawn() for detailed explanation of both cases.
                 if namespaces.contains(Namespace::PID) {
                     let inner_pid = libc::fork();
                     if inner_pid < 0 {
@@ -3787,6 +3842,39 @@ impl Command {
                                 if e != libc::EINTR {
                                     libc::_exit(1);
                                 }
+                            }
+                        }
+                        if libc::WIFEXITED(status) {
+                            libc::_exit(libc::WEXITSTATUS(status));
+                        } else {
+                            libc::_exit(128 + libc::WTERMSIG(status));
+                        }
+                    }
+                    libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL);
+                } else if let Some(&(pid_join_fd, _)) =
+                    join_ns_fds.iter().find(|(_, ns)| *ns == Namespace::PID)
+                {
+                    // Joining an existing PID namespace — setns then double-fork.
+                    if libc::setns(pid_join_fd, 0) != 0 {
+                        return Err(io::Error::last_os_error());
+                    }
+                    let inner_pid = libc::fork();
+                    if inner_pid < 0 {
+                        return Err(io::Error::last_os_error());
+                    }
+                    if inner_pid > 0 {
+                        for fd in 3..1024 {
+                            libc::close(fd);
+                        }
+                        let mut status: libc::c_int = 0;
+                        loop {
+                            let r = libc::waitpid(inner_pid, &mut status, 0);
+                            if r == inner_pid {
+                                break;
+                            }
+                            let e = std::io::Error::last_os_error().raw_os_error().unwrap_or(-1);
+                            if e != libc::EINTR {
+                                libc::_exit(1);
                             }
                         }
                         if libc::WIFEXITED(status) {
@@ -4426,7 +4514,11 @@ impl Command {
                     cb()?;
                 }
 
-                for (fd, _ns) in &join_ns_fds {
+                for (fd, ns) in &join_ns_fds {
+                    if *ns == Namespace::PID {
+                        // Handled at step 1.65 (double-fork) — skip here.
+                        continue;
+                    }
                     let result = libc::setns(*fd, 0);
                     if result != 0 {
                         return Err(io::Error::last_os_error());

--- a/src/network.rs
+++ b/src/network.rs
@@ -2070,7 +2070,10 @@ mod tests {
         drop(rt2);
         server_stop2.store(true, Ordering::Relaxed);
 
-        assert_eq!(&response, payload, "proxy should relay bytes unchanged in both directions");
+        assert_eq!(
+            &response, payload,
+            "proxy should relay bytes unchanged in both directions"
+        );
     }
 
     /// Verify that simultaneous connections through the proxy are all served.
@@ -2115,7 +2118,10 @@ mod tests {
             })
             .collect();
 
-        let results: Vec<bool> = handles.into_iter().map(|h| h.join().unwrap_or(false)).collect();
+        let results: Vec<bool> = handles
+            .into_iter()
+            .map(|h| h.join().unwrap_or(false))
+            .collect();
         drop(rt);
         server_stop.store(true, Ordering::Relaxed);
 
@@ -2125,7 +2131,11 @@ mod tests {
             .filter(|(_, &ok)| !ok)
             .map(|(i, _)| i)
             .collect();
-        assert!(failures.is_empty(), "concurrent relay failed for connections: {:?}", failures);
+        assert!(
+            failures.is_empty(),
+            "concurrent relay failed for connections: {:?}",
+            failures
+        );
     }
 
     /// Verify that dropping the runtime releases the listener port.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4648,6 +4648,9 @@ mod exec {
     /// Helper: build an exec Command that joins the container's mount namespace
     /// via pre_exec (setns + fchdir + chroot(".") + chdir("/")) and joins all
     /// other differing namespaces via with_namespace_join().
+    ///
+    /// Mirrors `discover_namespaces` in src/cli/exec.rs including the
+    /// `pid_for_children` fallback for PID namespaces.
     fn build_exec_command(pid: i32, exe: &str, args: &[&str]) -> Command {
         let ns_types: &[(&str, Namespace)] = &[
             ("mnt", Namespace::MOUNT),
@@ -4661,6 +4664,7 @@ mod exec {
 
         let mut cmd = Command::new(exe).args(args);
         let mut has_mount_ns = false;
+        let mut pid_ns_found = false;
 
         for &(ns_name, ns_flag) in ns_types {
             let container_ns = format!("/proc/{}/ns/{}", pid, ns_name);
@@ -4678,8 +4682,30 @@ mod exec {
                     if ns_flag == Namespace::MOUNT {
                         has_mount_ns = true;
                     } else {
+                        if ns_flag == Namespace::PID {
+                            pid_ns_found = true;
+                        }
                         cmd = cmd.with_namespace_join(&container_ns, ns_flag);
                     }
+                }
+            }
+        }
+
+        // pid_for_children fallback: when `pid` is the intermediate process P
+        // (in host PID ns), its children's namespace is in pid_for_children.
+        if !pid_ns_found {
+            let pfc_path = format!("/proc/{}/ns/pid_for_children", pid);
+            let pfc_ino = std::fs::metadata(&pfc_path).map(|m| {
+                use std::os::unix::fs::MetadataExt;
+                m.ino()
+            });
+            let init_pid_ino = std::fs::metadata("/proc/1/ns/pid").map(|m| {
+                use std::os::unix::fs::MetadataExt;
+                m.ino()
+            });
+            if let (Ok(pfc), Ok(init)) = (pfc_ino, init_pid_ino) {
+                if pfc != init {
+                    cmd = cmd.with_namespace_join(&pfc_path, Namespace::PID);
                 }
             }
         }
@@ -4943,6 +4969,121 @@ mod exec {
         // Also verify that /proc/999999/root does not exist, so chroot would fail.
         let root_path = std::path::Path::new("/proc/999999/root");
         assert!(!root_path.exists(), "/proc/999999/root should not exist");
+    }
+
+    /// `remora exec` joins the container's PID namespace via `pid_for_children`.
+    ///
+    /// Requires: root, alpine-rootfs.
+    ///
+    /// Starts a detached container with a PID namespace (`remora run -d --rootfs`
+    /// always enables Namespace::PID). The container's PID namespace is reachable
+    /// via `/proc/<intermediate_pid>/ns/pid_for_children` — NOT via `ns/pid`, which
+    /// still points at the host PID namespace for the intermediate process.
+    ///
+    /// After the fix, `discover_namespaces` checks `pid_for_children` as a fallback
+    /// when the regular `pid` check finds no difference. We verify the fix by:
+    ///  1. Reading the container's expected PID namespace via `pid_for_children` on the host.
+    ///  2. Running `remora exec <name> readlink /proc/self/ns/pid` inside the container.
+    ///  3. Asserting the two strings are equal.
+    ///
+    /// Failure indicates `discover_namespaces` is not joining the PID namespace, so
+    /// exec'd processes still see the host PID namespace.
+    #[test]
+    #[serial]
+    fn test_exec_joins_pid_namespace() {
+        if !is_root() {
+            eprintln!("Skipping test_exec_joins_pid_namespace (requires root)");
+            return;
+        }
+        let rootfs = match get_test_rootfs() {
+            Some(r) => r,
+            None => {
+                eprintln!("Skipping test_exec_joins_pid_namespace (no rootfs)");
+                return;
+            }
+        };
+
+        let bin = env!("CARGO_BIN_EXE_remora");
+        let name = "remora-exec-pid-ns-test";
+
+        let _ = std::process::Command::new(bin)
+            .args(["rm", "-f", name])
+            .output();
+
+        // Start a container with PID namespace (--rootfs always enables Namespace::PID).
+        let run_status = std::process::Command::new(bin)
+            .args([
+                "run",
+                "-d",
+                "--name",
+                name,
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "/bin/sleep",
+                "30",
+            ])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("remora run -d");
+        assert!(run_status.success(), "remora run -d failed");
+
+        // Poll until the watcher writes the real PID.
+        let state_path = format!("/run/remora/containers/{}/state.json", name);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let mut started = false;
+        while std::time::Instant::now() < deadline {
+            if let Ok(data) = std::fs::read_to_string(&state_path) {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&data) {
+                    if v["pid"].as_i64().unwrap_or(0) > 0 {
+                        started = true;
+                        break;
+                    }
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        assert!(started, "container did not start within 10s");
+
+        let state_data = std::fs::read_to_string(&state_path).expect("read state.json");
+        let state: serde_json::Value = serde_json::from_str(&state_data).expect("parse state.json");
+        let intermediate_pid = state["pid"].as_i64().expect("state.pid") as i32;
+
+        // Read the container's PID namespace from the host via pid_for_children.
+        let pfc_link = format!("/proc/{}/ns/pid_for_children", intermediate_pid);
+        let container_pid_ns = std::fs::read_link(&pfc_link)
+            .expect("read pid_for_children link")
+            .to_string_lossy()
+            .into_owned();
+
+        // Exec into the container and capture the exec'd process's PID namespace.
+        let exec_out = std::process::Command::new(bin)
+            .args(["exec", name, "readlink", "/proc/self/ns/pid"])
+            .output()
+            .expect("remora exec readlink /proc/self/ns/pid");
+
+        let _ = std::process::Command::new(bin)
+            .args(["stop", name])
+            .output();
+        let _ = std::process::Command::new(bin)
+            .args(["rm", "-f", name])
+            .output();
+
+        assert!(
+            exec_out.status.success(),
+            "remora exec readlink failed: {}",
+            String::from_utf8_lossy(&exec_out.stderr)
+        );
+
+        let exec_pid_ns = String::from_utf8_lossy(&exec_out.stdout).trim().to_string();
+
+        assert_eq!(
+            exec_pid_ns, container_pid_ns,
+            "exec'd process should be in the container's PID namespace ({}), \
+             but is in namespace ({}). \
+             This means discover_namespaces did not join pid_for_children.",
+            container_pid_ns, exec_pid_ns
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- **`discover_namespaces`** now falls back to `/proc/{pid}/ns/pid_for_children` when the regular `pid` inode check finds no PID namespace difference. This handles the case where `state.pid` is the intermediate process P (in the host PID namespace) rather than the container's PID 1.

- **Container.rs step 1.65, Case B**: `setns(CLONE_NEWPID)` alone only updates `pid_for_children`; it does not move the calling process. The fix implements the required **double-fork** (setns → fork → grandchild in target namespace → exec), mirroring how `nsenter --pid` works internally. Applied to both `spawn()` and `spawn_interactive()`.

## Root cause

When a PID namespace is active, `state.pid` stores the intermediate process P which lives in the *host* PID namespace. Only P's future children are born into the container's PID namespace. So:

1. `/proc/P/ns/pid` == host ns inode → inode comparison found no difference → PID ns never added to setns list
2. Even if it had been found, `setns(CLONE_NEWPID)` + `exec()` is insufficient — only a subsequent `fork()` enters the new namespace

## Test plan

- [x] New integration test `exec::test_exec_joins_pid_namespace` verifies that `remora exec` places the exec'd process inside the container's PID namespace by comparing `/proc/self/ns/pid` reported from inside exec against the expected `pid_for_children` symlink target
- [x] All 5 existing exec tests pass
- [x] 158 integration tests pass, 0 failed
- [x] `cargo fmt` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --lib` — 271 tests pass

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)