### PR TITLE
fix: replace per-fd relay threads with single epoll relay (issue #3)

### DIFF
--- a/ONGOING_TASKS.md
+++ b/ONGOING_TASKS.md
@@ -85,9 +85,33 @@ GitHub issue: #2 (closed by this work).
 
 ---
 
+## Completed: epoll log relay (2026-02-28)
+
+### Context
+
+Each watcher previously spawned two dedicated relay threads (one for stdout, one
+for stderr). This cost 2 threads per container at steady state. The fix replaces
+both with a single `epoll`-based relay thread in `src/cli/relay.rs` that
+multiplexes both pipe fds via `epoll_wait`, reducing the static thread count per
+container from 3 to 2 (main + relay, down from main + stdout relay + stderr relay).
+
+GitHub issue: #3 (closed by this work).
+
+### Files changed
+
+- `src/cli/relay.rs`: new module — `start_log_relay`, `relay_loop` (epoll), 3 unit
+  tests
+- `src/cli/mod.rs`: added `pub mod relay;`
+- `src/cli/run.rs`: replaced two relay `thread::spawn` + two `join` calls with
+  `super::relay::start_log_relay`; removed unused `Read` import
+- `src/cli/compose.rs`: replaced two relay `thread::spawn` calls with
+  `super::relay::start_log_relay`; removed unused `Read` import
+- `docs/INTEGRATION_TESTS.md`: added entries for all three relay unit tests
+
+---
+
 ## Open GitHub issues (remaining work)
 
 | # | Title |
 |---|-------|
-| #3 | Log relay: thread-per-fd model wastes 2 threads per container |
 | #4 | UDP proxy: reply threads never explicitly joined |

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -1009,6 +1009,42 @@ detecting that a timed-out probe child was successfully cleaned up.
 
 ---
 
+## Log Relay Tests (`cli::relay` unit tests)
+
+These tests live directly in `src/cli/relay.rs` and run via `cargo test --bin remora`
+(no root required).
+
+### `cli::relay::tests::test_relay_captures_stdout_and_stderr`
+**Requires:** none (no root, no rootfs)
+
+Spawns `sh -c "printf 'hello stdout'; printf 'hello stderr' >&2"` with piped
+stdio, passes the handles to `start_log_relay`, joins the relay thread after
+`child.wait()`, and asserts both log files contain the expected strings.
+
+Failure indicates the epoll relay loop is not writing pipe data to the log files
+(e.g. fd registration failed, write error was silently dropped, or the thread
+exited before draining the pipe).
+
+### `cli::relay::tests::test_relay_large_output`
+**Requires:** none (no root, no rootfs)
+
+Spawns `yes x | head -c 65536` (65 536 bytes — 8× the `BUF` read size) and
+relays its stdout to a log file. After the relay thread finishes, asserts the
+log file is exactly 65 536 bytes.
+
+Failure indicates that multi-cycle relay (where epoll fires multiple times because
+data exceeds one read buffer) is losing or truncating data.
+
+### `cli::relay::tests::test_relay_none_handles`
+**Requires:** none (no root, no rootfs)
+
+Calls `start_log_relay(None, None, ...)` and joins the thread. Verifies the relay
+exits immediately when no pipe fds are registered.
+
+Failure indicates the relay loop hangs or panics when given empty input.
+
+---
+
 ## Minimal /dev Tests (`dev` module)
 
 ### `test_dev_minimal_devices`

--- a/docs/WATCHER_PROCESS_MODEL.md
+++ b/docs/WATCHER_PROCESS_MODEL.md
@@ -92,8 +92,7 @@ These threads are always present for every running container:
 | Thread | Purpose | Lifetime |
 |--------|----------|----------|
 | **Main thread** | `child.wait()` — blocks until container exits; then writes final `state.json`, cleans up DNS | Container lifetime |
-| **stdout relay** | Reads container stdout pipe → appends to `stdout.log` | Until container stdout pipe closes |
-| **stderr relay** | Reads container stderr pipe → appends to `stderr.log` | Until container stderr pipe closes |
+| **epoll relay** | Single `epoll_wait` loop multiplexes stdout and stderr pipes → `stdout.log` / `stderr.log` | Until both pipes reach EOF |
 
 ### Watcher process — optional: health monitor
 
@@ -169,7 +168,7 @@ entries idle longer than 30 seconds.
 Let W = `min(available_parallelism, 4)` (tokio TCP worker threads; 0 if no TCP ports).
 
 ```
-total = 3 (static)
+total = 2 (static: main + epoll relay)
       + 1  (health monitor, if HEALTHCHECK)
       + W  (TCP proxy worker threads, if any TCP ports; shared across all TCP ports)
       + N_udp_ports          (UDP proxy threads)
@@ -179,10 +178,10 @@ total = 3 (static)
 Active TCP connections do **not** add threads — they are async tasks on the W workers.
 
 At rest with one TCP port and one UDP port, no HEALTHCHECK, 4-core machine:
-**8 threads** (3 static + 4 TCP workers + 1 UDP proxy).
+**7 threads** (2 static + 4 TCP workers + 1 UDP proxy).
 
-At rest with one TCP port, no UDP, no HEALTHCHECK: **7 threads**.
-Under 1000 simultaneous TCP connections on the same port: still **7 threads**.
+At rest with one TCP port, no UDP, no HEALTHCHECK: **6 threads**.
+Under 1000 simultaneous TCP connections on the same port: still **6 threads**.
 
 ### Scalability note
 
@@ -304,6 +303,6 @@ two-hop chain.
 |-----------|--------|-------------|
 | ~~`remora exec` does not join container PID namespace~~ | ~~`ps` in exec'd shell shows host PIDs~~ | **Fixed** — `pid_for_children` + double-fork (issue #1) |
 | ~~Probe timeout does not SIGKILL the probe child~~ | ~~Hung probes consume a thread until OS reaps them~~ | **Fixed** — `exec_in_container_with_pid_sink` + SIGKILL on timeout (issue #2) |
-| Thread-per-fd log relay | O(2) threads per container for I/O | epoll-based relay (future) |
+| ~~Thread-per-fd log relay~~ | ~~O(2) threads per container for I/O~~ | **Fixed** — single epoll relay thread in `src/cli/relay.rs` (issue #3) |
 | UDP reply threads are never explicitly reaped | Thread joins on stop flag only; idle sessions may linger until stop | Migrate UDP to async (tokio already used for TCP) |
 | ~~Watcher death does not propagate to PID 1~~ | ~~Container orphaned if watcher dies~~ | **Fixed** — `PR_SET_CHILD_SUBREAPER` on watcher (issue #5) |

--- a/src/cli/compose.rs
+++ b/src/cli/compose.rs
@@ -13,7 +13,7 @@ use remora::lisp::{HookMap, Interpreter};
 use remora::network::NetworkMode;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::net::{Ipv4Addr, SocketAddr, TcpStream};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -866,45 +866,15 @@ fn spawn_service(
         }
     }
 
-    // Spawn log relay threads.
-    let mut stdout_handle = child.take_stdout();
-    let mut stderr_handle = child.take_stderr();
-    let stdout_path = stdout_log.clone();
-    let stderr_path = stderr_log.clone();
+    // Single epoll relay thread: multiplexes stdout and stderr into log files.
     let svc_name = svc.name.clone();
     let cn = container_name.to_string();
-
-    std::thread::spawn(move || {
-        if let Some(mut src) = stdout_handle.take() {
-            if let Ok(mut f) = std::fs::File::create(&stdout_path) {
-                let mut buf = [0u8; 4096];
-                loop {
-                    match src.read(&mut buf) {
-                        Ok(0) | Err(_) => break,
-                        Ok(n) => {
-                            let _ = f.write_all(&buf[..n]);
-                        }
-                    }
-                }
-            }
-        }
-    });
-
-    std::thread::spawn(move || {
-        if let Some(mut src) = stderr_handle.take() {
-            if let Ok(mut f) = std::fs::File::create(&stderr_path) {
-                let mut buf = [0u8; 4096];
-                loop {
-                    match src.read(&mut buf) {
-                        Ok(0) | Err(_) => break,
-                        Ok(n) => {
-                            let _ = f.write_all(&buf[..n]);
-                        }
-                    }
-                }
-            }
-        }
-    });
+    super::relay::start_log_relay(
+        child.take_stdout(),
+        child.take_stderr(),
+        stdout_log.clone(),
+        stderr_log.clone(),
+    );
 
     // Spawn a waiter thread that updates state when the container exits.
     let cn_wait = cn.clone();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -27,6 +27,7 @@ pub mod image;
 pub mod logs;
 pub mod network;
 pub mod ps;
+pub mod relay;
 pub mod rm;
 pub mod rootfs;
 pub mod run;

--- a/src/cli/relay.rs
+++ b/src/cli/relay.rs
@@ -1,0 +1,185 @@
+//! Single-thread epoll-based log relay.
+//!
+//! Replaces the two per-container relay threads with one thread that
+//! multiplexes stdout and stderr pipes via epoll(7), reducing the static
+//! thread count per container by one (3 → 2 for the common case).
+
+use std::fs::File;
+use std::io::Write;
+use std::os::unix::io::AsRawFd;
+use std::path::PathBuf;
+use std::process::{ChildStderr, ChildStdout};
+
+const BUF: usize = 8192;
+
+/// Spawn a single relay thread that copies `stdout` → `stdout_path` and
+/// `stderr` → `stderr_path` using one epoll loop.
+///
+/// The returned `JoinHandle` completes once both pipes reach EOF.
+pub fn start_log_relay(
+    stdout: Option<ChildStdout>,
+    stderr: Option<ChildStderr>,
+    stdout_path: PathBuf,
+    stderr_path: PathBuf,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || relay_loop(stdout, stderr, stdout_path, stderr_path))
+}
+
+fn relay_loop(
+    stdout: Option<ChildStdout>,
+    stderr: Option<ChildStderr>,
+    stdout_path: PathBuf,
+    stderr_path: PathBuf,
+) {
+    let epfd = unsafe { libc::epoll_create1(libc::EPOLL_CLOEXEC) };
+    if epfd < 0 {
+        log::warn!(
+            "relay: epoll_create1 failed: {}",
+            std::io::Error::last_os_error()
+        );
+        return;
+    }
+
+    // Slot 0 = stdout, slot 1 = stderr.
+    // done[i] starts true; set to false only when the fd is registered.
+    let mut files: [Option<File>; 2] = [None, None];
+    let mut done: [bool; 2] = [true, true];
+    let mut raw_fds: [i32; 2] = [-1, -1];
+
+    let mut register = |idx: usize, fd: i32, path: &PathBuf| {
+        if let Ok(f) = File::create(path) {
+            let mut ev = libc::epoll_event {
+                events: (libc::EPOLLIN | libc::EPOLLHUP) as u32,
+                u64: idx as u64,
+            };
+            if unsafe { libc::epoll_ctl(epfd, libc::EPOLL_CTL_ADD, fd, &mut ev) } == 0 {
+                files[idx] = Some(f);
+                done[idx] = false;
+                raw_fds[idx] = fd;
+            }
+        }
+    };
+
+    if let Some(ref s) = stdout {
+        register(0, s.as_raw_fd(), &stdout_path);
+    }
+    if let Some(ref s) = stderr {
+        register(1, s.as_raw_fd(), &stderr_path);
+    }
+
+    let mut buf = [0u8; BUF];
+    let mut events = [libc::epoll_event { events: 0, u64: 0 }; 4];
+
+    while !done[0] || !done[1] {
+        let n = unsafe { libc::epoll_wait(epfd, events.as_mut_ptr(), 4, -1) };
+        if n < 0 {
+            if std::io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            break;
+        }
+
+        for ev in &events[..n as usize] {
+            let idx = ev.u64 as usize;
+            if done[idx] {
+                continue;
+            }
+            let fd = raw_fds[idx];
+
+            // One read per epoll event; LT will re-notify if more data remains.
+            let nread = loop {
+                let r = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+                if r >= 0 || std::io::Error::last_os_error().raw_os_error() != Some(libc::EINTR) {
+                    break r;
+                }
+                // EINTR: retry the read
+            };
+
+            if nread > 0 {
+                if let Some(ref mut f) = files[idx] {
+                    let _ = f.write_all(&buf[..nread as usize]);
+                }
+            } else {
+                // EOF (0) or non-EINTR error (-1): deregister and mark done.
+                unsafe { libc::epoll_ctl(epfd, libc::EPOLL_CTL_DEL, fd, std::ptr::null_mut()) };
+                done[idx] = true;
+            }
+        }
+    }
+
+    unsafe { libc::close(epfd) };
+    // stdout / stderr are dropped here, closing the pipe read-ends.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_relay_captures_stdout_and_stderr() {
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg("printf 'hello stdout'; printf 'hello stderr' >&2")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn sh");
+
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let out_path = tmp.path().join("stdout.log");
+        let err_path = tmp.path().join("stderr.log");
+
+        let handle = start_log_relay(stdout, stderr, out_path.clone(), err_path.clone());
+        child.wait().expect("wait");
+        handle.join().expect("join relay thread");
+
+        assert_eq!(
+            std::fs::read_to_string(&out_path).unwrap_or_default(),
+            "hello stdout"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&err_path).unwrap_or_default(),
+            "hello stderr"
+        );
+    }
+
+    #[test]
+    fn test_relay_large_output() {
+        // Write more than BUF bytes to exercise multiple read/epoll cycles.
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg("yes x | head -c 65536")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn sh");
+
+        let stdout = child.stdout.take();
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let out_path = tmp.path().join("stdout.log");
+        let err_path = tmp.path().join("stderr.log");
+
+        let handle = start_log_relay(stdout, None, out_path.clone(), err_path.clone());
+        child.wait().expect("wait");
+        handle.join().expect("join relay thread");
+
+        let out = std::fs::read(&out_path).unwrap_or_default();
+        assert_eq!(out.len(), 65536, "expected 65536 bytes, got {}", out.len());
+    }
+
+    #[test]
+    fn test_relay_none_handles() {
+        // Both None: relay thread should start and exit immediately.
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let out_path = tmp.path().join("stdout.log");
+        let err_path = tmp.path().join("stderr.log");
+
+        let handle = start_log_relay(None, None, out_path.clone(), err_path.clone());
+        handle.join().expect("join relay thread");
+        // No log files created — that's fine.
+    }
+}

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use remora::container::{Capability, Command, Namespace, Stdio, Volume};
 use remora::network::NetworkMode;
-use std::io::{self, Read, Write};
+use std::io::{self, Write};
 use std::path::PathBuf;
 
 #[derive(Debug, clap::Args)]
@@ -797,44 +797,13 @@ fn run_detached(
                 std::thread::spawn(move || super::health::run_health_monitor(name2, pid, hc, stop))
             });
 
-            // Relay stdout and stderr to log files concurrently.
-            let mut stdout_handle = child.take_stdout();
-            let mut stderr_handle = child.take_stderr();
-
-            let stdout_path = stdout_log.clone();
-            let stderr_path = stderr_log.clone();
-
-            // Use two threads: one for each stream.
-            let t_out = std::thread::spawn(move || {
-                if let Some(mut src) = stdout_handle.take() {
-                    if let Ok(mut f) = std::fs::File::create(&stdout_path) {
-                        let mut buf = [0u8; 4096];
-                        loop {
-                            match src.read(&mut buf) {
-                                Ok(0) | Err(_) => break,
-                                Ok(n) => {
-                                    let _ = f.write_all(&buf[..n]);
-                                }
-                            }
-                        }
-                    }
-                }
-            });
-            let t_err = std::thread::spawn(move || {
-                if let Some(mut src) = stderr_handle.take() {
-                    if let Ok(mut f) = std::fs::File::create(&stderr_path) {
-                        let mut buf = [0u8; 4096];
-                        loop {
-                            match src.read(&mut buf) {
-                                Ok(0) | Err(_) => break,
-                                Ok(n) => {
-                                    let _ = f.write_all(&buf[..n]);
-                                }
-                            }
-                        }
-                    }
-                }
-            });
+            // Single epoll relay thread: multiplexes stdout and stderr into log files.
+            let t_relay = super::relay::start_log_relay(
+                child.take_stdout(),
+                child.take_stderr(),
+                stdout_log.clone(),
+                stderr_log.clone(),
+            );
 
             // Wait for the container to exit.
             let exit = match child.wait() {
@@ -844,10 +813,9 @@ fn run_detached(
                     unsafe { libc::_exit(1) };
                 }
             };
-            // Signal the health monitor to stop and wait for it.
+            // Signal the health monitor to stop; join relay and health threads.
             health_stop.store(true, std::sync::atomic::Ordering::Relaxed);
-            let _ = t_out.join();
-            let _ = t_err.join();
+            let _ = t_relay.join();
             if let Some(t) = health_thread {
                 let _ = t.join();
             }


### PR DESCRIPTION
## Summary

- Introduces `src/cli/relay.rs` with `start_log_relay()` — a single thread that uses `epoll_wait` to multiplex both stdout and stderr pipe fds into their log files.
- Replaces the two `thread::spawn` relay blocks in `run.rs` and `compose.rs` (4 blocks total, 2 per site).
- Reduces static thread count per watcher process from **3 → 2** (main thread + epoll relay, vs. main + stdout relay + stderr relay).

## How it works

Level-triggered `epoll(7)` monitors both pipe fds. On each event, one read is performed (LT re-notifies if data remains). When `read()` returns 0 (EOF), the fd is deregistered. The loop exits when both fds are done.

The `ChildStdout`/`ChildStderr` handles are moved into the relay thread; their destructors close the pipe read-ends when the thread exits.

## Test plan
- [x] `cli::relay::tests::test_relay_captures_stdout_and_stderr` — basic correctness (no root)
- [x] `cli::relay::tests::test_relay_large_output` — 65 536 bytes, exercises multi-cycle reads (no root)
- [x] `cli::relay::tests::test_relay_none_handles` — empty-input fast-exit path (no root)
- [x] Full integration suite: 160 passed, 0 failed

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)