### PR TITLE
fix: join UDP proxy threads on teardown (issue #4)

### DIFF
--- a/ONGOING_TASKS.md
+++ b/ONGOING_TASKS.md
@@ -110,8 +110,40 @@ GitHub issue: #3 (closed by this work).
 
 ---
 
-## Open GitHub issues (remaining work)
+## Completed: UDP proxy thread joining (2026-02-28)
 
-| # | Title |
-|---|-------|
-| #4 | UDP proxy: reply threads never explicitly joined |
+### Context
+
+UDP proxy threads (one per mapped port, plus one per active client session) were
+never explicitly joined. `teardown_network` set the stop flag but returned
+immediately; threads exited within 100ms on their own. This meant the inbound
+socket was still held briefly after teardown returned, and reply threads had no
+explicit synchronisation point.
+
+The fix stores per-port `JoinHandle`s in `NetworkSetup.proxy_udp_threads`.
+`teardown_network` now drains and joins them after setting the stop flag, ensuring
+the inbound socket is released before the function returns.  `start_udp_proxy`
+accumulates reply-thread handles and joins them all after its main loop exits (once
+the stop flag causes the loop to terminate), completing the cleanup chain.
+
+GitHub issue: #4 (closed by this work).
+
+### Files changed
+
+- `src/network.rs`:
+  - `NetworkSetup`: added `proxy_udp_threads: Vec<JoinHandle<()>>`
+  - `start_port_proxies`: changed return type to 3-tuple; collects per-port handles
+  - callsite: destructured 3-tuple, stored `proxy_udp_threads` in `NetworkSetup`
+  - `teardown_network`: joins per-port threads after setting stop flag
+  - `start_udp_proxy`: collects reply handles, prunes finished ones, joins remainder
+  - secondary `NetworkSetup` literal: added `proxy_udp_threads: Vec::new()`
+- `tests/integration_tests.rs`: new test
+  `networking::test_udp_proxy_threads_joined_on_teardown`
+- `docs/INTEGRATION_TESTS.md`: added entry
+- `docs/WATCHER_PROCESS_MODEL.md`: marked limitation as fixed
+
+---
+
+## All issues resolved
+
+All four open issues are now closed.

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -510,6 +510,19 @@ After 200 ms, queries nftables and asserts the prerouting chain contains BOTH
 Failure indicates the `Both` variant does not generate the two required rules,
 which would break dual-protocol services (e.g. DNS, QUIC/HTTP3).
 
+### `test_udp_proxy_threads_joined_on_teardown` — N4-UDP
+**Requires:** root, rootfs
+
+Starts a container with `with_port_forward_udp(19097, 5000)` and verifies:
+1. While running: `UdpSocket::bind(127.0.0.1:19097)` fails (proxy holds the port).
+2. After `SIGKILL` + `child.wait()`: the same bind succeeds (proxy thread was joined,
+   inbound socket is closed, port is released).
+
+This directly tests that `teardown_network` joins the per-port UDP proxy threads
+(via `proxy_udp_threads.drain(..)` + `handle.join()`). Without the join, the
+thread keeps the socket open and the port remains unavailable for a short window,
+causing the test to fail.
+
 ### `test_bridge_cleanup_after_sigkill` — N2+N3
 **Requires:** root, rootfs
 

--- a/docs/WATCHER_PROCESS_MODEL.md
+++ b/docs/WATCHER_PROCESS_MODEL.md
@@ -304,5 +304,5 @@ two-hop chain.
 | ~~`remora exec` does not join container PID namespace~~ | ~~`ps` in exec'd shell shows host PIDs~~ | **Fixed** — `pid_for_children` + double-fork (issue #1) |
 | ~~Probe timeout does not SIGKILL the probe child~~ | ~~Hung probes consume a thread until OS reaps them~~ | **Fixed** — `exec_in_container_with_pid_sink` + SIGKILL on timeout (issue #2) |
 | ~~Thread-per-fd log relay~~ | ~~O(2) threads per container for I/O~~ | **Fixed** — single epoll relay thread in `src/cli/relay.rs` (issue #3) |
-| UDP reply threads are never explicitly reaped | Thread joins on stop flag only; idle sessions may linger until stop | Migrate UDP to async (tokio already used for TCP) |
+| ~~UDP reply threads are never explicitly reaped~~ | ~~Thread joins on stop flag only; idle sessions may linger until stop~~ | **Fixed** — per-port threads joined in `teardown_network`; reply threads joined at end of `start_udp_proxy` (issue #4) |
 | ~~Watcher death does not propagate to PID 1~~ | ~~Container orphaned if watcher dies~~ | **Fixed** — `PR_SET_CHILD_SUBREAPER` on watcher (issue #5) |

--- a/src/network.rs
+++ b/src/network.rs
@@ -412,6 +412,8 @@ pub struct NetworkSetup {
     proxy_tcp_runtime: Option<tokio::runtime::Runtime>,
     /// Stop flag for UDP proxy threads (std threads).
     proxy_udp_stop: Option<Arc<AtomicBool>>,
+    /// Join handles for per-port UDP proxy threads; joined explicitly in teardown.
+    proxy_udp_threads: Vec<std::thread::JoinHandle<()>>,
     /// Name of the network this setup belongs to (e.g. `"remora0"`, `"frontend"`).
     pub network_name: String,
 }
@@ -426,6 +428,7 @@ impl std::fmt::Debug for NetworkSetup {
             .field("port_forwards", &self.port_forwards)
             .field("proxy_tcp_active", &self.proxy_tcp_runtime.is_some())
             .field("proxy_udp_active", &self.proxy_udp_stop.is_some())
+            .field("proxy_udp_threads", &self.proxy_udp_threads.len())
             .field("network_name", &self.network_name)
             .finish()
     }
@@ -707,10 +710,10 @@ pub fn setup_bridge_network(
     // 9. Start userspace port proxies (handles localhost traffic that nftables
     //    DNAT in PREROUTING cannot intercept).  TCP uses an async tokio runtime;
     //    UDP uses std threads unchanged.
-    let (proxy_tcp_runtime, proxy_udp_stop) = if !port_forwards.is_empty() {
+    let (proxy_tcp_runtime, proxy_udp_stop, proxy_udp_threads) = if !port_forwards.is_empty() {
         start_port_proxies(container_ip, &port_forwards)
     } else {
-        (None, None)
+        (None, None, Vec::new())
     };
 
     Ok(NetworkSetup {
@@ -721,6 +724,7 @@ pub fn setup_bridge_network(
         port_forwards,
         proxy_tcp_runtime,
         proxy_udp_stop,
+        proxy_udp_threads,
         network_name: network_name.to_string(),
     })
 }
@@ -739,9 +743,15 @@ pub fn teardown_network(mut setup: NetworkSetup) {
     if let Some(rt) = setup.proxy_tcp_runtime.take() {
         rt.shutdown_background();
     }
-    // Stop UDP proxy threads.
+    // Stop UDP proxy threads and join them.  Setting the flag first lets the
+    // threads notice the stop signal during their next 100ms recv_from timeout.
+    // Joining ensures the inbound socket is fully closed (port released) before
+    // we proceed to delete the veth/netns.
     if let Some(ref stop) = setup.proxy_udp_stop {
         stop.store(true, Ordering::Relaxed);
+    }
+    for handle in setup.proxy_udp_threads.drain(..) {
+        let _ = handle.join();
     }
     if let Err(e) = run("ip", &["link", "del", &setup.veth_host]) {
         log::warn!("network teardown veth (non-fatal): {}", e);
@@ -837,6 +847,7 @@ pub fn attach_network_to_netns(
         port_forwards: Vec::new(),
         proxy_tcp_runtime: None,
         proxy_udp_stop: None,
+        proxy_udp_threads: Vec::new(),
         network_name: network_name.to_string(),
     })
 }
@@ -1380,13 +1391,17 @@ fn disable_port_forwards(ns_name: &str, net: &NetworkDef) {
 /// UDP still uses std threads: one thread per port plus one thread per active
 /// client session (30-second idle eviction).
 ///
-/// Returns `(tcp_runtime, udp_stop)`. The caller stores both in `NetworkSetup`;
-/// teardown calls `rt.shutdown_background()` for TCP and sets the stop flag
-/// for UDP.
+/// Returns `(tcp_runtime, udp_stop, udp_threads)`. The caller stores all three in
+/// `NetworkSetup`; teardown calls `rt.shutdown_background()` for TCP, sets the
+/// stop flag for UDP, and joins the per-port UDP threads.
 fn start_port_proxies(
     container_ip: Ipv4Addr,
     forwards: &[(u16, u16, PortProto)],
-) -> (Option<tokio::runtime::Runtime>, Option<Arc<AtomicBool>>) {
+) -> (
+    Option<tokio::runtime::Runtime>,
+    Option<Arc<AtomicBool>>,
+    Vec<std::thread::JoinHandle<()>>,
+) {
     let tcp_forwards: Vec<(u16, u16)> = forwards
         .iter()
         .filter(|(_, _, p)| matches!(p, PortProto::Tcp | PortProto::Both))
@@ -1405,20 +1420,21 @@ fn start_port_proxies(
         None
     };
 
-    let udp_stop = if !udp_forwards.is_empty() {
+    let (udp_stop, udp_threads) = if !udp_forwards.is_empty() {
         let stop = Arc::new(AtomicBool::new(false));
+        let mut handles = Vec::new();
         for (host_port, container_port) in udp_forwards {
-            let stop = Arc::clone(&stop);
-            std::thread::spawn(move || {
-                start_udp_proxy(host_port, container_ip, container_port, stop);
-            });
+            let stop_clone = Arc::clone(&stop);
+            handles.push(std::thread::spawn(move || {
+                start_udp_proxy(host_port, container_ip, container_port, stop_clone);
+            }));
         }
-        Some(stop)
+        (Some(stop), handles)
     } else {
-        None
+        (None, Vec::new())
     };
 
-    (tcp_runtime, udp_stop)
+    (tcp_runtime, udp_stop, udp_threads)
 }
 
 /// Build a tokio multi-threaded runtime and spawn one async accept-loop task
@@ -1548,20 +1564,23 @@ fn start_udp_proxy(
     let sessions: Arc<Mutex<SessionMap>> = Arc::new(Mutex::new(HashMap::new()));
 
     let mut buf = [0u8; 65535];
+    // Collect reply-thread handles so we can join them when the proxy stops.
+    let mut reply_handles: Vec<std::thread::JoinHandle<()>> = Vec::new();
 
     while !stop.load(Ordering::Relaxed) {
         match inbound.recv_from(&mut buf) {
             Ok((n, client_addr)) => {
                 let data = buf[..n].to_vec();
 
-                let outbound = {
+                // Return both the outbound socket and an optional new reply handle.
+                let (outbound, spawned) = {
                     let mut map = sessions.lock().unwrap();
                     // Evict sessions idle > 30 seconds.
                     map.retain(|_, (_, last)| last.elapsed() < Duration::from_secs(30));
 
                     if let Some((sock, last)) = map.get_mut(&client_addr) {
                         *last = Instant::now();
-                        Arc::clone(sock)
+                        (Arc::clone(sock), None)
                     } else {
                         // New client: create a dedicated outbound socket.
                         let sock = match UdpSocket::bind("0.0.0.0:0") {
@@ -1581,7 +1600,7 @@ fn start_udp_proxy(
                         let reply_sock = Arc::clone(&sock);
                         let inbound_ref = Arc::clone(&inbound);
                         let stop2 = Arc::clone(&stop);
-                        std::thread::spawn(move || {
+                        let handle = std::thread::spawn(move || {
                             let mut rbuf = [0u8; 65535];
                             reply_sock
                                 .set_read_timeout(Some(Duration::from_millis(100)))
@@ -1599,9 +1618,15 @@ fn start_udp_proxy(
                             }
                         });
 
-                        sock
+                        (sock, Some(handle))
                     }
                 };
+
+                if let Some(h) = spawned {
+                    reply_handles.push(h);
+                    // Prune already-finished handles to bound memory use.
+                    reply_handles.retain(|h| !h.is_finished());
+                }
 
                 if let Err(e) = outbound.send(&data) {
                     log::debug!("udp proxy: forward to {} failed: {}", target, e);
@@ -1617,6 +1642,12 @@ fn start_udp_proxy(
                 break;
             }
         }
+    }
+
+    // Join all remaining reply threads.  They observe the same stop flag and
+    // exit within one read timeout (100 ms) of it being set.
+    for handle in reply_handles {
+        let _ = handle.join();
     }
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2584,6 +2584,74 @@ mod networking {
         );
     }
 
+    /// N4-UDP teardown: UDP proxy threads are joined on container stop, releasing the port.
+    ///
+    /// Starts a container with `with_port_forward_udp(19097, 5000)`. Verifies the
+    /// proxy holds the port (a second `UdpSocket::bind` to that port must fail).
+    /// Then kills the container and calls `wait()`, which triggers `teardown_network`.
+    /// After `wait()` returns the per-port proxy thread has been joined, meaning the
+    /// inbound socket is closed and the port is available for re-use.
+    ///
+    /// Failure (bind succeeds while container is running) means the proxy did not
+    /// start.  Failure (bind fails after teardown) means the proxy thread was not
+    /// joined and the socket is still held — i.e. `proxy_udp_threads` join logic is
+    /// broken.
+    #[test]
+    #[serial(nat)]
+    fn test_udp_proxy_threads_joined_on_teardown() {
+        if !is_root() {
+            eprintln!("Skipping test_udp_proxy_threads_joined_on_teardown: requires root");
+            return;
+        }
+
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!(
+                "Skipping test_udp_proxy_threads_joined_on_teardown: alpine-rootfs not found"
+            );
+            return;
+        };
+
+        let test_port: u16 = 19097;
+
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "sleep 60"])
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS)
+            .with_network(NetworkMode::Bridge)
+            .with_nat()
+            .with_port_forward_udp(test_port, 5000)
+            .with_chroot(&rootfs)
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Null)
+            .stderr(Stdio::Null)
+            .spawn()
+            .expect("spawn container");
+
+        // Give the proxy a moment to bind.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // Proxy should hold the port: binding to it must fail.
+        let bind_while_running =
+            std::net::UdpSocket::bind(std::net::SocketAddr::from(([127, 0, 0, 1], test_port)));
+        assert!(
+            bind_while_running.is_err(),
+            "UDP proxy should hold port {} while container is running",
+            test_port
+        );
+
+        // Kill container; wait() calls teardown_network which joins proxy threads.
+        unsafe { libc::kill(child.pid(), libc::SIGKILL) };
+        let _ = child.wait();
+
+        // Port must now be released (proxy thread joined → socket dropped).
+        let bind_after =
+            std::net::UdpSocket::bind(std::net::SocketAddr::from(([127, 0, 0, 1], test_port)));
+        assert!(
+            bind_after.is_ok(),
+            "UDP proxy port {} should be released after teardown (thread not joined?)",
+            test_port
+        );
+    }
+
     /// N2+N3: Bridge + NAT cleanup must work even after SIGKILL.
     ///
     /// Spawns a bridge+NAT container (`sleep 60`), records veth name, netns name,


### PR DESCRIPTION
## Summary

- Adds `proxy_udp_threads: Vec<JoinHandle<()>>` to `NetworkSetup`.
- `start_port_proxies` now returns per-port join handles; they are stored in the field.
- `teardown_network` drains and joins them after setting the stop flag — ensures the inbound socket is closed (port released) before the function returns.
- `start_udp_proxy` collects reply-thread handles and joins them after its main loop exits, completing the cleanup chain for both thread types.

## Why this matters

Before the fix, `teardown_network` set the stop flag and immediately returned. The per-port proxy threads kept the inbound `UdpSocket` open for up to 100 ms. The reply threads had no explicit synchronisation point at all — they were abandoned and eventually killed by `_exit(0)`. This was harmless in practice but meant ports were not deterministically released after teardown.

## Test

`test_udp_proxy_threads_joined_on_teardown`:
1. Spawn container with `with_port_forward_udp(19097, 5000)`.
2. Verify proxy holds the port (bind to 127.0.0.1:19097 must fail).
3. SIGKILL + `child.wait()` (triggers `teardown_network`).
4. Assert the port is now available (bind succeeds) — proves the thread was joined.

## Test plan
- [x] `networking::test_udp_proxy_threads_joined_on_teardown` passes
- [x] Full integration suite: 161 passed, 0 failed

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)