### PR TITLE
feat(oci): Phase 5 — linux.rootfsPropagation + linux.cgroupsPath

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -741,6 +741,27 @@ written with a positive integer that matches the PID reported in `state.json`. F
 
 ---
 
+### `test_oci_rootfs_propagation`
+**Requires:** root, rootfs
+
+Creates an OCI bundle with `linux.rootfsPropagation: "private"` and runs `echo ok` inside it.
+Verifies the container starts and completes successfully. Failure indicates the `rootfsPropagation`
+field is not parsed, the mapping to `MS_PRIVATE|MS_REC` is wrong, or the `mount(2)` call fails,
+which would cause the container to refuse to start whenever a runtime-tools bundle specifies
+mount propagation.
+
+---
+
+### `test_oci_cgroups_path`
+**Requires:** root, rootfs
+
+Creates an OCI bundle with `linux.cgroupsPath` set to a unique name and runs `echo ok` inside it.
+Verifies the container starts and completes successfully. Failure indicates the `cgroupsPath` field
+is not wired from OCI config through to `CgroupConfig.path`, which would break runtimes that
+rely on predictable cgroup hierarchy placement (e.g. systemd-managed slices).
+
+---
+
 ## Rootless Mode Tests
 
 The following tests only execute when the test binary is run **without root** (no `sudo`).

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -53,6 +53,10 @@ pub struct CgroupConfig {
 
     /// Maximum number of live processes/threads in the cgroup (`pids.max`).
     pub pids_limit: Option<u64>,
+
+    /// Explicit cgroup path from OCI `linux.cgroupsPath`.
+    /// If set, used as-is as the cgroup name/path; otherwise defaults to `remora-{pid}`.
+    pub path: Option<String>,
 }
 
 /// Create a cgroup named `remora-{child_pid}`, apply configured limits, and add
@@ -66,7 +70,10 @@ pub struct CgroupConfig {
 /// Returns an error if the cgroup cannot be created (e.g. missing permissions,
 /// cgroup fs not mounted) or if the PID cannot be added.
 pub fn setup_cgroup(cfg: &CgroupConfig, child_pid: u32) -> io::Result<Cgroup> {
-    let name = format!("remora-{}", child_pid);
+    let name = cfg
+        .path
+        .clone()
+        .unwrap_or_else(|| format!("remora-{}", child_pid));
     let hier = hierarchies::auto();
 
     let mut builder = CgroupBuilder::new(&name);

--- a/src/container.rs
+++ b/src/container.rs
@@ -696,6 +696,9 @@ pub struct Command {
     devices: Vec<DeviceNode>,
     // Pre-compiled seccomp BPF program (takes priority over seccomp_profile).
     seccomp_program: Option<seccompiler::BpfProgram>,
+    // Mount propagation flags applied to the rootfs mountpoint after pivot_root/chroot.
+    // None → default (MS_PRIVATE|MS_REC). Some(flags) → apply those flags instead.
+    rootfs_propagation: Option<libc::c_ulong>,
     // Hostname to set inside the container's UTS namespace.
     hostname: Option<String>,
     // Whether to use newuidmap/newgidmap helpers for multi-range UID/GID mapping.
@@ -744,6 +747,7 @@ impl Command {
             sysctl: Vec::new(),
             devices: Vec::new(),
             seccomp_program: None,
+            rootfs_propagation: None,
             hostname: None,
             links: Vec::new(),
             use_id_helpers: false,
@@ -1135,6 +1139,15 @@ impl Command {
         self.cgroup_config
             .get_or_insert_with(Default::default)
             .pids_limit = Some(max);
+        self
+    }
+
+    /// Override the cgroup path/name for this container (OCI `linux.cgroupsPath`).
+    ///
+    /// By default remora names the cgroup `remora-{child_pid}`. When the OCI config
+    /// specifies `linux.cgroupsPath`, pass it here to use that name instead.
+    pub fn with_cgroup_path(mut self, path: impl Into<String>) -> Self {
+        self.cgroup_config.get_or_insert_with(Default::default).path = Some(path.into());
         self
     }
 
@@ -1594,6 +1607,15 @@ impl Command {
         self
     }
 
+    /// Override the rootfs mount propagation applied after chroot/pivot_root.
+    ///
+    /// Pass `MS_SHARED`, `MS_SLAVE`, `MS_PRIVATE`, or `MS_UNBINDABLE` (optionally OR'd
+    /// with `MS_REC`). By default remora applies `MS_PRIVATE | MS_REC`.
+    pub fn with_rootfs_propagation(mut self, flags: libc::c_ulong) -> Self {
+        self.rootfs_propagation = Some(flags);
+        self
+    }
+
     /// Add a read-write bind mount from a host directory into the container.
     ///
     /// The `source` is an absolute path on the host; `target` is the absolute
@@ -1835,6 +1857,7 @@ impl Command {
         let bind_mounts = self.bind_mounts.clone();
         let tmpfs_mounts = self.tmpfs_mounts.clone();
         let kernel_mounts = self.kernel_mounts.clone();
+        let rootfs_propagation = self.rootfs_propagation;
         let hostname = self.hostname.clone();
         let use_id_helpers = self.use_id_helpers;
         // Loopback/Pasta mode: bring up lo inside pre_exec (after unshare(NEWNET)).
@@ -2231,16 +2254,19 @@ impl Command {
 
                     // Step 1.5: If we created a mount namespace, make all mounts private
                     // to prevent mount propagation leaking to the parent namespace.
+                    // linux.rootfsPropagation overrides the default MS_PRIVATE|MS_REC.
                     if namespaces.contains(Namespace::MOUNT) {
                         use std::ptr;
 
+                        let prop_flags =
+                            rootfs_propagation.unwrap_or(libc::MS_REC | libc::MS_PRIVATE);
                         let root = c"/";
                         let result = libc::mount(
-                            ptr::null(),                     // source: NULL (remount)
-                            root.as_ptr(),                   // target: root
-                            ptr::null(),                     // fstype: NULL (remount)
-                            libc::MS_REC | libc::MS_PRIVATE, // flags: recursive + private
-                            ptr::null(),                     // data: NULL
+                            ptr::null(),   // source: NULL (remount)
+                            root.as_ptr(), // target: root
+                            ptr::null(),   // fstype: NULL (remount)
+                            prop_flags,
+                            ptr::null(), // data: NULL
                         );
 
                         if result != 0 {
@@ -2909,8 +2935,13 @@ impl Command {
                 // Mount kernel filesystems (proc, sysfs, devpts, mqueue, cgroup2, …)
                 // specified by OCI config.json `mounts` entries.
                 for km in &kernel_mounts {
-                    std::fs::create_dir_all(&km.target)
-                        .map_err(|e| io::Error::other(format!("kernel mount mkdir {}: {}", km.target.display(), e)))?;
+                    std::fs::create_dir_all(&km.target).map_err(|e| {
+                        io::Error::other(format!(
+                            "kernel mount mkdir {}: {}",
+                            km.target.display(),
+                            e
+                        ))
+                    })?;
                     let tgt_c = CString::new(km.target.as_os_str().as_encoded_bytes()).unwrap();
                     let src_c = CString::new(km.source.as_bytes()).unwrap();
                     let fst_c = CString::new(km.fs_type.as_bytes()).unwrap();
@@ -2920,11 +2951,19 @@ impl Command {
                     } else {
                         dat_c.as_ptr() as *const libc::c_void
                     };
-                    let result = libc::mount(src_c.as_ptr(), tgt_c.as_ptr(), fst_c.as_ptr(), km.flags, dat_ptr);
+                    let result = libc::mount(
+                        src_c.as_ptr(),
+                        tgt_c.as_ptr(),
+                        fst_c.as_ptr(),
+                        km.flags,
+                        dat_ptr,
+                    );
                     if result != 0 {
                         return Err(io::Error::other(format!(
                             "mount {} ({}) at {}: {}",
-                            km.fs_type, km.source, km.target.display(),
+                            km.fs_type,
+                            km.source,
+                            km.target.display(),
                             io::Error::last_os_error()
                         )));
                     }
@@ -3501,6 +3540,7 @@ impl Command {
         let bind_mounts = self.bind_mounts.clone();
         let tmpfs_mounts = self.tmpfs_mounts.clone();
         let kernel_mounts = self.kernel_mounts.clone();
+        let rootfs_propagation = self.rootfs_propagation;
         let hostname = self.hostname.clone();
         let use_id_helpers = self.use_id_helpers;
         let bring_up_loopback = self.network_config.as_ref().is_some_and(|c| {
@@ -3882,13 +3922,16 @@ impl Command {
                             .map_err(|e| io::Error::other(format!("unshare error: {}", e)))?;
                     }
 
+                    // linux.rootfsPropagation overrides the default MS_PRIVATE|MS_REC.
                     if namespaces.contains(Namespace::MOUNT) {
+                        let prop_flags =
+                            rootfs_propagation.unwrap_or(libc::MS_REC | libc::MS_PRIVATE);
                         let root = c"/";
                         let result = libc::mount(
                             ptr::null(),
                             root.as_ptr(),
                             ptr::null(),
-                            libc::MS_PRIVATE | libc::MS_REC,
+                            prop_flags,
                             ptr::null(),
                         );
                         if result != 0 {
@@ -4450,8 +4493,13 @@ impl Command {
                 // Mount kernel filesystems (proc, sysfs, devpts, mqueue, cgroup2, …)
                 // specified by OCI config.json `mounts` entries.
                 for km in &kernel_mounts {
-                    std::fs::create_dir_all(&km.target)
-                        .map_err(|e| io::Error::other(format!("kernel mount mkdir {}: {}", km.target.display(), e)))?;
+                    std::fs::create_dir_all(&km.target).map_err(|e| {
+                        io::Error::other(format!(
+                            "kernel mount mkdir {}: {}",
+                            km.target.display(),
+                            e
+                        ))
+                    })?;
                     let tgt_c = CString::new(km.target.as_os_str().as_encoded_bytes()).unwrap();
                     let src_c = CString::new(km.source.as_bytes()).unwrap();
                     let fst_c = CString::new(km.fs_type.as_bytes()).unwrap();
@@ -4461,11 +4509,19 @@ impl Command {
                     } else {
                         dat_c.as_ptr() as *const libc::c_void
                     };
-                    let result = libc::mount(src_c.as_ptr(), tgt_c.as_ptr(), fst_c.as_ptr(), km.flags, dat_ptr);
+                    let result = libc::mount(
+                        src_c.as_ptr(),
+                        tgt_c.as_ptr(),
+                        fst_c.as_ptr(),
+                        km.flags,
+                        dat_ptr,
+                    );
                     if result != 0 {
                         return Err(io::Error::other(format!(
                             "mount {} ({}) at {}: {}",
-                            km.fs_type, km.source, km.target.display(),
+                            km.fs_type,
+                            km.source,
+                            km.target.display(),
                             io::Error::last_os_error()
                         )));
                     }

--- a/src/oci.rs
+++ b/src/oci.rs
@@ -105,6 +105,12 @@ pub struct OciLinux {
     #[serde(default)]
     pub devices: Vec<OciDevice>,
     pub seccomp: Option<OciSeccomp>,
+    /// Mount propagation of the rootfs: "shared" | "slave" | "private" | "unbindable".
+    /// Defaults to "rprivate" (remora makes all mounts private by default).
+    pub rootfs_propagation: Option<String>,
+    /// Absolute path for the container's cgroup (e.g. "/myapp/container1").
+    /// If absent, remora auto-generates a path.
+    pub cgroups_path: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -317,48 +323,48 @@ fn oci_cap_to_flag(name: &str) -> Option<crate::container::Capability> {
     // Strip optional "CAP_" prefix — OCI bundles may include it or omit it.
     let n = name.strip_prefix("CAP_").unwrap_or(name);
     match n {
-        "CHOWN"              => Some(Capability::CHOWN),
-        "DAC_OVERRIDE"       => Some(Capability::DAC_OVERRIDE),
-        "DAC_READ_SEARCH"    => Some(Capability::DAC_READ_SEARCH),
-        "FOWNER"             => Some(Capability::FOWNER),
-        "FSETID"             => Some(Capability::FSETID),
-        "KILL"               => Some(Capability::KILL),
-        "SETGID"             => Some(Capability::SETGID),
-        "SETUID"             => Some(Capability::SETUID),
-        "SETPCAP"            => Some(Capability::SETPCAP),
-        "LINUX_IMMUTABLE"    => Some(Capability::LINUX_IMMUTABLE),
-        "NET_BIND_SERVICE"   => Some(Capability::NET_BIND_SERVICE),
-        "NET_BROADCAST"      => Some(Capability::NET_BROADCAST),
-        "NET_ADMIN"          => Some(Capability::NET_ADMIN),
-        "NET_RAW"            => Some(Capability::NET_RAW),
-        "IPC_LOCK"           => Some(Capability::IPC_LOCK),
-        "IPC_OWNER"          => Some(Capability::IPC_OWNER),
-        "SYS_MODULE"         => Some(Capability::SYS_MODULE),
-        "SYS_RAWIO"          => Some(Capability::SYS_RAWIO),
-        "SYS_CHROOT"         => Some(Capability::SYS_CHROOT),
-        "SYS_PTRACE"         => Some(Capability::SYS_PTRACE),
-        "SYS_PACCT"          => Some(Capability::SYS_PACCT),
-        "SYS_ADMIN"          => Some(Capability::SYS_ADMIN),
-        "SYS_BOOT"           => Some(Capability::SYS_BOOT),
-        "SYS_NICE"           => Some(Capability::SYS_NICE),
-        "SYS_RESOURCE"       => Some(Capability::SYS_RESOURCE),
-        "SYS_TIME"           => Some(Capability::SYS_TIME),
-        "SYS_TTY_CONFIG"     => Some(Capability::SYS_TTY_CONFIG),
-        "MKNOD"              => Some(Capability::MKNOD),
-        "LEASE"              => Some(Capability::LEASE),
-        "AUDIT_WRITE"        => Some(Capability::AUDIT_WRITE),
-        "AUDIT_CONTROL"      => Some(Capability::AUDIT_CONTROL),
-        "SETFCAP"            => Some(Capability::SETFCAP),
-        "MAC_OVERRIDE"       => Some(Capability::MAC_OVERRIDE),
-        "MAC_ADMIN"          => Some(Capability::MAC_ADMIN),
-        "SYSLOG"             => Some(Capability::SYSLOG),
-        "WAKE_ALARM"         => Some(Capability::WAKE_ALARM),
-        "BLOCK_SUSPEND"      => Some(Capability::BLOCK_SUSPEND),
-        "AUDIT_READ"         => Some(Capability::AUDIT_READ),
-        "PERFMON"            => Some(Capability::PERFMON),
-        "BPF"                => Some(Capability::BPF),
+        "CHOWN" => Some(Capability::CHOWN),
+        "DAC_OVERRIDE" => Some(Capability::DAC_OVERRIDE),
+        "DAC_READ_SEARCH" => Some(Capability::DAC_READ_SEARCH),
+        "FOWNER" => Some(Capability::FOWNER),
+        "FSETID" => Some(Capability::FSETID),
+        "KILL" => Some(Capability::KILL),
+        "SETGID" => Some(Capability::SETGID),
+        "SETUID" => Some(Capability::SETUID),
+        "SETPCAP" => Some(Capability::SETPCAP),
+        "LINUX_IMMUTABLE" => Some(Capability::LINUX_IMMUTABLE),
+        "NET_BIND_SERVICE" => Some(Capability::NET_BIND_SERVICE),
+        "NET_BROADCAST" => Some(Capability::NET_BROADCAST),
+        "NET_ADMIN" => Some(Capability::NET_ADMIN),
+        "NET_RAW" => Some(Capability::NET_RAW),
+        "IPC_LOCK" => Some(Capability::IPC_LOCK),
+        "IPC_OWNER" => Some(Capability::IPC_OWNER),
+        "SYS_MODULE" => Some(Capability::SYS_MODULE),
+        "SYS_RAWIO" => Some(Capability::SYS_RAWIO),
+        "SYS_CHROOT" => Some(Capability::SYS_CHROOT),
+        "SYS_PTRACE" => Some(Capability::SYS_PTRACE),
+        "SYS_PACCT" => Some(Capability::SYS_PACCT),
+        "SYS_ADMIN" => Some(Capability::SYS_ADMIN),
+        "SYS_BOOT" => Some(Capability::SYS_BOOT),
+        "SYS_NICE" => Some(Capability::SYS_NICE),
+        "SYS_RESOURCE" => Some(Capability::SYS_RESOURCE),
+        "SYS_TIME" => Some(Capability::SYS_TIME),
+        "SYS_TTY_CONFIG" => Some(Capability::SYS_TTY_CONFIG),
+        "MKNOD" => Some(Capability::MKNOD),
+        "LEASE" => Some(Capability::LEASE),
+        "AUDIT_WRITE" => Some(Capability::AUDIT_WRITE),
+        "AUDIT_CONTROL" => Some(Capability::AUDIT_CONTROL),
+        "SETFCAP" => Some(Capability::SETFCAP),
+        "MAC_OVERRIDE" => Some(Capability::MAC_OVERRIDE),
+        "MAC_ADMIN" => Some(Capability::MAC_ADMIN),
+        "SYSLOG" => Some(Capability::SYSLOG),
+        "WAKE_ALARM" => Some(Capability::WAKE_ALARM),
+        "BLOCK_SUSPEND" => Some(Capability::BLOCK_SUSPEND),
+        "AUDIT_READ" => Some(Capability::AUDIT_READ),
+        "PERFMON" => Some(Capability::PERFMON),
+        "BPF" => Some(Capability::BPF),
         "CHECKPOINT_RESTORE" => Some(Capability::CHECKPOINT_RESTORE),
-        _                    => None,
+        _ => None,
     }
 }
 
@@ -567,6 +573,28 @@ pub fn build_command(config: &OciConfig, bundle: &Path) -> io::Result<crate::con
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
             cmd = cmd.with_seccomp_program(prog);
         }
+
+        // linux.rootfsPropagation
+        if let Some(ref prop) = linux.rootfs_propagation {
+            let flags: libc::c_ulong = match prop.as_str() {
+                "shared" => libc::MS_SHARED | libc::MS_REC,
+                "slave" => libc::MS_SLAVE | libc::MS_REC,
+                "private" => libc::MS_PRIVATE | libc::MS_REC,
+                "unbindable" => libc::MS_UNBINDABLE | libc::MS_REC,
+                other => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("unknown rootfsPropagation: {}", other),
+                    ));
+                }
+            };
+            cmd = cmd.with_rootfs_propagation(flags);
+        }
+
+        // linux.cgroupsPath
+        if let Some(ref cg_path) = linux.cgroups_path {
+            cmd = cmd.with_cgroup_path(cg_path.as_str());
+        }
     }
 
     // process.rlimits
@@ -606,21 +634,21 @@ pub fn build_command(config: &OciConfig, bundle: &Path) -> io::Result<crate::con
         let mut extra_data_parts: Vec<&str> = Vec::new();
         for opt in &mount.options {
             match opt.as_str() {
-                "nosuid"    => flags |= libc::MS_NOSUID,
-                "noexec"    => flags |= libc::MS_NOEXEC,
-                "nodev"     => flags |= libc::MS_NODEV,
+                "nosuid" => flags |= libc::MS_NOSUID,
+                "noexec" => flags |= libc::MS_NOEXEC,
+                "nodev" => flags |= libc::MS_NODEV,
                 "ro" | "readonly" => flags |= libc::MS_RDONLY,
-                "relatime"  => flags |= libc::MS_RELATIME,
-                "noatime"   => flags |= libc::MS_NOATIME,
+                "relatime" => flags |= libc::MS_RELATIME,
+                "noatime" => flags |= libc::MS_NOATIME,
                 "nodiratime" => flags |= libc::MS_NODIRATIME,
                 "strictatime" => flags |= libc::MS_STRICTATIME,
-                "shared"    => flags |= libc::MS_SHARED,
-                "slave"     => flags |= libc::MS_SLAVE,
-                "private"   => flags |= libc::MS_PRIVATE,
+                "shared" => flags |= libc::MS_SHARED,
+                "slave" => flags |= libc::MS_SLAVE,
+                "private" => flags |= libc::MS_PRIVATE,
                 "unbindable" => flags |= libc::MS_UNBINDABLE,
-                "bind"      => flags |= libc::MS_BIND,
-                "rbind"     => flags |= libc::MS_BIND | libc::MS_REC,
-                other       => extra_data_parts.push(other),
+                "bind" => flags |= libc::MS_BIND,
+                "rbind" => flags |= libc::MS_BIND | libc::MS_REC,
+                other => extra_data_parts.push(other),
             }
         }
         let extra_data = extra_data_parts.join(",");
@@ -658,12 +686,14 @@ pub fn build_command(config: &OciConfig, bundle: &Path) -> io::Result<crate::con
                 cmd = cmd.with_kernel_mount("mqueue", src, dest, f, "");
             }
             "cgroup" => {
-                let f = libc::MS_NOSUID | libc::MS_NOEXEC | libc::MS_NODEV | libc::MS_RELATIME | flags;
+                let f =
+                    libc::MS_NOSUID | libc::MS_NOEXEC | libc::MS_NODEV | libc::MS_RELATIME | flags;
                 let src = mount.source.as_deref().unwrap_or("cgroup");
                 cmd = cmd.with_kernel_mount("cgroup", src, dest, f, &extra_data);
             }
             "cgroup2" => {
-                let f = libc::MS_NOSUID | libc::MS_NOEXEC | libc::MS_NODEV | libc::MS_RELATIME | flags;
+                let f =
+                    libc::MS_NOSUID | libc::MS_NOEXEC | libc::MS_NODEV | libc::MS_RELATIME | flags;
                 let src = mount.source.as_deref().unwrap_or("cgroup2");
                 cmd = cmd.with_kernel_mount("cgroup2", src, dest, f, "");
             }
@@ -1154,40 +1184,43 @@ pub fn cmd_kill(id: &str, signal: &str) -> io::Result<()> {
 
     // Accept signal as name (with or without "SIG" prefix) or number.
     let sig: i32 = match signal.to_ascii_uppercase().trim_start_matches("SIG") {
-        "HUP"    | "1"  => libc::SIGHUP,
-        "INT"    | "2"  => libc::SIGINT,
-        "QUIT"   | "3"  => libc::SIGQUIT,
-        "ILL"    | "4"  => libc::SIGILL,
-        "TRAP"   | "5"  => libc::SIGTRAP,
-        "ABRT"   | "6"  => libc::SIGABRT,
-        "BUS"    | "7"  => libc::SIGBUS,
-        "FPE"    | "8"  => libc::SIGFPE,
-        "KILL"   | "9"  => libc::SIGKILL,
-        "USR1"   | "10" => libc::SIGUSR1,
-        "SEGV"   | "11" => libc::SIGSEGV,
-        "USR2"   | "12" => libc::SIGUSR2,
-        "PIPE"   | "13" => libc::SIGPIPE,
-        "ALRM"   | "14" => libc::SIGALRM,
-        "TERM"   | "15" => libc::SIGTERM,
-        "CHLD"   | "17" => libc::SIGCHLD,
-        "CONT"   | "18" => libc::SIGCONT,
-        "STOP"   | "19" => libc::SIGSTOP,
-        "TSTP"   | "20" => libc::SIGTSTP,
-        "TTIN"   | "21" => libc::SIGTTIN,
-        "TTOU"   | "22" => libc::SIGTTOU,
-        "URG"    | "23" => libc::SIGURG,
-        "XCPU"   | "24" => libc::SIGXCPU,
-        "XFSZ"   | "25" => libc::SIGXFSZ,
+        "HUP" | "1" => libc::SIGHUP,
+        "INT" | "2" => libc::SIGINT,
+        "QUIT" | "3" => libc::SIGQUIT,
+        "ILL" | "4" => libc::SIGILL,
+        "TRAP" | "5" => libc::SIGTRAP,
+        "ABRT" | "6" => libc::SIGABRT,
+        "BUS" | "7" => libc::SIGBUS,
+        "FPE" | "8" => libc::SIGFPE,
+        "KILL" | "9" => libc::SIGKILL,
+        "USR1" | "10" => libc::SIGUSR1,
+        "SEGV" | "11" => libc::SIGSEGV,
+        "USR2" | "12" => libc::SIGUSR2,
+        "PIPE" | "13" => libc::SIGPIPE,
+        "ALRM" | "14" => libc::SIGALRM,
+        "TERM" | "15" => libc::SIGTERM,
+        "CHLD" | "17" => libc::SIGCHLD,
+        "CONT" | "18" => libc::SIGCONT,
+        "STOP" | "19" => libc::SIGSTOP,
+        "TSTP" | "20" => libc::SIGTSTP,
+        "TTIN" | "21" => libc::SIGTTIN,
+        "TTOU" | "22" => libc::SIGTTOU,
+        "URG" | "23" => libc::SIGURG,
+        "XCPU" | "24" => libc::SIGXCPU,
+        "XFSZ" | "25" => libc::SIGXFSZ,
         "VTALRM" | "26" => libc::SIGVTALRM,
-        "PROF"   | "27" => libc::SIGPROF,
-        "WINCH"  | "28" => libc::SIGWINCH,
+        "PROF" | "27" => libc::SIGPROF,
+        "WINCH" | "28" => libc::SIGWINCH,
         "IO" | "POLL" | "29" => libc::SIGIO,
-        "PWR"    | "30" => libc::SIGPWR,
-        "SYS"    | "31" => libc::SIGSYS,
+        "PWR" | "30" => libc::SIGPWR,
+        "SYS" | "31" => libc::SIGSYS,
         s => s.parse::<i32>().map_err(|_| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
-                format!("unknown signal '{}' — use a name (SIGTERM) or number (15)", signal),
+                format!(
+                    "unknown signal '{}' — use a name (SIGTERM) or number (15)",
+                    signal
+                ),
             )
         })?,
     };
@@ -1243,22 +1276,53 @@ mod tests {
     fn test_oci_cap_all_known_names_round_trip() {
         // Every OCI capability name used in Docker's default profile must map to a flag.
         let known = [
-            "CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_DAC_READ_SEARCH", "CAP_FOWNER",
-            "CAP_FSETID", "CAP_KILL", "CAP_SETGID", "CAP_SETUID", "CAP_SETPCAP",
-            "CAP_LINUX_IMMUTABLE", "CAP_NET_BIND_SERVICE", "CAP_NET_BROADCAST",
-            "CAP_NET_ADMIN", "CAP_NET_RAW", "CAP_IPC_LOCK", "CAP_IPC_OWNER",
-            "CAP_SYS_MODULE", "CAP_SYS_RAWIO", "CAP_SYS_CHROOT", "CAP_SYS_PTRACE",
-            "CAP_SYS_PACCT", "CAP_SYS_ADMIN", "CAP_SYS_BOOT", "CAP_SYS_NICE",
-            "CAP_SYS_RESOURCE", "CAP_SYS_TIME", "CAP_SYS_TTY_CONFIG", "CAP_MKNOD",
-            "CAP_LEASE", "CAP_AUDIT_WRITE", "CAP_AUDIT_CONTROL", "CAP_SETFCAP",
-            "CAP_MAC_OVERRIDE", "CAP_MAC_ADMIN", "CAP_SYSLOG", "CAP_WAKE_ALARM",
-            "CAP_BLOCK_SUSPEND", "CAP_AUDIT_READ", "CAP_PERFMON", "CAP_BPF",
+            "CAP_CHOWN",
+            "CAP_DAC_OVERRIDE",
+            "CAP_DAC_READ_SEARCH",
+            "CAP_FOWNER",
+            "CAP_FSETID",
+            "CAP_KILL",
+            "CAP_SETGID",
+            "CAP_SETUID",
+            "CAP_SETPCAP",
+            "CAP_LINUX_IMMUTABLE",
+            "CAP_NET_BIND_SERVICE",
+            "CAP_NET_BROADCAST",
+            "CAP_NET_ADMIN",
+            "CAP_NET_RAW",
+            "CAP_IPC_LOCK",
+            "CAP_IPC_OWNER",
+            "CAP_SYS_MODULE",
+            "CAP_SYS_RAWIO",
+            "CAP_SYS_CHROOT",
+            "CAP_SYS_PTRACE",
+            "CAP_SYS_PACCT",
+            "CAP_SYS_ADMIN",
+            "CAP_SYS_BOOT",
+            "CAP_SYS_NICE",
+            "CAP_SYS_RESOURCE",
+            "CAP_SYS_TIME",
+            "CAP_SYS_TTY_CONFIG",
+            "CAP_MKNOD",
+            "CAP_LEASE",
+            "CAP_AUDIT_WRITE",
+            "CAP_AUDIT_CONTROL",
+            "CAP_SETFCAP",
+            "CAP_MAC_OVERRIDE",
+            "CAP_MAC_ADMIN",
+            "CAP_SYSLOG",
+            "CAP_WAKE_ALARM",
+            "CAP_BLOCK_SUSPEND",
+            "CAP_AUDIT_READ",
+            "CAP_PERFMON",
+            "CAP_BPF",
             "CAP_CHECKPOINT_RESTORE",
         ];
         for name in &known {
             assert!(
                 oci_cap_to_flag(name).is_some(),
-                "oci_cap_to_flag returned None for {}", name
+                "oci_cap_to_flag returned None for {}",
+                name
             );
         }
     }
@@ -1277,11 +1341,11 @@ mod tests {
         // The signal parsing in cmd_kill must accept names from runtime-tools.
         let cases: &[(&str, i32)] = &[
             ("SIGTERM", libc::SIGTERM),
-            ("TERM",    libc::SIGTERM),
-            ("15",      libc::SIGTERM),
+            ("TERM", libc::SIGTERM),
+            ("15", libc::SIGTERM),
             ("SIGKILL", libc::SIGKILL),
-            ("9",       libc::SIGKILL),
-            ("SIGHUP",  libc::SIGHUP),
+            ("9", libc::SIGKILL),
+            ("SIGHUP", libc::SIGHUP),
             ("SIGWINCH", libc::SIGWINCH),
             ("SIGCHLD", libc::SIGCHLD),
             ("SIGCONT", libc::SIGCONT),
@@ -1293,43 +1357,47 @@ mod tests {
             ("SIGALRM", libc::SIGALRM),
             ("SIGSEGV", libc::SIGSEGV),
             ("SIGABRT", libc::SIGABRT),
-            ("SIGSYS",  libc::SIGSYS),
+            ("SIGSYS", libc::SIGSYS),
         ];
         for (name, expected) in cases {
             let got = match name.to_ascii_uppercase().trim_start_matches("SIG") {
-                "HUP"    | "1"  => libc::SIGHUP,
-                "INT"    | "2"  => libc::SIGINT,
-                "QUIT"   | "3"  => libc::SIGQUIT,
-                "ILL"    | "4"  => libc::SIGILL,
-                "TRAP"   | "5"  => libc::SIGTRAP,
-                "ABRT"   | "6"  => libc::SIGABRT,
-                "BUS"    | "7"  => libc::SIGBUS,
-                "FPE"    | "8"  => libc::SIGFPE,
-                "KILL"   | "9"  => libc::SIGKILL,
-                "USR1"   | "10" => libc::SIGUSR1,
-                "SEGV"   | "11" => libc::SIGSEGV,
-                "USR2"   | "12" => libc::SIGUSR2,
-                "PIPE"   | "13" => libc::SIGPIPE,
-                "ALRM"   | "14" => libc::SIGALRM,
-                "TERM"   | "15" => libc::SIGTERM,
-                "CHLD"   | "17" => libc::SIGCHLD,
-                "CONT"   | "18" => libc::SIGCONT,
-                "STOP"   | "19" => libc::SIGSTOP,
-                "TSTP"   | "20" => libc::SIGTSTP,
-                "TTIN"   | "21" => libc::SIGTTIN,
-                "TTOU"   | "22" => libc::SIGTTOU,
-                "URG"    | "23" => libc::SIGURG,
-                "XCPU"   | "24" => libc::SIGXCPU,
-                "XFSZ"   | "25" => libc::SIGXFSZ,
+                "HUP" | "1" => libc::SIGHUP,
+                "INT" | "2" => libc::SIGINT,
+                "QUIT" | "3" => libc::SIGQUIT,
+                "ILL" | "4" => libc::SIGILL,
+                "TRAP" | "5" => libc::SIGTRAP,
+                "ABRT" | "6" => libc::SIGABRT,
+                "BUS" | "7" => libc::SIGBUS,
+                "FPE" | "8" => libc::SIGFPE,
+                "KILL" | "9" => libc::SIGKILL,
+                "USR1" | "10" => libc::SIGUSR1,
+                "SEGV" | "11" => libc::SIGSEGV,
+                "USR2" | "12" => libc::SIGUSR2,
+                "PIPE" | "13" => libc::SIGPIPE,
+                "ALRM" | "14" => libc::SIGALRM,
+                "TERM" | "15" => libc::SIGTERM,
+                "CHLD" | "17" => libc::SIGCHLD,
+                "CONT" | "18" => libc::SIGCONT,
+                "STOP" | "19" => libc::SIGSTOP,
+                "TSTP" | "20" => libc::SIGTSTP,
+                "TTIN" | "21" => libc::SIGTTIN,
+                "TTOU" | "22" => libc::SIGTTOU,
+                "URG" | "23" => libc::SIGURG,
+                "XCPU" | "24" => libc::SIGXCPU,
+                "XFSZ" | "25" => libc::SIGXFSZ,
                 "VTALRM" | "26" => libc::SIGVTALRM,
-                "PROF"   | "27" => libc::SIGPROF,
-                "WINCH"  | "28" => libc::SIGWINCH,
+                "PROF" | "27" => libc::SIGPROF,
+                "WINCH" | "28" => libc::SIGWINCH,
                 "IO" | "POLL" | "29" => libc::SIGIO,
-                "PWR"    | "30" => libc::SIGPWR,
-                "SYS"    | "31" => libc::SIGSYS,
+                "PWR" | "30" => libc::SIGPWR,
+                "SYS" | "31" => libc::SIGSYS,
                 s => s.parse::<i32>().unwrap_or(-1),
             };
-            assert_eq!(got, *expected, "signal '{}' mapped to {} not {}", name, got, expected);
+            assert_eq!(
+                got, *expected,
+                "signal '{}' mapped to {} not {}",
+                name, got, expected
+            );
         }
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3678,7 +3678,10 @@ mod oci_lifecycle {
         std::fs::write(bundle_dir.path().join("config.json"), config).unwrap();
         let id = format!("test-oci-kmnt-{}", std::process::id());
         let (_, stderr, ok) = run_remora(&[
-            "create", "--bundle", bundle_dir.path().to_str().unwrap(), &id,
+            "create",
+            "--bundle",
+            bundle_dir.path().to_str().unwrap(),
+            &id,
         ]);
         assert!(ok, "remora create (kernel mounts) failed: {}", stderr);
         let (_, stderr, ok) = run_remora(&["start", &id]);
@@ -3687,7 +3690,9 @@ mod oci_lifecycle {
         loop {
             std::thread::sleep(std::time::Duration::from_millis(100));
             let (stdout, _, _) = run_remora(&["state", &id]);
-            if stdout.contains("\"stopped\"") { break; }
+            if stdout.contains("\"stopped\"") {
+                break;
+            }
             if std::time::Instant::now() > deadline {
                 run_remora(&["delete", &id]);
                 panic!("container with kernel mounts did not stop within 5s");
@@ -3731,7 +3736,11 @@ mod oci_lifecycle {
         assert!(ok, "remora create --bundle failed: {}", stderr);
 
         let (stdout, _, _) = run_remora(&["state", &id]);
-        assert!(stdout.contains("\"created\""), "expected created state, got: {}", stdout);
+        assert!(
+            stdout.contains("\"created\""),
+            "expected created state, got: {}",
+            stdout
+        );
 
         run_remora(&["kill", &id, "SIGKILL"]);
         std::thread::sleep(std::time::Duration::from_millis(300));
@@ -3775,9 +3784,11 @@ mod oci_lifecycle {
         assert!(ok, "remora create --pid-file failed: {}", stderr);
 
         // Verify pid file exists and contains a positive integer.
-        let pid_str = std::fs::read_to_string(&pid_file)
-            .expect("pid file not written");
-        let pid: i32 = pid_str.trim().parse().expect("pid file contains non-integer");
+        let pid_str = std::fs::read_to_string(&pid_file).expect("pid file not written");
+        let pid: i32 = pid_str
+            .trim()
+            .parse()
+            .expect("pid file contains non-integer");
         assert!(pid > 1, "pid file contains invalid PID {}", pid);
 
         // Verify PID matches state.json.
@@ -3785,12 +3796,120 @@ mod oci_lifecycle {
         assert!(
             state_out.contains(&pid.to_string()),
             "pid file PID {} not found in state: {}",
-            pid, state_out
+            pid,
+            state_out
         );
 
         run_remora(&["kill", &id, "SIGKILL"]);
         std::thread::sleep(std::time::Duration::from_millis(300));
         run_remora(&["delete", &id]);
+    }
+
+    /// test_oci_rootfs_propagation
+    ///
+    /// Requires: root, alpine-rootfs.
+    ///
+    /// Creates an OCI bundle with `linux.rootfsPropagation: "private"` and runs
+    /// `echo ok` inside it. Verifies that the container starts and finishes
+    /// successfully — confirming that the field is parsed, mapped to MS_PRIVATE|MS_REC,
+    /// and applied in pre_exec without error.
+    ///
+    /// Failure indicates the propagation flag parsing or mount(2) call is broken.
+    #[test]
+    fn test_oci_rootfs_propagation() {
+        if !is_root() {
+            eprintln!("Skipping test_oci_rootfs_propagation: requires root");
+            return;
+        }
+        let rootfs = match get_test_rootfs() {
+            Some(p) => p,
+            None => {
+                eprintln!("Skipping test_oci_rootfs_propagation: alpine-rootfs not found");
+                return;
+            }
+        };
+        let bundle_dir = tempfile::tempdir().expect("tempdir");
+        let rootfs_link = bundle_dir.path().join("rootfs");
+        std::os::unix::fs::symlink(&rootfs, &rootfs_link).unwrap();
+
+        // Config with rootfsPropagation: "private"
+        let config = r#"{
+  "ociVersion": "1.0.2",
+  "root": {"path": "rootfs"},
+  "process": {
+    "args": ["/bin/echo", "ok"],
+    "cwd": "/",
+    "env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]
+  },
+  "linux": {
+    "rootfsPropagation": "private",
+    "namespaces": [
+      {"type": "mount"},
+      {"type": "uts"},
+      {"type": "pid"}
+    ]
+  }
+}"#;
+        std::fs::write(bundle_dir.path().join("config.json"), config).unwrap();
+
+        let id = format!("test-oci-prop-{}", std::process::id());
+        oci_run_to_completion(&id, bundle_dir.path(), 10);
+        // reaching here means the container ran to completion successfully
+    }
+
+    /// test_oci_cgroups_path
+    ///
+    /// Requires: root, alpine-rootfs, cgroups v2.
+    ///
+    /// Creates an OCI bundle with `linux.cgroupsPath: "remora-oci-test"` and runs
+    /// `echo ok` inside it. Verifies that the container starts and finishes
+    /// successfully — confirming that the path is parsed and passed to the cgroup
+    /// builder without error.
+    ///
+    /// Failure indicates the cgroupsPath wiring from OCI config to CgroupConfig is broken.
+    #[test]
+    fn test_oci_cgroups_path() {
+        if !is_root() {
+            eprintln!("Skipping test_oci_cgroups_path: requires root");
+            return;
+        }
+        let rootfs = match get_test_rootfs() {
+            Some(p) => p,
+            None => {
+                eprintln!("Skipping test_oci_cgroups_path: alpine-rootfs not found");
+                return;
+            }
+        };
+        let bundle_dir = tempfile::tempdir().expect("tempdir");
+        let rootfs_link = bundle_dir.path().join("rootfs");
+        std::os::unix::fs::symlink(&rootfs, &rootfs_link).unwrap();
+
+        let unique_cg = format!("remora-oci-test-{}", std::process::id());
+        let config = format!(
+            r#"{{
+  "ociVersion": "1.0.2",
+  "root": {{"path": "rootfs"}},
+  "process": {{
+    "args": ["/bin/echo", "ok"],
+    "cwd": "/",
+    "env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]
+  }},
+  "linux": {{
+    "cgroupsPath": "{}",
+    "namespaces": [
+      {{"type": "mount"}},
+      {{"type": "uts"}},
+      {{"type": "pid"}}
+    ]
+  }}
+}}"#,
+            unique_cg
+        );
+        std::fs::write(bundle_dir.path().join("config.json"), config).unwrap();
+
+        let id = format!("test-oci-cgpath-{}", std::process::id());
+        oci_run_to_completion(&id, bundle_dir.path(), 10);
+        // reaching here means the container ran successfully with explicit cgroupsPath
     }
 }
 


### PR DESCRIPTION
## Summary

- `linux.rootfsPropagation` (`shared`/`slave`/`private`/`unbindable`) is parsed from OCI `config.json` and applied as the mount-propagation flags at namespace-setup time; default remains `MS_PRIVATE|MS_REC`
- `linux.cgroupsPath` is parsed and wired through `CgroupConfig.path` so the container's cgroup leaf uses the specified name instead of the auto-generated `remora-{pid}`
- New `with_rootfs_propagation(flags)` and `with_cgroup_path(path)` builder methods on `Command`

## Test plan

- [ ] `test_oci_rootfs_propagation` — OCI bundle with `rootfsPropagation: "private"` runs to completion
- [ ] `test_oci_cgroups_path` — OCI bundle with explicit `cgroupsPath` runs to completion
- [ ] `cargo test --lib` — 274 unit tests pass
- [ ] `cargo clippy -- -D warnings` — clean

Closes #16
Part of epic #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)