### PR TITLE
fix: auto-bind-mount host /etc/resolv.conf into containers (#87)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -3163,3 +3163,38 @@ a single-cap drop removes only that capability without becoming drop-all.
 
 Failure in either direction: if `CHOWN=OK`, the cap-drop didn't apply; if
 `ALIVE` is missing, the implementation accidentally dropped all caps.
+
+---
+
+## `auto_resolv_conf` module
+
+### `test_auto_resolv_conf_loopback`
+**Requires:** root, alpine-rootfs
+
+Spawns a container with `Namespace::MOUNT` + chroot but **no** `with_dns()` call
+and reads `/etc/resolv.conf` inside the container.  Asserts the output contains
+at least one `nameserver` line.
+
+Failure indicates the auto-bind-mount of the host's `/etc/resolv.conf` is not
+being applied, so glibc containers (Ubuntu, Debian) would have no DNS resolution
+out of the box.
+
+### `test_explicit_dns_skips_auto_resolv`
+**Requires:** root, alpine-rootfs, `Namespace::MOUNT`
+
+Spawns a container with `with_dns(&["1.2.3.4"])` and reads `/etc/resolv.conf`.
+Asserts the content contains `1.2.3.4` (the explicitly configured server).
+
+Failure indicates either: the explicit DNS path is broken, or the auto-mount is
+running in addition to (and overwriting) the explicit DNS mount.
+
+### `test_no_mount_ns_no_auto_resolv`
+**Requires:** root, alpine-rootfs
+
+Spawns a container **without** `Namespace::MOUNT`.  Asserts the container exits
+0.  Without a private mount namespace, `auto_bind_resolv_conf` must be false —
+the container shares the host's mount namespace and sees the host's
+`/etc/resolv.conf` directly.  No bind-mount attempt is made.
+
+Failure indicates the auto-mount code is running unconditionally, which would
+corrupt the host mount namespace for non-isolated containers.

--- a/src/container.rs
+++ b/src/container.rs
@@ -2842,6 +2842,15 @@ impl Command {
             std::ffi::CString::new(dir.join("resolv.conf").as_os_str().as_bytes()).unwrap()
         });
 
+        // Auto-bind-mount host /etc/resolv.conf when no DNS is already configured.
+        // Mirrors Docker/containerd behaviour: containers without an explicit DNS
+        // configuration still get working name resolution out of the box.
+        // Condition: no DNS mount planned (auto_dns empty) + MOUNT ns + chroot + host file present.
+        let auto_bind_resolv_conf = auto_dns.is_empty()
+            && self.chroot_dir.is_some()
+            && self.namespaces.contains(Namespace::MOUNT)
+            && std::path::Path::new("/etc/resolv.conf").exists();
+
         // Pasta containers need CA certs for HTTPS. Alpine base images don't include them.
         // Bind-mount the host's trust store read-only into the container so wget/curl/etc
         // can verify TLS certificates without any image changes.
@@ -3439,6 +3448,39 @@ impl Command {
                         if r != 0 {
                             return Err(io::Error::other(format!(
                                 "dns bind mount: {}",
+                                io::Error::last_os_error()
+                            )));
+                        }
+                    }
+
+                    // Auto resolv.conf: when no DNS mount was configured above, bind-mount
+                    // the host's /etc/resolv.conf directly so plain containers get DNS.
+                    if auto_bind_resolv_conf {
+                        let etc_host = effective_root.join("etc");
+                        std::fs::create_dir_all(&etc_host)
+                            .map_err(|e| io::Error::other(format!("resolv mkdir /etc: {}", e)))?;
+                        let resolv_host = etc_host.join("resolv.conf");
+                        let src_c = std::ffi::CString::new("/etc/resolv.conf").unwrap();
+                        let tgt_c =
+                            std::ffi::CString::new(resolv_host.as_os_str().as_bytes()).unwrap();
+                        let fd = libc::open(
+                            tgt_c.as_ptr(),
+                            libc::O_CREAT | libc::O_WRONLY | libc::O_CLOEXEC,
+                            0o644u32,
+                        );
+                        if fd >= 0 {
+                            libc::close(fd);
+                        }
+                        let r = libc::mount(
+                            src_c.as_ptr(),
+                            tgt_c.as_ptr(),
+                            ptr::null(),
+                            libc::MS_BIND,
+                            ptr::null(),
+                        );
+                        if r != 0 {
+                            return Err(io::Error::other(format!(
+                                "auto resolv.conf bind mount: {}",
                                 io::Error::last_os_error()
                             )));
                         }
@@ -5093,6 +5135,12 @@ impl Command {
             std::ffi::CString::new(dir.join("resolv.conf").as_os_str().as_bytes()).unwrap()
         });
 
+        // Auto-bind-mount host /etc/resolv.conf when no DNS is already configured.
+        let auto_bind_resolv_conf = auto_dns.is_empty()
+            && self.chroot_dir.is_some()
+            && self.namespaces.contains(Namespace::MOUNT)
+            && std::path::Path::new("/etc/resolv.conf").exists();
+
         let pasta_ca_cert_cstring: Option<std::ffi::CString> = if is_pasta
             && self.namespaces.contains(Namespace::MOUNT)
             && self.chroot_dir.is_some()
@@ -5591,6 +5639,39 @@ impl Command {
                         if r != 0 {
                             return Err(io::Error::other(format!(
                                 "dns bind mount: {}",
+                                io::Error::last_os_error()
+                            )));
+                        }
+                    }
+
+                    // Auto resolv.conf: when no DNS mount was configured above, bind-mount
+                    // the host's /etc/resolv.conf directly so plain containers get DNS.
+                    if auto_bind_resolv_conf {
+                        let etc_host = effective_root.join("etc");
+                        std::fs::create_dir_all(&etc_host)
+                            .map_err(|e| io::Error::other(format!("resolv mkdir /etc: {}", e)))?;
+                        let resolv_host = etc_host.join("resolv.conf");
+                        let src_c = std::ffi::CString::new("/etc/resolv.conf").unwrap();
+                        let tgt_c =
+                            std::ffi::CString::new(resolv_host.as_os_str().as_bytes()).unwrap();
+                        let fd = libc::open(
+                            tgt_c.as_ptr(),
+                            libc::O_CREAT | libc::O_WRONLY | libc::O_CLOEXEC,
+                            0o644u32,
+                        );
+                        if fd >= 0 {
+                            libc::close(fd);
+                        }
+                        let r = libc::mount(
+                            src_c.as_ptr(),
+                            tgt_c.as_ptr(),
+                            ptr::null(),
+                            libc::MS_BIND,
+                            ptr::null(),
+                        );
+                        if r != 0 {
+                            return Err(io::Error::other(format!(
+                                "auto resolv.conf bind mount: {}",
                                 io::Error::last_os_error()
                             )));
                         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -15923,3 +15923,115 @@ fn test_cap_drop_individual_removes_only_that_cap() {
         "process must remain alive (other caps intact, not drop-all); stdout={stdout:?}"
     );
 }
+
+mod auto_resolv_conf {
+    use super::*;
+
+    /// Verify that a container with MOUNT namespace + chroot but no explicit DNS
+    /// configuration automatically receives a bind-mount of the host's
+    /// /etc/resolv.conf.  The container reads the file and we assert at least one
+    /// "nameserver" line is present.
+    ///
+    /// Requires: root, alpine-rootfs.
+    #[test]
+    fn test_auto_resolv_conf_loopback() {
+        if !is_root() {
+            eprintln!("SKIP: test_auto_resolv_conf_loopback requires root");
+            return;
+        }
+        let rootfs = match get_test_rootfs() {
+            Some(p) => p,
+            None => {
+                eprintln!("SKIP: test_auto_resolv_conf_loopback requires alpine-rootfs");
+                return;
+            }
+        };
+        // No with_dns() call — auto-mount should kick in.
+        let (status, stdout_bytes, _) = Command::new("cat")
+            .args(["/etc/resolv.conf"])
+            .with_chroot(rootfs)
+            .with_namespaces(Namespace::UTS | Namespace::MOUNT | Namespace::IPC)
+            .with_proc_mount()
+            .env("PATH", ALPINE_PATH)
+            .stdout(Stdio::Piped)
+            .spawn()
+            .expect("spawn failed")
+            .wait_with_output()
+            .expect("wait failed");
+        assert!(status.success(), "container exited non-zero: {:?}", status);
+        let stdout = String::from_utf8_lossy(&stdout_bytes);
+        assert!(
+            stdout.contains("nameserver"),
+            "expected at least one 'nameserver' line in /etc/resolv.conf, got: {stdout:?}"
+        );
+    }
+
+    /// Verify that an explicit with_dns() call takes precedence and the auto-mount
+    /// is NOT applied (auto_dns is non-empty → auto_bind_resolv_conf = false).
+    /// The container should see the explicitly configured nameserver, not the host's.
+    ///
+    /// Requires: root, alpine-rootfs, Namespace::MOUNT.
+    #[test]
+    fn test_explicit_dns_skips_auto_resolv() {
+        if !is_root() {
+            eprintln!("SKIP: test_explicit_dns_skips_auto_resolv requires root");
+            return;
+        }
+        let rootfs = match get_test_rootfs() {
+            Some(p) => p,
+            None => {
+                eprintln!("SKIP: test_explicit_dns_skips_auto_resolv requires alpine-rootfs");
+                return;
+            }
+        };
+        // Explicit DNS server — auto-mount must NOT double-mount.
+        let (status, stdout_bytes, _) = Command::new("cat")
+            .args(["/etc/resolv.conf"])
+            .with_chroot(rootfs)
+            .with_namespaces(Namespace::UTS | Namespace::MOUNT | Namespace::IPC)
+            .with_proc_mount()
+            .with_dns(&["1.2.3.4"])
+            .env("PATH", ALPINE_PATH)
+            .stdout(Stdio::Piped)
+            .spawn()
+            .expect("spawn failed")
+            .wait_with_output()
+            .expect("wait failed");
+        assert!(status.success(), "container exited non-zero: {:?}", status);
+        let stdout = String::from_utf8_lossy(&stdout_bytes);
+        assert!(
+            stdout.contains("1.2.3.4"),
+            "expected explicitly configured nameserver 1.2.3.4 in resolv.conf, got: {stdout:?}"
+        );
+    }
+
+    /// Verify that without Namespace::MOUNT the auto-mount is not attempted and
+    /// the container still exits 0 (shared host mount namespace — no bind mount needed,
+    /// /etc/resolv.conf is inherited directly from the host).
+    ///
+    /// Requires: root, alpine-rootfs.
+    #[test]
+    fn test_no_mount_ns_no_auto_resolv() {
+        if !is_root() {
+            eprintln!("SKIP: test_no_mount_ns_no_auto_resolv requires root");
+            return;
+        }
+        let rootfs = match get_test_rootfs() {
+            Some(p) => p,
+            None => {
+                eprintln!("SKIP: test_no_mount_ns_no_auto_resolv requires alpine-rootfs");
+                return;
+            }
+        };
+        // No MOUNT namespace → auto_bind_resolv_conf = false; container shares host mounts.
+        let status = Command::new("true")
+            .with_chroot(rootfs)
+            .with_namespaces(Namespace::UTS | Namespace::IPC)
+            .env("PATH", ALPINE_PATH)
+            .spawn()
+            .expect("spawn failed")
+            .wait()
+            .expect("wait failed");
+        assert!(status.success(), "container must exit 0 without MOUNT ns: {:?}", status);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds automatic bind-mount of the host's `/etc/resolv.conf` into containers that have a private `Namespace::MOUNT` + chroot but no explicit DNS configuration
- Condition: `auto_dns.is_empty() && chroot_dir.is_some() && Namespace::MOUNT set && /etc/resolv.conf exists`
- Applied in both `spawn()` and `spawn_oci()` pre-exec paths; no cleanup needed (mount is scoped to the container's private mount namespace)
- Existing bridge/pasta/`with_dns()` paths are unchanged — `auto_bind_resolv_conf = false` whenever `auto_dns` is non-empty

## Test plan

- [x] `test_auto_resolv_conf_loopback` — loopback container reads `/etc/resolv.conf` with ≥1 `nameserver` line
- [x] `test_explicit_dns_skips_auto_resolv` — `with_dns(&["1.2.3.4"])` → explicit server visible, no double-mount
- [x] `test_no_mount_ns_no_auto_resolv` — no MOUNT namespace → no bind attempted, container exits 0
- [x] Full suite: 252/252 pass, 6 ignored

Closes #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)