### PR TITLE
fix: auto-inject host DNS via per-container temp file, not direct bind-mount

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -3175,9 +3175,13 @@ Spawns a container with `Namespace::MOUNT` + chroot but **no** `with_dns()` call
 and reads `/etc/resolv.conf` inside the container.  Asserts the output contains
 at least one `nameserver` line.
 
-Failure indicates the auto-bind-mount of the host's `/etc/resolv.conf` is not
-being applied, so glibc containers (Ubuntu, Debian) would have no DNS resolution
-out of the box.
+The auto-inject path reads the host's nameservers via `host_upstream_dns()` (which
+filters loopback stub addresses like `127.0.0.53`) and writes them to a
+per-container temp file bind-mounted inside the container's private MOUNT namespace.
+The host file is never shared directly — container writes go to the temp copy only.
+
+Failure indicates the auto-injection is not populating `auto_dns`, so glibc
+containers (Ubuntu, Debian) would have no DNS resolution out of the box.
 
 ### `test_explicit_dns_skips_auto_resolv`
 **Requires:** root, alpine-rootfs, `Namespace::MOUNT`
@@ -3185,16 +3189,20 @@ out of the box.
 Spawns a container with `with_dns(&["1.2.3.4"])` and reads `/etc/resolv.conf`.
 Asserts the content contains `1.2.3.4` (the explicitly configured server).
 
-Failure indicates either: the explicit DNS path is broken, or the auto-mount is
-running in addition to (and overwriting) the explicit DNS mount.
+The auto-inject condition requires `auto_dns.is_empty() && dns_servers.is_empty()`,
+so an explicit `with_dns()` call bypasses it entirely.
+
+Failure indicates either: the explicit DNS path is broken, or the auto-inject
+is running in addition to and overwriting the explicit configuration.
 
 ### `test_no_mount_ns_no_auto_resolv`
 **Requires:** root, alpine-rootfs
 
-Spawns a container **without** `Namespace::MOUNT`.  Asserts the container exits
-0.  Without a private mount namespace, `auto_bind_resolv_conf` must be false —
-the container shares the host's mount namespace and sees the host's
-`/etc/resolv.conf` directly.  No bind-mount attempt is made.
+Spawns a container **without** `Namespace::MOUNT`.  Asserts the container exits 0.
+The auto-inject condition requires `Namespace::MOUNT` — without it no DNS injection
+is attempted, and the container shares the host's mount namespace where
+`/etc/resolv.conf` is already visible.
 
-Failure indicates the auto-mount code is running unconditionally, which would
-corrupt the host mount namespace for non-isolated containers.
+Failure indicates the auto-inject is running unconditionally, which would attempt
+to create a DNS temp file and bind-mount in a shared mount namespace, potentially
+corrupting the host's view of `/etc/resolv.conf`.

--- a/src/container.rs
+++ b/src/container.rs
@@ -2805,6 +2805,27 @@ impl Command {
                 }
             }
         }
+        // Auto-inject host DNS for isolated containers with no explicit DNS config.
+        // Mirrors Docker's behaviour: read the host's resolv.conf at container start,
+        // filter loopback addresses (127.x / ::1 are unreachable from the container's
+        // netns), and write the result to a per-container temp file that is bind-mounted
+        // read-write inside the container's private MOUNT namespace.
+        //
+        // This is strictly safer than bind-mounting the host file directly:
+        //   - Writes inside the container go to the temp copy, not the host file.
+        //   - No shared mutable state between containers.
+        //   - Loopback stub resolvers (systemd-resolved 127.0.0.53) are filtered out.
+        if auto_dns.is_empty()
+            && self.dns_servers.is_empty()
+            && self.namespaces.contains(Namespace::MOUNT)
+            && self.chroot_dir.is_some()
+        {
+            for server in host_upstream_dns() {
+                if !auto_dns.contains(&server) {
+                    auto_dns.push(server);
+                }
+            }
+        }
         // Append user-specified DNS servers as fallback.
         auto_dns.extend(self.dns_servers.iter().cloned());
 
@@ -2841,15 +2862,6 @@ impl Command {
             use std::os::unix::ffi::OsStrExt as _;
             std::ffi::CString::new(dir.join("resolv.conf").as_os_str().as_bytes()).unwrap()
         });
-
-        // Auto-bind-mount host /etc/resolv.conf when no DNS is already configured.
-        // Mirrors Docker/containerd behaviour: containers without an explicit DNS
-        // configuration still get working name resolution out of the box.
-        // Condition: no DNS mount planned (auto_dns empty) + MOUNT ns + chroot + host file present.
-        let auto_bind_resolv_conf = auto_dns.is_empty()
-            && self.chroot_dir.is_some()
-            && self.namespaces.contains(Namespace::MOUNT)
-            && std::path::Path::new("/etc/resolv.conf").exists();
 
         // Pasta containers need CA certs for HTTPS. Alpine base images don't include them.
         // Bind-mount the host's trust store read-only into the container so wget/curl/etc
@@ -3448,39 +3460,6 @@ impl Command {
                         if r != 0 {
                             return Err(io::Error::other(format!(
                                 "dns bind mount: {}",
-                                io::Error::last_os_error()
-                            )));
-                        }
-                    }
-
-                    // Auto resolv.conf: when no DNS mount was configured above, bind-mount
-                    // the host's /etc/resolv.conf directly so plain containers get DNS.
-                    if auto_bind_resolv_conf {
-                        let etc_host = effective_root.join("etc");
-                        std::fs::create_dir_all(&etc_host)
-                            .map_err(|e| io::Error::other(format!("resolv mkdir /etc: {}", e)))?;
-                        let resolv_host = etc_host.join("resolv.conf");
-                        let src_c = std::ffi::CString::new("/etc/resolv.conf").unwrap();
-                        let tgt_c =
-                            std::ffi::CString::new(resolv_host.as_os_str().as_bytes()).unwrap();
-                        let fd = libc::open(
-                            tgt_c.as_ptr(),
-                            libc::O_CREAT | libc::O_WRONLY | libc::O_CLOEXEC,
-                            0o644u32,
-                        );
-                        if fd >= 0 {
-                            libc::close(fd);
-                        }
-                        let r = libc::mount(
-                            src_c.as_ptr(),
-                            tgt_c.as_ptr(),
-                            ptr::null(),
-                            libc::MS_BIND,
-                            ptr::null(),
-                        );
-                        if r != 0 {
-                            return Err(io::Error::other(format!(
-                                "auto resolv.conf bind mount: {}",
                                 io::Error::last_os_error()
                             )));
                         }
@@ -5101,6 +5080,18 @@ impl Command {
                 }
             }
         }
+        // Auto-inject host DNS for isolated containers with no explicit DNS config.
+        if auto_dns.is_empty()
+            && self.dns_servers.is_empty()
+            && self.namespaces.contains(Namespace::MOUNT)
+            && self.chroot_dir.is_some()
+        {
+            for server in host_upstream_dns() {
+                if !auto_dns.contains(&server) {
+                    auto_dns.push(server);
+                }
+            }
+        }
         auto_dns.extend(self.dns_servers.iter().cloned());
 
         // DNS: write nameservers to a per-container temp file; bind-mount into container.
@@ -5134,12 +5125,6 @@ impl Command {
             use std::os::unix::ffi::OsStrExt as _;
             std::ffi::CString::new(dir.join("resolv.conf").as_os_str().as_bytes()).unwrap()
         });
-
-        // Auto-bind-mount host /etc/resolv.conf when no DNS is already configured.
-        let auto_bind_resolv_conf = auto_dns.is_empty()
-            && self.chroot_dir.is_some()
-            && self.namespaces.contains(Namespace::MOUNT)
-            && std::path::Path::new("/etc/resolv.conf").exists();
 
         let pasta_ca_cert_cstring: Option<std::ffi::CString> = if is_pasta
             && self.namespaces.contains(Namespace::MOUNT)
@@ -5639,39 +5624,6 @@ impl Command {
                         if r != 0 {
                             return Err(io::Error::other(format!(
                                 "dns bind mount: {}",
-                                io::Error::last_os_error()
-                            )));
-                        }
-                    }
-
-                    // Auto resolv.conf: when no DNS mount was configured above, bind-mount
-                    // the host's /etc/resolv.conf directly so plain containers get DNS.
-                    if auto_bind_resolv_conf {
-                        let etc_host = effective_root.join("etc");
-                        std::fs::create_dir_all(&etc_host)
-                            .map_err(|e| io::Error::other(format!("resolv mkdir /etc: {}", e)))?;
-                        let resolv_host = etc_host.join("resolv.conf");
-                        let src_c = std::ffi::CString::new("/etc/resolv.conf").unwrap();
-                        let tgt_c =
-                            std::ffi::CString::new(resolv_host.as_os_str().as_bytes()).unwrap();
-                        let fd = libc::open(
-                            tgt_c.as_ptr(),
-                            libc::O_CREAT | libc::O_WRONLY | libc::O_CLOEXEC,
-                            0o644u32,
-                        );
-                        if fd >= 0 {
-                            libc::close(fd);
-                        }
-                        let r = libc::mount(
-                            src_c.as_ptr(),
-                            tgt_c.as_ptr(),
-                            ptr::null(),
-                            libc::MS_BIND,
-                            ptr::null(),
-                        );
-                        if r != 0 {
-                            return Err(io::Error::other(format!(
-                                "auto resolv.conf bind mount: {}",
                                 io::Error::last_os_error()
                             )));
                         }


### PR DESCRIPTION
## Summary

- Removes the insecure direct bind-mount of the host's `/etc/resolv.conf` introduced in PR #88
- Replaces it with the same safe copy-on-use pattern already used by bridge/pasta DNS: read nameservers from host at container start, write a per-container temp file, bind-mount the copy
- Container writes go to the temp file only — the host file is never shared or modified
- `host_upstream_dns()` already filters loopback stub resolvers (e.g. systemd-resolved's `127.0.0.53`) that are unreachable from inside a container network namespace
- The `auto_bind_resolv_conf` bool and its pre_exec bind-mount blocks are removed entirely — no new code paths

## Security fix

The PR #88 approach was unsafe:
- `MS_BIND` without `MS_RDONLY` → root-in-container could write through to the host's DNS config
- All containers shared the same mutable backing file

This fix matches Docker's behaviour: snapshot nameservers at container start into a per-container copy.

## Test plan

- [x] `test_auto_resolv_conf_loopback` — loopback container gets working DNS via temp-file path
- [x] `test_explicit_dns_skips_auto_resolv` — `with_dns()` still takes precedence
- [x] `test_no_mount_ns_no_auto_resolv` — no MOUNT namespace → no injection, exits 0
- [x] Full suite: 252/252 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)