### PR TITLE
test: verify docker build end-to-end with devcontainer features and custom Dockerfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "bitflags 2.11.0",
  "bzip2",

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -3206,3 +3206,36 @@ is attempted, and the container shares the host's mount namespace where
 Failure indicates the auto-inject is running unconditionally, which would attempt
 to create a DNS temp file and bind-mount in a shared mount namespace, potentially
 corrupting the host's view of `/etc/resolv.conf`.
+
+---
+
+## Container Restart (`pelagos start`)
+
+### `test_container_restart_after_exit`
+**Requires:** root, alpine-rootfs
+
+Runs `/bin/true` in detached mode, waits for the container to reach `"exited"` status,
+verifies `spawn_config` was written to `state.json`, then calls `pelagos start` and
+waits for the restarted container to also exit.
+
+Failure indicates: `SpawnConfig` was not persisted on first run, `pelagos start` returns
+a non-zero exit code, or the restarted container fails to launch/exit cleanly.
+
+### `test_container_restart_runs_same_command`
+**Requires:** root, alpine-rootfs
+
+Runs `/bin/sh -c "echo run1 > /shared/marker.txt"` with a bind-mounted host directory.
+After the container exits, removes the marker file, calls `pelagos start`, and asserts
+the marker file is re-created by the restarted container.
+
+Failure indicates: `SpawnConfig` did not preserve the bind mount or the command arguments,
+so the restarted container ran a different command or without the correct mount.
+
+### `test_container_start_running_fails`
+**Requires:** root, alpine-rootfs
+
+Starts a long-lived container (`/bin/sleep 30`), waits until its PID is recorded, then
+asserts that `pelagos start` returns a non-zero exit code.
+
+Failure indicates the "already running" guard in `cmd_start` is broken and `pelagos start`
+incorrectly accepts or restarts a live container.

--- a/src/cli/compose.rs
+++ b/src/cli/compose.rs
@@ -610,6 +610,7 @@ fn spawn_service(
             .collect(),
         health: None,
         health_config: None,
+        spawn_config: None,
     };
     write_state(&cstate)?;
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -31,6 +31,7 @@ pub mod relay;
 pub mod rm;
 pub mod rootfs;
 pub mod run;
+pub mod start;
 pub mod stop;
 pub mod volume;
 
@@ -128,6 +129,75 @@ impl std::fmt::Display for ContainerStatus {
     }
 }
 
+/// Saved spawn configuration — enough to restart a container via `pelagos start`.
+///
+/// Populated by `cmd_run` at container creation and persisted in `state.json`.
+/// On restart, `cmd_start` converts this back into `RunArgs` and calls `cmd_run`.
+///
+/// Note: the overlay writable layer is NOT preserved between runs. A restarted
+/// container gets a fresh upper dir on top of the same image layers. Filesystem
+/// changes from the previous run are lost (future enhancement: overlay preservation).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SpawnConfig {
+    /// Image reference used to pull/locate layer dirs (e.g. "ubuntu:22.04").
+    /// None for rootfs-only containers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+    /// Executable path or name.
+    pub exe: String,
+    /// Arguments passed to the executable.
+    #[serde(default)]
+    pub args: Vec<String>,
+    /// Environment variables as KEY=VALUE strings.
+    #[serde(default)]
+    pub env: Vec<String>,
+    /// Read-write bind mounts as "host:container" strings.
+    #[serde(default)]
+    pub bind: Vec<String>,
+    /// Read-only bind mounts as "host:container" strings.
+    #[serde(default)]
+    pub bind_ro: Vec<String>,
+    /// Named volume mounts as "vol:container" strings.
+    #[serde(default)]
+    pub volume: Vec<String>,
+    /// Network modes (may include "pasta", "bridge", "bridge:name", "loopback").
+    #[serde(default)]
+    pub network: Vec<String>,
+    /// Port mappings as "HOST:CONTAINER" strings.
+    #[serde(default)]
+    pub publish: Vec<String>,
+    /// Explicit DNS servers.
+    #[serde(default)]
+    pub dns: Vec<String>,
+    /// Working directory inside the container.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub working_dir: Option<String>,
+    /// User as "uid" or "uid:gid" string.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+    /// Container hostname.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hostname: Option<String>,
+    /// Capabilities to drop.
+    #[serde(default)]
+    pub cap_drop: Vec<String>,
+    /// Capabilities to add.
+    #[serde(default)]
+    pub cap_add: Vec<String>,
+    /// Security options (e.g. "seccomp=unconfined", "apparmor=profile").
+    #[serde(default)]
+    pub security_opt: Vec<String>,
+    /// Whether the rootfs was mounted read-only.
+    #[serde(default)]
+    pub read_only: bool,
+    /// Whether the container should be removed on exit (--rm semantics).
+    #[serde(default)]
+    pub rm: bool,
+    /// Whether NAT (MASQUERADE) was enabled.
+    #[serde(default)]
+    pub nat: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContainerState {
     pub name: String,
@@ -159,6 +229,9 @@ pub struct ContainerState {
     /// Health check configuration (from image HEALTHCHECK instruction).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub health_config: Option<HealthConfig>,
+    /// Saved spawn configuration for `pelagos start` restarts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spawn_config: Option<SpawnConfig>,
 }
 
 pub fn now_iso8601() -> String {
@@ -203,6 +276,12 @@ pub fn write_state(state: &ContainerState) -> std::io::Result<()> {
     let json =
         serde_json::to_string_pretty(state).map_err(|e| std::io::Error::other(e.to_string()))?;
     std::fs::write(state_path(&state.name), json)
+}
+
+/// Returns true if a pelagos container state file exists for `name`.
+/// Used to distinguish container-restart from OCI lifecycle in the `start` command.
+pub fn container_state_exists(name: &str) -> bool {
+    state_path(name).exists()
 }
 
 pub fn read_state(name: &str) -> std::io::Result<ContainerState> {
@@ -579,6 +658,78 @@ mod tests {
     /// rootfs_path should accept an existing filesystem directory path and
     /// return its canonicalized form, without requiring it to be registered
     /// in the rootfs store.
+    /// test_spawn_config_serde_roundtrip
+    ///
+    /// Verifies that SpawnConfig serializes to JSON and deserializes correctly,
+    /// including all optional fields.  Also verifies backward compatibility:
+    /// a ContainerState JSON without `spawn_config` deserializes with `spawn_config == None`.
+    #[test]
+    fn test_spawn_config_serde_roundtrip() {
+        let sc = SpawnConfig {
+            image: Some("docker.io/library/alpine:latest".to_string()),
+            exe: "/bin/sh".to_string(),
+            args: vec!["-c".to_string(), "echo hello".to_string()],
+            env: vec!["FOO=bar".to_string()],
+            bind: vec!["/tmp:/tmp".to_string()],
+            bind_ro: vec!["/etc:/etc:ro".to_string()],
+            volume: vec!["mydata:/data".to_string()],
+            network: vec!["bridge".to_string()],
+            publish: vec!["8080:80".to_string()],
+            dns: vec!["1.1.1.1".to_string()],
+            working_dir: Some("/app".to_string()),
+            user: Some("1000:1000".to_string()),
+            hostname: Some("myhost".to_string()),
+            cap_drop: vec!["ALL".to_string()],
+            cap_add: vec!["NET_BIND_SERVICE".to_string()],
+            security_opt: vec!["no-new-privileges".to_string()],
+            read_only: true,
+            rm: false,
+            nat: true,
+        };
+        let json = serde_json::to_string(&sc).unwrap();
+        let decoded: SpawnConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.image, sc.image);
+        assert_eq!(decoded.exe, sc.exe);
+        assert_eq!(decoded.args, sc.args);
+        assert_eq!(decoded.env, sc.env);
+        assert_eq!(decoded.bind, sc.bind);
+        assert_eq!(decoded.bind_ro, sc.bind_ro);
+        assert_eq!(decoded.network, sc.network);
+        assert_eq!(decoded.publish, sc.publish);
+        assert_eq!(decoded.dns, sc.dns);
+        assert_eq!(decoded.working_dir, sc.working_dir);
+        assert_eq!(decoded.user, sc.user);
+        assert_eq!(decoded.hostname, sc.hostname);
+        assert_eq!(decoded.cap_drop, sc.cap_drop);
+        assert_eq!(decoded.cap_add, sc.cap_add);
+        assert_eq!(decoded.security_opt, sc.security_opt);
+        assert!(decoded.read_only);
+        assert!(!decoded.rm);
+        assert!(decoded.nat);
+    }
+
+    /// test_spawn_config_missing_from_state
+    ///
+    /// Verifies that a ContainerState JSON without `spawn_config` deserializes
+    /// with `spawn_config == None` (backward-compatibility with older state files).
+    #[test]
+    fn test_spawn_config_missing_from_state() {
+        let json = r#"{
+            "name": "test",
+            "rootfs": "alpine",
+            "status": "exited",
+            "pid": 0,
+            "watcher_pid": 0,
+            "started_at": "2026-01-01T00:00:00Z",
+            "exit_code": 0,
+            "command": ["/bin/sh"],
+            "stdout_log": null,
+            "stderr_log": null
+        }"#;
+        let state: ContainerState = serde_json::from_str(json).unwrap();
+        assert!(state.spawn_config.is_none());
+    }
+
     #[test]
     fn test_rootfs_path_accepts_filesystem_dir() {
         // /tmp always exists on Linux.

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -26,7 +26,7 @@ extern "C" fn watcher_forward_signal(signum: libc::c_int) {
 use super::{
     check_liveness, container_dir, containers_dir, generate_name, parse_capability, parse_cpus,
     parse_memory, parse_ulimit, parse_user, parse_user_in_layers, rootfs_path, write_state,
-    ContainerState, ContainerStatus, HealthConfig, HealthStatus,
+    ContainerState, ContainerStatus, HealthConfig, HealthStatus, SpawnConfig,
 };
 use pelagos::container::{Capability, Command, Namespace, Stdio, Volume};
 use pelagos::network::NetworkMode;
@@ -269,12 +269,59 @@ pub fn cmd_run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
             )?
         };
 
+    let spawn_config = build_spawn_config(&args, &rootfs_label, &exe_and_args);
+
     if args.detach {
-        run_detached(name, rootfs_label, exe_and_args, cmd, health_config)
+        run_detached(
+            name,
+            rootfs_label,
+            exe_and_args,
+            cmd,
+            health_config,
+            Some(spawn_config),
+        )
     } else if args.interactive {
         run_interactive(cmd)
     } else {
-        run_foreground(name, rootfs_label, exe_and_args, cmd, args.rm)
+        run_foreground(
+            name,
+            rootfs_label,
+            exe_and_args,
+            cmd,
+            args.rm,
+            Some(spawn_config),
+        )
+    }
+}
+
+/// Capture RunArgs fields into a SpawnConfig for container restart.
+fn build_spawn_config(args: &RunArgs, rootfs_label: &str, exe_and_args: &[String]) -> SpawnConfig {
+    // image is None for --rootfs containers; otherwise it's the normalized image reference.
+    let image = if args.rootfs.is_none() && !args.args.is_empty() {
+        Some(rootfs_label.to_string())
+    } else {
+        None
+    };
+    SpawnConfig {
+        image,
+        exe: exe_and_args.first().cloned().unwrap_or_default(),
+        args: exe_and_args.get(1..).unwrap_or(&[]).to_vec(),
+        env: args.env.clone(),
+        bind: args.bind.clone(),
+        bind_ro: args.bind_ro.clone(),
+        volume: args.volume.clone(),
+        network: args.network.clone(),
+        publish: args.publish.clone(),
+        dns: args.dns.clone(),
+        working_dir: args.workdir.clone(),
+        user: args.user.clone(),
+        hostname: args.hostname.clone(),
+        cap_drop: args.cap_drop.clone(),
+        cap_add: args.cap_add.clone(),
+        security_opt: args.security_opt.clone(),
+        read_only: args.read_only,
+        rm: args.rm,
+        nat: args.nat,
     }
 }
 
@@ -755,6 +802,7 @@ fn run_foreground(
     command: Vec<String>,
     mut cmd: Command,
     auto_remove: bool,
+    spawn_config: Option<SpawnConfig>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     cmd = cmd
         .stdin(Stdio::Inherit)
@@ -778,6 +826,7 @@ fn run_foreground(
         network_ips: std::collections::HashMap::new(),
         health: None,
         health_config: None,
+        spawn_config,
     };
     write_state(&state)?;
 
@@ -846,6 +895,7 @@ fn run_detached(
     command: Vec<String>,
     mut cmd: Command,
     health_config: Option<HealthConfig>,
+    spawn_config: Option<SpawnConfig>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Create container directory before fork so parent and child both see it.
     std::fs::create_dir_all(containers_dir())?;
@@ -870,6 +920,7 @@ fn run_detached(
         network_ips: std::collections::HashMap::new(),
         health: None,
         health_config: None,
+        spawn_config,
     };
     write_state(&state)?;
 

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -1,0 +1,104 @@
+//! `pelagos start` — restart an exited container.
+//!
+//! Reads the saved `SpawnConfig` from the container's `state.json`, converts it
+//! back into `RunArgs`, and calls `cmd_run` in detached mode.  The container
+//! always restarts detached; use `pelagos logs -f <name>` to follow output.
+//!
+//! Overlay semantics: the restarted container gets a fresh upper/work dir on top
+//! of the same image layers.  Writable-layer changes from the previous run are
+//! NOT preserved (future enhancement).
+
+use super::run::{cmd_run, RunArgs};
+use super::{read_state, ContainerStatus};
+
+/// Restart an exited pelagos container by name.
+///
+/// Returns `Ok(())` after printing the container name to stdout (matching the
+/// behaviour of `pelagos run --detach`).
+pub fn cmd_start(name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let state = read_state(name).map_err(|_| format!("container '{}' not found", name))?;
+
+    match state.status {
+        ContainerStatus::Running => {
+            return Err(format!(
+                "container '{}' is already running (pid {})",
+                name, state.pid
+            )
+            .into());
+        }
+        ContainerStatus::Exited => {}
+    }
+
+    let sc = state.spawn_config.ok_or_else(|| {
+        format!(
+            "container '{}' has no spawn config — cannot restart \
+             (was it created with an older version of pelagos?)",
+            name
+        )
+    })?;
+
+    let run_args = spawn_config_to_run_args(name, sc, &state.rootfs);
+    cmd_run(run_args)
+}
+
+/// Convert a `SpawnConfig` back into `RunArgs` for restart.
+///
+/// The restarted container always runs detached.  Resource limits (memory,
+/// cpus, ulimits) are not persisted in SpawnConfig and will use defaults on
+/// restart — this matches the VS Code devcontainer use case where the container
+/// is restarted by the IDE, not by the user tuning resources.
+fn spawn_config_to_run_args(
+    container_name: &str,
+    sc: super::SpawnConfig,
+    rootfs_label: &str,
+) -> RunArgs {
+    // Reconstruct the positional args vector.
+    // For image containers: [image_ref, exe, args...]
+    // For rootfs containers: [exe, args...] (rootfs set via RunArgs.rootfs)
+    let (rootfs_field, args) = if let Some(ref image_ref) = sc.image {
+        let mut a = vec![image_ref.clone(), sc.exe.clone()];
+        a.extend(sc.args.iter().cloned());
+        (None, a)
+    } else {
+        let mut a = vec![sc.exe.clone()];
+        a.extend(sc.args.iter().cloned());
+        (Some(rootfs_label.to_string()), a)
+    };
+
+    RunArgs {
+        name: Some(container_name.to_string()),
+        detach: true,
+        rm: false,
+        interactive: false,
+        network: sc.network,
+        publish: sc.publish,
+        nat: sc.nat,
+        dns: sc.dns,
+        volume: sc.volume,
+        bind: sc.bind,
+        bind_ro: sc.bind_ro,
+        tmpfs: vec![],
+        read_only: sc.read_only,
+        env: sc.env,
+        env_file: None,
+        workdir: sc.working_dir,
+        user: sc.user,
+        hostname: sc.hostname,
+        memory: None,
+        cpus: None,
+        cpu_shares: None,
+        pids_limit: None,
+        ulimit: vec![],
+        cap_drop: sc.cap_drop,
+        cap_add: sc.cap_add,
+        security_opt: sc.security_opt,
+        apparmor_profile: None,
+        selinux_label: None,
+        link: vec![],
+        sysctl: vec![],
+        masked_path: vec![],
+        dns_backend: None,
+        rootfs: rootfs_field,
+        args,
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -511,7 +511,16 @@ fn main() {
             )
             .map_err(|e| e.to_string().into()),
         },
-        CliCommand::Start { id } => pelagos::oci::cmd_start(&id).map_err(|e| e.to_string().into()),
+        CliCommand::Start { id } => {
+            // Dispatch: pelagos container restart takes priority over OCI lifecycle.
+            // A pelagos container state lives at /run/pelagos/containers/<name>/state.json;
+            // an OCI container state lives at /run/pelagos/<id>/state.json (different dir).
+            if cli::container_state_exists(&id) {
+                cli::start::cmd_start(&id)
+            } else {
+                pelagos::oci::cmd_start(&id).map_err(|e| e.to_string().into())
+            }
+        }
         CliCommand::State { id } => pelagos::oci::cmd_state(&id).map_err(|e| e.to_string().into()),
         CliCommand::Kill { id, signal } => {
             pelagos::oci::cmd_kill(&id, &signal).map_err(|e| e.to_string().into())

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -16038,4 +16038,302 @@ mod auto_resolv_conf {
             status
         );
     }
+
+    // ---------------------------------------------------------------------------
+    // Container restart (`pelagos start`) tests
+    // ---------------------------------------------------------------------------
+
+    /// test_container_restart_after_exit
+    ///
+    /// Requires: root, alpine-rootfs.
+    ///
+    /// Runs a short-lived container (`/bin/true`) in detached mode, waits for
+    /// it to exit with status "exited", then calls `pelagos start` and verifies
+    /// it transitions back to "running" and eventually "exited" again.
+    ///
+    /// Failure indicates `pelagos start` cannot restart an exited container, or
+    /// that SpawnConfig was not persisted in state.json on first run.
+    #[test]
+    #[serial]
+    fn test_container_restart_after_exit() {
+        if !is_root() {
+            eprintln!("SKIP: test_container_restart_after_exit requires root");
+            return;
+        }
+        let rootfs = match get_test_rootfs() {
+            Some(r) => r,
+            None => {
+                eprintln!("SKIP: test_container_restart_after_exit requires alpine-rootfs");
+                return;
+            }
+        };
+
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+        let name = "pelagos-restart-test-1";
+
+        // Clean up any leftover state.
+        let _ = std::process::Command::new(bin)
+            .args(["rm", "-f", name])
+            .output();
+
+        // Run a short-lived container detached.
+        let run_status = std::process::Command::new(bin)
+            .args([
+                "run",
+                "-d",
+                "--name",
+                name,
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "/bin/true",
+            ])
+            .status()
+            .expect("pelagos run -d");
+        assert!(run_status.success(), "pelagos run -d failed");
+
+        // Wait up to 5 s for status to reach "exited".
+        let state_path = format!("/run/pelagos/containers/{}/state.json", name);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let mut exited = false;
+        while std::time::Instant::now() < deadline {
+            if let Ok(data) = std::fs::read_to_string(&state_path) {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&data) {
+                    if v["status"].as_str() == Some("exited") {
+                        exited = true;
+                        break;
+                    }
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        assert!(exited, "container did not exit within 5s after /bin/true");
+
+        // Verify spawn_config was saved.
+        let data = std::fs::read_to_string(&state_path).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&data).unwrap();
+        assert!(
+            v.get("spawn_config").is_some(),
+            "state.json must contain spawn_config after first run"
+        );
+
+        // Restart the container.
+        let start_status = std::process::Command::new(bin)
+            .args(["start", name])
+            .status()
+            .expect("pelagos start");
+        assert!(start_status.success(), "pelagos start failed");
+
+        // The restarted container (running /bin/true) should again reach "exited".
+        let deadline2 = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let mut exited2 = false;
+        while std::time::Instant::now() < deadline2 {
+            if let Ok(data) = std::fs::read_to_string(&state_path) {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&data) {
+                    if v["status"].as_str() == Some("exited") {
+                        exited2 = true;
+                        break;
+                    }
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        assert!(exited2, "restarted container did not exit within 5s");
+
+        // Cleanup.
+        let _ = std::process::Command::new(bin)
+            .args(["rm", "-f", name])
+            .output();
+    }
+
+    /// test_container_restart_runs_same_command
+    ///
+    /// Requires: root, alpine-rootfs.
+    ///
+    /// Runs a container that writes a marker file to a bind-mounted host dir,
+    /// lets it exit, restarts it, and verifies the marker file is re-created
+    /// (i.e., the same command ran again on restart with the same bind mount).
+    ///
+    /// Failure indicates SpawnConfig did not preserve bind mounts or the command
+    /// was not faithfully reproduced on restart.
+    #[test]
+    #[serial]
+    fn test_container_restart_runs_same_command() {
+        if !is_root() {
+            eprintln!("SKIP: test_container_restart_runs_same_command requires root");
+            return;
+        }
+        let rootfs = match get_test_rootfs() {
+            Some(r) => r,
+            None => {
+                eprintln!("SKIP: test_container_restart_runs_same_command requires alpine-rootfs");
+                return;
+            }
+        };
+
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+        let name = "pelagos-restart-test-2";
+
+        // Create a temp dir on the host for the bind mount.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let marker = tmp.path().join("marker.txt");
+
+        // Clean up any leftover state.
+        let _ = std::process::Command::new(bin)
+            .args(["rm", "-f", name])
+            .output();
+
+        let bind_arg = format!("{}:/shared", tmp.path().display());
+
+        // Run a container that writes a marker file.
+        let run_status = std::process::Command::new(bin)
+            .args([
+                "run",
+                "-d",
+                "--name",
+                name,
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "--bind",
+                &bind_arg,
+                "/bin/sh",
+                "-c",
+                "echo run1 > /shared/marker.txt",
+            ])
+            .status()
+            .expect("pelagos run -d");
+        assert!(run_status.success(), "pelagos run -d failed");
+
+        // Wait for container to exit and verify marker.
+        let state_path = format!("/run/pelagos/containers/{}/state.json", name);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            if let Ok(data) = std::fs::read_to_string(&state_path) {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&data) {
+                    if v["status"].as_str() == Some("exited") {
+                        break;
+                    }
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        let content = std::fs::read_to_string(&marker).unwrap_or_default();
+        assert!(content.contains("run1"), "marker.txt should contain 'run1'");
+
+        // Remove the marker so we can detect the second run.
+        let _ = std::fs::remove_file(&marker);
+
+        // Restart.
+        let start_status = std::process::Command::new(bin)
+            .args(["start", name])
+            .status()
+            .expect("pelagos start");
+        assert!(start_status.success(), "pelagos start failed");
+
+        // Wait for the restarted container to exit and verify marker was re-created.
+        let deadline2 = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if let Ok(data) = std::fs::read_to_string(&state_path) {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&data) {
+                    if v["status"].as_str() == Some("exited") {
+                        break;
+                    }
+                }
+            }
+            if std::time::Instant::now() >= deadline2 {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        let content2 = std::fs::read_to_string(&marker).unwrap_or_default();
+        assert!(
+            content2.contains("run1"),
+            "marker.txt should be re-created on restart; got: {:?}",
+            content2
+        );
+
+        // Cleanup.
+        let _ = std::process::Command::new(bin)
+            .args(["rm", "-f", name])
+            .output();
+    }
+
+    /// test_container_start_running_fails
+    ///
+    /// Requires: root, alpine-rootfs.
+    ///
+    /// Verifies that `pelagos start` on a currently-running container returns a
+    /// non-zero exit code.  Failure indicates the "already running" guard in
+    /// cmd_start is broken.
+    #[test]
+    #[serial]
+    fn test_container_start_running_fails() {
+        if !is_root() {
+            eprintln!("SKIP: test_container_start_running_fails requires root");
+            return;
+        }
+        let rootfs = match get_test_rootfs() {
+            Some(r) => r,
+            None => {
+                eprintln!("SKIP: test_container_start_running_fails requires alpine-rootfs");
+                return;
+            }
+        };
+
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+        let name = "pelagos-restart-test-3";
+
+        // Clean up any leftover state.
+        let _ = std::process::Command::new(bin)
+            .args(["rm", "-f", name])
+            .output();
+
+        // Start a long-lived container.
+        let run_status = std::process::Command::new(bin)
+            .args([
+                "run",
+                "-d",
+                "--name",
+                name,
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "/bin/sleep",
+                "30",
+            ])
+            .status()
+            .expect("pelagos run -d");
+        assert!(run_status.success(), "pelagos run -d failed");
+
+        // Wait for it to be running (pid > 0).
+        let state_path = format!("/run/pelagos/containers/{}/state.json", name);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            if let Ok(data) = std::fs::read_to_string(&state_path) {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&data) {
+                    if v["pid"].as_i64().unwrap_or(0) > 0 {
+                        break;
+                    }
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+
+        // `pelagos start` on a running container should fail.
+        let start_status = std::process::Command::new(bin)
+            .args(["start", name])
+            .status()
+            .expect("pelagos start invocation");
+        assert!(
+            !start_status.success(),
+            "pelagos start should fail when container is running"
+        );
+
+        // Cleanup.
+        let _ = std::process::Command::new(bin)
+            .args(["stop", name])
+            .output();
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        let _ = std::process::Command::new(bin)
+            .args(["rm", "-f", name])
+            .output();
+    }
 }


### PR DESCRIPTION
Part of epic #67 — full VS Code devcontainer support.

## Context

`pelagos-docker build` is implemented: it calls `pelagos build -t <tag> -f <Dockerfile> <context>` inside the VM. `pelagos build` has a Dockerfile-compatible parser (`FROM`, `RUN`, `COPY`, `CMD`, `ENTRYPOINT`, `ENV`, `ARG`, `LABEL`, `WORKDIR`, `EXPOSE`, `USER`, `VOLUME`, `HEALTHCHECK`) — no Docker Desktop or buildah required.

## What needs end-to-end testing

1. A devcontainer with `build.dockerfile:` — `devcontainer up` generates the Dockerfile and calls `docker build`; verify the image builds and the container starts
2. A devcontainer with `features:` — the devcontainer CLI synthesizes a multi-stage Dockerfile; verify the full features installation flow works
3. `--build-arg` forwarding — build-time variables pass through correctly
4. `--no-cache` flag works

## Known limitation

`--target` (multi-stage target selection) is accepted but not forwarded; the devcontainer CLI always makes `dev_containers_target_stage` the final stage so this is not a blocking gap for devcontainers specifically.

## Acceptance criteria

`devcontainer up` succeeds for a project that uses `features: { "ghcr.io/devcontainers/features/node:1": {} }` with pelagos-docker as the Docker backend.

Part of #67