### PR TITLE
feat: native container labels (--label, --filter label=, inspect)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -3239,3 +3239,25 @@ asserts that `pelagos start` returns a non-zero exit code.
 
 Failure indicates the "already running" guard in `cmd_start` is broken and `pelagos start`
 incorrectly accepts or restarts a live container.
+
+## Native Container Labels (`pelagos run --label`)
+
+### `test_run_with_labels_appear_in_inspect`
+**Requires:** root, alpine-rootfs
+
+Starts a detached container with `--label env=staging --label managed=true`, waits until
+the container PID is recorded, then runs `pelagos container inspect` and asserts the
+JSON output contains `labels.env == "staging"` and `labels.managed == "true"`.
+
+Failure indicates: labels are not being parsed from CLI args, not written to `state.json`,
+or `container inspect` does not include them in its JSON output.
+
+### `test_ps_filter_label`
+**Requires:** root, alpine-rootfs
+
+Starts two containers with different `tier=web` and `tier=db` labels, then runs
+`pelagos ps --format json --filter label=tier=web` and asserts exactly one container
+is returned and it is the one with `tier=web`.
+
+Failure indicates the label filter in `cmd_ps` / `apply_filters` is broken — either
+the wrong containers are returned or the JSON output is malformed.

--- a/src/cli/compose.rs
+++ b/src/cli/compose.rs
@@ -611,6 +611,7 @@ fn spawn_service(
         health: None,
         health_config: None,
         spawn_config: None,
+        labels: std::collections::HashMap::new(),
     };
     write_state(&cstate)?;
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -196,6 +196,9 @@ pub struct SpawnConfig {
     /// Whether NAT (MASQUERADE) was enabled.
     #[serde(default)]
     pub nat: bool,
+    /// Container labels as KEY=VALUE strings (e.g. "env=staging").
+    #[serde(default)]
+    pub labels: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -232,6 +235,9 @@ pub struct ContainerState {
     /// Saved spawn configuration for `pelagos start` restarts.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub spawn_config: Option<SpawnConfig>,
+    /// Container labels as KEY=VALUE strings.
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub labels: std::collections::HashMap<String, String>,
 }
 
 pub fn now_iso8601() -> String {
@@ -685,6 +691,7 @@ mod tests {
             read_only: true,
             rm: false,
             nat: true,
+            labels: vec!["env=staging".to_string(), "managed=true".to_string()],
         };
         let json = serde_json::to_string(&sc).unwrap();
         let decoded: SpawnConfig = serde_json::from_str(&json).unwrap();
@@ -706,6 +713,137 @@ mod tests {
         assert!(decoded.read_only);
         assert!(!decoded.rm);
         assert!(decoded.nat);
+        assert_eq!(decoded.labels, sc.labels);
+    }
+
+    /// test_spawn_config_labels_roundtrip
+    ///
+    /// Verifies that SpawnConfig.labels serializes and deserializes correctly,
+    /// and that an older state JSON without labels field deserializes with empty vec.
+    #[test]
+    fn test_spawn_config_labels_roundtrip() {
+        let sc = SpawnConfig {
+            exe: "/bin/sh".to_string(),
+            labels: vec!["project=myapp".to_string(), "env=prod".to_string()],
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&sc).unwrap();
+        let decoded: SpawnConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.labels, vec!["project=myapp", "env=prod"]);
+
+        // Old state JSON without labels field → empty vec (default).
+        let old_json = r#"{"exe":"/bin/sh"}"#;
+        let old: SpawnConfig = serde_json::from_str(old_json).unwrap();
+        assert!(old.labels.is_empty());
+    }
+
+    /// test_label_filter
+    ///
+    /// Verifies that apply_filters correctly filters containers by label,
+    /// including key-only and key=value forms, and that unknown filters are ignored.
+    #[test]
+    fn test_label_filter() {
+        use super::ps::apply_filters;
+
+        fn make_state(name: &str, labels: &[(&str, &str)]) -> ContainerState {
+            ContainerState {
+                name: name.to_string(),
+                rootfs: "alpine".to_string(),
+                status: ContainerStatus::Running,
+                pid: 1,
+                watcher_pid: 0,
+                started_at: "2026-01-01T00:00:00Z".to_string(),
+                exit_code: None,
+                command: vec!["/bin/sh".to_string()],
+                stdout_log: None,
+                stderr_log: None,
+                bridge_ip: None,
+                network_ips: std::collections::HashMap::new(),
+                health: None,
+                health_config: None,
+                spawn_config: None,
+                labels: labels
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            }
+        }
+
+        let mut states = vec![
+            make_state("web", &[("env", "staging"), ("managed", "true")]),
+            make_state("db", &[("env", "prod"), ("managed", "true")]),
+            make_state("cache", &[("tier", "infra")]),
+        ];
+
+        // Filter by key only.
+        let mut s = states.clone();
+        apply_filters(&mut s, &["label=managed".to_string()]);
+        assert_eq!(s.len(), 2);
+        assert!(s.iter().any(|c| c.name == "web"));
+        assert!(s.iter().any(|c| c.name == "db"));
+
+        // Filter by key=value.
+        let mut s = states.clone();
+        apply_filters(&mut s, &["label=env=staging".to_string()]);
+        assert_eq!(s.len(), 1);
+        assert_eq!(s[0].name, "web");
+
+        // No matches.
+        let mut s = states.clone();
+        apply_filters(&mut s, &["label=env=dev".to_string()]);
+        assert!(s.is_empty());
+
+        // Unknown filter is silently ignored.
+        apply_filters(&mut states, &["unknown=foo".to_string()]);
+        assert_eq!(states.len(), 3);
+    }
+
+    /// test_container_state_labels_serde
+    ///
+    /// Labels on ContainerState round-trip through JSON. Old state files without
+    /// `labels` field deserialize with an empty map.
+    #[test]
+    fn test_container_state_labels_serde() {
+        let mut labels = std::collections::HashMap::new();
+        labels.insert("env".to_string(), "prod".to_string());
+        labels.insert("managed".to_string(), "true".to_string());
+
+        let state = ContainerState {
+            name: "test".to_string(),
+            rootfs: "alpine".to_string(),
+            status: ContainerStatus::Running,
+            pid: 42,
+            watcher_pid: 0,
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+            exit_code: None,
+            command: vec!["/bin/sh".to_string()],
+            stdout_log: None,
+            stderr_log: None,
+            bridge_ip: None,
+            network_ips: std::collections::HashMap::new(),
+            health: None,
+            health_config: None,
+            spawn_config: None,
+            labels,
+        };
+
+        let json = serde_json::to_string(&state).unwrap();
+        let decoded: ContainerState = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.labels.get("env").map(|s| s.as_str()), Some("prod"));
+        assert_eq!(
+            decoded.labels.get("managed").map(|s| s.as_str()),
+            Some("true")
+        );
+
+        // Old state without labels → empty map.
+        let old_json = r#"{
+            "name": "old", "rootfs": "alpine", "status": "exited",
+            "pid": 0, "watcher_pid": 0, "started_at": "2026-01-01T00:00:00Z",
+            "exit_code": 0, "command": ["/bin/sh"],
+            "stdout_log": null, "stderr_log": null
+        }"#;
+        let old: ContainerState = serde_json::from_str(old_json).unwrap();
+        assert!(old.labels.is_empty());
     }
 
     /// test_spawn_config_missing_from_state

--- a/src/cli/ps.rs
+++ b/src/cli/ps.rs
@@ -5,7 +5,35 @@ use super::{
     check_liveness, format_age, list_containers, read_state, write_state, ContainerStatus,
 };
 
-pub fn cmd_ps(all: bool, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+/// Filter a container state list by `--filter` expressions.
+///
+/// Supported filter formats:
+/// - `label=KEY` — container has this label (any value)
+/// - `label=KEY=VALUE` — container has this label with exactly this value
+/// - `name=PATTERN` — container name equals PATTERN (exact match for now)
+/// - `status=running|exited`
+pub fn apply_filters(states: &mut Vec<super::ContainerState>, filters: &[String]) {
+    for f in filters {
+        if let Some(rest) = f.strip_prefix("label=") {
+            // rest is either "KEY" or "KEY=VALUE"
+            let (key, val) = match rest.split_once('=') {
+                Some((k, v)) => (k, Some(v)),
+                None => (rest, None),
+            };
+            states.retain(|s| match val {
+                Some(v) => s.labels.get(key).map(|lv| lv == v).unwrap_or(false),
+                None => s.labels.contains_key(key),
+            });
+        } else if let Some(pattern) = f.strip_prefix("name=") {
+            states.retain(|s| s.name == pattern);
+        } else if let Some(status) = f.strip_prefix("status=") {
+            states.retain(|s| s.status.to_string() == status);
+        }
+        // Unknown filter types are silently ignored (Docker-compatible behaviour).
+    }
+}
+
+pub fn cmd_ps(all: bool, json: bool, filters: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     let mut states = list_containers();
 
     // Sort by started_at (lexicographic on ISO 8601 string = chronological).
@@ -27,6 +55,8 @@ pub fn cmd_ps(all: bool, json: bool) -> Result<(), Box<dyn std::error::Error>> {
     if !all {
         states.retain(|s| s.status == ContainerStatus::Running);
     }
+
+    apply_filters(&mut states, filters);
 
     if json {
         println!("{}", serde_json::to_string_pretty(&states)?);

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -168,6 +168,10 @@ pub struct RunArgs {
     #[clap(long = "dns-backend", value_name = "BACKEND")]
     pub dns_backend: Option<String>,
 
+    /// Label KEY=VALUE (repeatable; stored in state.json and filterable via pelagos ps --filter)
+    #[clap(long = "label", short = 'l')]
+    pub label: Vec<String>,
+
     /// Use a local rootfs instead of an OCI image (advanced)
     #[clap(long)]
     pub rootfs: Option<String>,
@@ -269,6 +273,7 @@ pub fn cmd_run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
             )?
         };
 
+    let labels = parse_labels(&args.label);
     let spawn_config = build_spawn_config(&args, &rootfs_label, &exe_and_args);
 
     if args.detach {
@@ -279,6 +284,7 @@ pub fn cmd_run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
             cmd,
             health_config,
             Some(spawn_config),
+            labels,
         )
     } else if args.interactive {
         run_interactive(cmd)
@@ -290,8 +296,20 @@ pub fn cmd_run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
             cmd,
             args.rm,
             Some(spawn_config),
+            labels,
         )
     }
+}
+
+/// Parse "KEY=VALUE" label strings into a HashMap.
+fn parse_labels(label_args: &[String]) -> std::collections::HashMap<String, String> {
+    label_args
+        .iter()
+        .filter_map(|s| {
+            let (k, v) = s.split_once('=')?;
+            Some((k.to_string(), v.to_string()))
+        })
+        .collect()
 }
 
 /// Capture RunArgs fields into a SpawnConfig for container restart.
@@ -322,6 +340,7 @@ fn build_spawn_config(args: &RunArgs, rootfs_label: &str, exe_and_args: &[String
         read_only: args.read_only,
         rm: args.rm,
         nat: args.nat,
+        labels: args.label.clone(),
     }
 }
 
@@ -803,6 +822,7 @@ fn run_foreground(
     mut cmd: Command,
     auto_remove: bool,
     spawn_config: Option<SpawnConfig>,
+    labels: std::collections::HashMap<String, String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     cmd = cmd
         .stdin(Stdio::Inherit)
@@ -827,6 +847,7 @@ fn run_foreground(
         health: None,
         health_config: None,
         spawn_config,
+        labels,
     };
     write_state(&state)?;
 
@@ -896,6 +917,7 @@ fn run_detached(
     mut cmd: Command,
     health_config: Option<HealthConfig>,
     spawn_config: Option<SpawnConfig>,
+    labels: std::collections::HashMap<String, String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Create container directory before fork so parent and child both see it.
     std::fs::create_dir_all(containers_dir())?;
@@ -921,6 +943,7 @@ fn run_detached(
         health: None,
         health_config: None,
         spawn_config,
+        labels,
     };
     write_state(&state)?;
 

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -100,5 +100,6 @@ fn spawn_config_to_run_args(
         dns_backend: None,
         rootfs: rootfs_field,
         args,
+        label: sc.labels,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,9 @@ pub(crate) enum CliCommand {
         /// Output format: table or json
         #[clap(long, default_value = "table")]
         format: OutputFormat,
+        /// Filter containers (e.g. label=env=staging, label=managed, status=running)
+        #[clap(long = "filter")]
+        filter: Vec<String>,
     },
 
     /// Send SIGTERM to a running container
@@ -200,6 +203,9 @@ pub(crate) enum ContainerCmd {
         /// Output format: table or json
         #[clap(long, default_value = "table")]
         format: OutputFormat,
+        /// Filter containers (e.g. label=env=staging, label=managed, status=running)
+        #[clap(long = "filter")]
+        filter: Vec<String>,
     },
     /// Show detailed information about a container (JSON)
     Inspect {
@@ -405,14 +411,22 @@ fn main() {
         CliCommand::Build(args) => cli::build::cmd_build(args),
         CliCommand::Run(args) => cli::run::cmd_run(*args),
         CliCommand::Exec(args) => cli::exec::cmd_exec(args),
-        CliCommand::Ps { all, format } => cli::ps::cmd_ps(all, format == OutputFormat::Json),
+        CliCommand::Ps {
+            all,
+            format,
+            filter,
+        } => cli::ps::cmd_ps(all, format == OutputFormat::Json, &filter),
         CliCommand::Stop { name } => cli::stop::cmd_stop(&name),
         CliCommand::Rm { name, force } => cli::rm::cmd_rm(&name, force),
         CliCommand::Logs { name, follow } => cli::logs::cmd_logs(&name, follow),
 
         // Container (noun subcommand)
         CliCommand::Container { cmd } => match cmd {
-            ContainerCmd::Ls { all, format } => cli::ps::cmd_ps(all, format == OutputFormat::Json),
+            ContainerCmd::Ls {
+                all,
+                format,
+                filter,
+            } => cli::ps::cmd_ps(all, format == OutputFormat::Json, &filter),
             ContainerCmd::Inspect { name } => cli::ps::cmd_inspect(&name),
             ContainerCmd::Stop { name } => cli::stop::cmd_stop(&name),
             ContainerCmd::Rm { name, force } => cli::rm::cmd_rm(&name, force),

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -16336,4 +16336,192 @@ mod auto_resolv_conf {
             .args(["rm", "-f", name])
             .output();
     }
+
+    /// test_run_with_labels_appear_in_inspect
+    ///
+    /// Requires root + rootfs. Verifies that `--label KEY=VALUE` flags passed to
+    /// `pelagos run -d` are persisted in state.json and visible via
+    /// `pelagos container inspect`. Failure indicates label serialization is broken.
+    #[test]
+    fn test_run_with_labels_appear_in_inspect() {
+        if !is_root() {
+            eprintln!("SKIP: test_run_with_labels_appear_in_inspect requires root");
+            return;
+        }
+        let rootfs = match get_test_rootfs() {
+            Some(r) => r,
+            None => {
+                eprintln!("SKIP: test_run_with_labels_appear_in_inspect requires alpine-rootfs");
+                return;
+            }
+        };
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+        let name = "test-labels-inspect";
+        let _ = std::process::Command::new(bin)
+            .args(["rm", "-f", name])
+            .output();
+
+        let run_status = std::process::Command::new(bin)
+            .args([
+                "run",
+                "-d",
+                "--name",
+                name,
+                "--label",
+                "env=staging",
+                "--label",
+                "managed=true",
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "/bin/sleep",
+                "30",
+            ])
+            .status()
+            .expect("pelagos run -d");
+        assert!(run_status.success(), "pelagos run -d with labels failed");
+
+        // Wait for container to be running.
+        let state_path = format!("/run/pelagos/containers/{}/state.json", name);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            if let Ok(data) = std::fs::read_to_string(&state_path) {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&data) {
+                    if v["pid"].as_i64().unwrap_or(0) > 0 {
+                        break;
+                    }
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+
+        // Inspect shows the labels.
+        let inspect_out = std::process::Command::new(bin)
+            .args(["container", "inspect", name])
+            .output()
+            .expect("pelagos container inspect");
+        assert!(inspect_out.status.success(), "inspect failed");
+        let json: serde_json::Value =
+            serde_json::from_slice(&inspect_out.stdout).expect("inspect output not JSON");
+        assert_eq!(
+            json["labels"]["env"].as_str(),
+            Some("staging"),
+            "label env=staging not found in inspect output"
+        );
+        assert_eq!(
+            json["labels"]["managed"].as_str(),
+            Some("true"),
+            "label managed=true not found in inspect output"
+        );
+
+        // Cleanup.
+        let _ = std::process::Command::new(bin)
+            .args(["stop", name])
+            .output();
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        let _ = std::process::Command::new(bin)
+            .args(["rm", "-f", name])
+            .output();
+    }
+
+    /// test_ps_filter_label
+    ///
+    /// Requires root + rootfs. Verifies that `pelagos ps --filter label=KEY=VALUE`
+    /// returns only containers with that label. Failure indicates filter logic is broken.
+    #[test]
+    fn test_ps_filter_label() {
+        if !is_root() {
+            eprintln!("SKIP: test_ps_filter_label requires root");
+            return;
+        }
+        let rootfs = match get_test_rootfs() {
+            Some(r) => r,
+            None => {
+                eprintln!("SKIP: test_ps_filter_label requires alpine-rootfs");
+                return;
+            }
+        };
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+        let name_a = "test-filter-label-a";
+        let name_b = "test-filter-label-b";
+        for n in [name_a, name_b] {
+            let _ = std::process::Command::new(bin)
+                .args(["rm", "-f", n])
+                .output();
+        }
+
+        // Run container A with label tier=web.
+        let run_a = std::process::Command::new(bin)
+            .args([
+                "run",
+                "-d",
+                "--name",
+                name_a,
+                "--label",
+                "tier=web",
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "/bin/sleep",
+                "30",
+            ])
+            .status()
+            .expect("run A");
+        assert!(run_a.success());
+
+        // Run container B with label tier=db.
+        let run_b = std::process::Command::new(bin)
+            .args([
+                "run",
+                "-d",
+                "--name",
+                name_b,
+                "--label",
+                "tier=db",
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "/bin/sleep",
+                "30",
+            ])
+            .status()
+            .expect("run B");
+        assert!(run_b.success());
+
+        // Wait for both containers to be running.
+        for n in [name_a, name_b] {
+            let state_path = format!("/run/pelagos/containers/{}/state.json", n);
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            while std::time::Instant::now() < deadline {
+                if let Ok(data) = std::fs::read_to_string(&state_path) {
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&data) {
+                        if v["pid"].as_i64().unwrap_or(0) > 0 {
+                            break;
+                        }
+                    }
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+        }
+
+        // Filter for tier=web — should return exactly name_a.
+        let ps_out = std::process::Command::new(bin)
+            .args(["ps", "--format", "json", "--filter", "label=tier=web"])
+            .output()
+            .expect("pelagos ps --filter");
+        assert!(ps_out.status.success(), "ps --filter failed");
+        let list: serde_json::Value =
+            serde_json::from_slice(&ps_out.stdout).expect("ps output not JSON");
+        let arr = list.as_array().expect("ps output is not a JSON array");
+        assert_eq!(arr.len(), 1, "expected exactly 1 container with tier=web");
+        assert_eq!(arr[0]["name"].as_str(), Some(name_a));
+
+        // Cleanup.
+        for n in [name_a, name_b] {
+            let _ = std::process::Command::new(bin).args(["stop", n]).output();
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        for n in [name_a, name_b] {
+            let _ = std::process::Command::new(bin)
+                .args(["rm", "-f", n])
+                .output();
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- `pelagos run --label KEY=VALUE` (repeatable) — labels persist in `state.json` via `ContainerState.labels`
- `pelagos ps --filter label=KEY` / `--filter label=KEY=VALUE` — filter running/all containers by label
- `pelagos container inspect` already emits labels since they're in the state JSON
- Labels survive restart: stored in `SpawnConfig.labels` and re-applied on `pelagos start`
- Backward-compatible: old state files without `labels` field deserialise with an empty map

## Test plan

- [x] Unit tests: SpawnConfig serde roundtrip with labels, ContainerState labels serde, label filter (key-only + key=value + no-match + unknown filter ignored)
- [x] Integration test: `test_run_with_labels_appear_in_inspect` — labels visible in `container inspect` JSON
- [x] Integration test: `test_ps_filter_label` — `ps --filter label=tier=web` returns exactly the matching container
- [x] `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test --lib`, `cargo test --bin pelagos` all pass
- [x] Full integration suite passes (256/257; one pre-existing ordering flake in `test_tut_p2_image_save_load`)

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)