### PR TITLE
fix(exec): detect PID reuse before entering namespaces (#97)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -3289,3 +3289,31 @@ persists, the old root was not properly detached.
 
 Failure indicates `do_pivot_root()` is not cleaning up after itself — either the
 `umount2(MNT_DETACH)` or `rmdir` failed silently, leaving the old root accessible.
+
+### `test_exec_mnt_ns_inode_stored`
+**Requires:** root, alpine-rootfs
+
+Spawns a container in detached mode (`pelagos run -d --rootfs ...`) and reads the
+resulting `state.json`.  Asserts that `mnt_ns_inode` is present and non-zero.  Then
+calls `pelagos exec` into the running container and asserts it succeeds — the inode
+check must pass transparently for a live container (stored inode equals live inode).
+
+Failure indicates either:
+- `mnt_ns_inode` is not being written to `state.json` at spawn time (storage missing)
+- The inode check in `cmd_exec` is incorrectly rejecting a live container (false reject)
+
+### `test_exec_detects_pid_reuse`
+**Requires:** root, alpine-rootfs
+
+Spawns a container in detached mode, polls until `state.json` has a real PID, then
+tampers with `mnt_ns_inode` in `state.json` by setting it to the bogus value
+`999_999_999`.  Calls `pelagos exec` and asserts it fails with an error message
+containing "no longer running".
+
+Simulates the scenario where a short-lived container exits and its PID is recycled by
+an unrelated process: the mount-namespace inode of the recycled process will differ from
+the stored inode, so `verify_pid_not_recycled` must catch this before any `setns(2)`
+call is made.
+
+Failure indicates the inode check in `cmd_exec` is not firing — `pelagos exec` would
+silently enter the wrong process's namespaces.

--- a/src/cli/compose.rs
+++ b/src/cli/compose.rs
@@ -612,6 +612,7 @@ fn spawn_service(
         health_config: None,
         spawn_config: None,
         labels: std::collections::HashMap::new(),
+        mnt_ns_inode: super::read_mnt_ns_inode(pid),
     };
     write_state(&cstate)?;
 

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -1,6 +1,6 @@
 //! `pelagos exec` — run a command inside a running container.
 
-use super::{check_liveness, parse_user, read_state, ContainerStatus};
+use super::{check_liveness, parse_user, read_state, verify_pid_not_recycled, ContainerStatus};
 use pelagos::container::{Command, Namespace, Stdio};
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
@@ -65,7 +65,13 @@ pub fn cmd_exec(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     let pid = state.pid;
 
-    // 2. Discover which namespaces the container has
+    // 2a. Verify PID identity before opening any namespace fds.
+    //     If the container exited and the OS recycled its PID, the mount-namespace
+    //     inode will differ from what was recorded at spawn time.  This catches the
+    //     race before we silently enter the wrong process's namespaces.
+    verify_pid_not_recycled(pid, &state).map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+
+    // 2b. Discover which namespaces the container has
     let ns_entries = discover_namespaces(pid)?;
 
     // 3. Read the container's environment.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -238,6 +238,12 @@ pub struct ContainerState {
     /// Container labels as KEY=VALUE strings.
     #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
     pub labels: std::collections::HashMap<String, String>,
+    /// Inode of the container's mount namespace (`/proc/<pid>/ns/mnt`) at creation
+    /// time.  Used by `pelagos exec` to detect PID reuse: if the current inode
+    /// doesn't match the stored one the original container has exited and the PID
+    /// has been recycled by an unrelated process.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mnt_ns_inode: Option<u64>,
 }
 
 pub fn now_iso8601() -> String {
@@ -657,6 +663,49 @@ pub fn parse_capability_mask(names: &[String]) -> pelagos::container::Capability
     mask
 }
 
+/// Read the inode number of `/proc/<pid>/ns/mnt`.
+///
+/// Returns `None` if the file cannot be stat'd (process has exited or the caller
+/// lacks permission).
+pub fn read_mnt_ns_inode(pid: i32) -> Option<u64> {
+    use std::os::unix::fs::MetadataExt;
+    std::fs::metadata(format!("/proc/{}/ns/mnt", pid))
+        .ok()
+        .map(|m| m.ino())
+}
+
+/// Verify that `pid` still belongs to the expected container by comparing the
+/// live mount-namespace inode against the inode stored in `state.mnt_ns_inode`
+/// at container creation time.
+///
+/// Returns `Ok(())` when:
+/// - No stored inode exists (old state files — backwards compatible).
+/// - The stored inode matches the current one.
+///
+/// Returns `Err` with a user-facing message when the inode doesn't match
+/// (PID has been recycled by an unrelated process) or when the namespace file
+/// can no longer be read (process has exited).
+pub fn verify_pid_not_recycled(pid: i32, state: &ContainerState) -> Result<(), String> {
+    let expected = match state.mnt_ns_inode {
+        Some(inode) => inode,
+        None => return Ok(()), // old state file — skip check
+    };
+    match read_mnt_ns_inode(pid) {
+        Some(current) if current == expected => Ok(()),
+        Some(_) => Err(format!(
+            "container '{}' process (pid {}) is no longer running \
+             (PID was reused by another process) — \
+             use 'pelagos start {}' to restart it",
+            state.name, pid, state.name
+        )),
+        None => Err(format!(
+            "container '{}' process (pid {}) is no longer running — \
+             use 'pelagos start {}' to restart it",
+            state.name, pid, state.name
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -766,6 +815,7 @@ mod tests {
                     .iter()
                     .map(|(k, v)| (k.to_string(), v.to_string()))
                     .collect(),
+                mnt_ns_inode: None,
             }
         }
 
@@ -825,6 +875,7 @@ mod tests {
             health_config: None,
             spawn_config: None,
             labels,
+            mnt_ns_inode: None,
         };
 
         let json = serde_json::to_string(&state).unwrap();

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -848,15 +848,17 @@ fn run_foreground(
         health_config: None,
         spawn_config,
         labels,
+        mnt_ns_inode: None,
     };
     write_state(&state)?;
 
     let mut child = cmd.spawn().map_err(|e| format!("spawn failed: {}", e))?;
     let pid = child.pid();
 
-    // Update state with real PID and network IPs (if bridge networking).
+    // Update state with real PID, mount-namespace inode, and network IPs.
     let mut state2 = state;
     state2.pid = pid;
+    state2.mnt_ns_inode = super::read_mnt_ns_inode(pid);
     state2.bridge_ip = child.container_ip();
     let all_ips: Vec<(String, String)> = child
         .container_ips()
@@ -944,6 +946,7 @@ fn run_detached(
         health_config: None,
         spawn_config,
         labels,
+        mnt_ns_inode: None,
     };
     write_state(&state)?;
 
@@ -1007,9 +1010,10 @@ fn run_detached(
                 );
             }
 
-            // Update state with real PIDs and network IPs.
+            // Update state with real PIDs, mount-namespace inode, and network IPs.
             let mut updated = state;
             updated.pid = pid;
+            updated.mnt_ns_inode = super::read_mnt_ns_inode(pid);
             updated.watcher_pid = watcher_pid;
             updated.bridge_ip = child.container_ip();
             let all_ips: Vec<(String, String)> = child

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7473,6 +7473,199 @@ mod exec {
             "exec output mismatch"
         );
     }
+
+    /// `mnt_ns_inode` is stored in state.json when a container is spawned.
+    ///
+    /// Requires: root, alpine-rootfs.
+    ///
+    /// Spawns a container in detached mode (so state.json is written with a real PID)
+    /// and verifies that `mnt_ns_inode` is Some and matches the live inode of
+    /// `/proc/<pid>/ns/mnt`.  A missing or zero inode would mean the check in
+    /// `cmd_exec` would silently skip PID-reuse detection for all new containers.
+    #[test]
+    #[serial]
+    fn test_exec_mnt_ns_inode_stored() {
+        if !is_root() {
+            eprintln!("Skipping test_exec_mnt_ns_inode_stored (requires root)");
+            return;
+        }
+        let rootfs = match get_test_rootfs() {
+            Some(r) => r,
+            None => {
+                eprintln!("Skipping (no rootfs)");
+                return;
+            }
+        };
+
+        let name = "test-mnt-inode";
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+
+        // Clean up any stale state.
+        let _ = std::process::Command::new(bin)
+            .args(["rm", "-f", name])
+            .output();
+
+        // Start a detached sleeping container.
+        let run_status = std::process::Command::new(bin)
+            .args([
+                "run",
+                "-d",
+                "--name",
+                name,
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "/bin/sleep",
+                "30",
+            ])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("pelagos run failed");
+        assert!(run_status.success(), "pelagos run -d failed");
+
+        // Poll for the watcher to write the real PID.
+        let state_path = format!("/run/pelagos/containers/{}/state.json", name);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let state_json;
+        loop {
+            if let Ok(data) = std::fs::read_to_string(&state_path) {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&data) {
+                    if v["pid"].as_i64().unwrap_or(0) > 0 {
+                        state_json = data;
+                        break;
+                    }
+                }
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "container did not start within 10s"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+
+        let state: serde_json::Value = serde_json::from_str(&state_json).expect("parse state.json");
+        let stored_inode = state["mnt_ns_inode"]
+            .as_u64()
+            .expect("mnt_ns_inode must be present in state.json");
+        assert!(stored_inode > 0, "mnt_ns_inode must be non-zero");
+
+        // Verify exec succeeds while the container is running — the inode check
+        // must pass transparently for a live container (stored inode == live inode).
+        let exec_out = std::process::Command::new(bin)
+            .args(["exec", name, "/bin/true"])
+            .output()
+            .expect("pelagos exec");
+
+        // Clean up before asserting so the container is always stopped.
+        let _ = std::process::Command::new(bin)
+            .args(["rm", "-f", name])
+            .output();
+
+        assert!(
+            exec_out.status.success(),
+            "exec into live container should succeed (inode check must not false-reject), stderr: {}",
+            String::from_utf8_lossy(&exec_out.stderr)
+        );
+    }
+
+    /// `pelagos exec` rejects a PID whose mount-namespace inode doesn't match
+    /// the stored value (simulating PID reuse after container exit).
+    ///
+    /// Requires: root, alpine-rootfs.
+    ///
+    /// Spawns a container, tampers with `mnt_ns_inode` in state.json to a
+    /// deliberately wrong value, then calls `pelagos exec`.  The exec must fail
+    /// with an error mentioning "no longer running" — not silently enter the wrong
+    /// process's namespaces.  A pass confirms the inode check fires before any
+    /// `setns(2)` call.
+    #[test]
+    #[serial]
+    fn test_exec_detects_pid_reuse() {
+        if !is_root() {
+            eprintln!("Skipping test_exec_detects_pid_reuse (requires root)");
+            return;
+        }
+        let rootfs = match get_test_rootfs() {
+            Some(r) => r,
+            None => {
+                eprintln!("Skipping (no rootfs)");
+                return;
+            }
+        };
+
+        let name = "test-pid-reuse";
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+
+        // Clean up stale state.
+        let _ = std::process::Command::new(bin)
+            .args(["rm", "-f", name])
+            .output();
+
+        // Start a detached sleeping container.
+        let run_status = std::process::Command::new(bin)
+            .args([
+                "run",
+                "-d",
+                "--name",
+                name,
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "/bin/sleep",
+                "30",
+            ])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("pelagos run failed");
+        assert!(run_status.success(), "pelagos run -d failed");
+
+        // Poll for the watcher to write the real PID.
+        let state_path = format!("/run/pelagos/containers/{}/state.json", name);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            if let Ok(data) = std::fs::read_to_string(&state_path) {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&data) {
+                    if v["pid"].as_i64().unwrap_or(0) > 0 {
+                        break;
+                    }
+                }
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "container did not start within 10s"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+
+        // Tamper with state.json — overwrite mnt_ns_inode with a bogus value.
+        let json = std::fs::read_to_string(&state_path).expect("read state.json");
+        let mut state: serde_json::Value = serde_json::from_str(&json).expect("parse state.json");
+        state["mnt_ns_inode"] = serde_json::Value::Number(serde_json::Number::from(999_999_999u64));
+        std::fs::write(&state_path, serde_json::to_string(&state).unwrap())
+            .expect("write tampered state.json");
+
+        // Attempt exec — must fail with a clear "no longer running" / PID-reuse error.
+        let exec_out = std::process::Command::new(bin)
+            .args(["exec", name, "/bin/true"])
+            .output()
+            .expect("pelagos exec invocation failed");
+
+        // Clean up before asserting so the container is always stopped.
+        let _ = std::process::Command::new(bin)
+            .args(["rm", "-f", name])
+            .output();
+
+        assert!(
+            !exec_out.status.success(),
+            "exec should have failed on tampered inode but exited 0"
+        );
+        let stderr = String::from_utf8_lossy(&exec_out.stderr);
+        assert!(
+            stderr.contains("no longer running"),
+            "error should mention 'no longer running', got: {}",
+            stderr
+        );
+    }
 }
 
 mod watcher {


### PR DESCRIPTION
## Summary

Fixes #97 — `pelagos exec` was silently entering the wrong process's namespaces when a short-lived container exited and its PID was recycled before exec arrived.

- Record the container's mount-namespace inode (`/proc/<pid>/ns/mnt`) at spawn time in `state.json` as `mnt_ns_inode`
- Before opening any `/proc/<pid>/ns/*` fd in `cmd_exec`, compare the live inode against the stored value via `verify_pid_not_recycled()`
- Mismatch → immediate clear error: _"container 'X' process (pid Y) is no longer running (PID was reused)"_
- Old state files without `mnt_ns_inode` skip the check (backwards compatible)

## Test plan

- [x] `test_exec_mnt_ns_inode_stored` — verifies inode is stored and exec into live container passes transparently
- [x] `test_exec_detects_pid_reuse` — tampers with stored inode; verifies exec fails with "no longer running"
- [x] Full integration suite: 260/260 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)