### PR TITLE
fix(run): write state with real PID before relaying stdout (issue #124)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pelagos"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 rust-version = "1.76"
 description = "Fast Linux container runtime — OCI-compatible, namespaces, cgroups v2, seccomp, networking, image management"

--- a/ONGOING_TASKS.md
+++ b/ONGOING_TASKS.md
@@ -2,6 +2,25 @@
 
 All work is tracked in GitHub Issues. This file is a brief index.
 
+## Session in progress: v0.59.0 (branch fix/run-state-ordering-issue-124)
+
+### Issues in progress
+
+| # | Title | Fix |
+|---|-------|-----|
+| #124 | fix(run): write state with real PID before relaying stdout | v0.59.0 |
+
+### Key implementation details
+
+**#124 (run state ordering race):**
+- Two distinct races: (A) `run_foreground` — stdout Inherit let container output flow before `write_state(real_pid)`; (B) `run_detached` non-attach — parent exited before watcher wrote real PID
+- Fix A: change stdout/stderr to `Stdio::Piped`, call `write_state(real_pid)` immediately after spawn, then start relay threads — data only flows after state is written
+- Fix B: sync pipe (O_CLOEXEC) created before fork; watcher writes 1 byte after `write_state(real_pid)`; parent blocks on read before printing name / starting relay
+- `run_detached` with `-a STDOUT/-a STDERR` was already correctly ordered (relay starts after write_state); sync pipe added there too for explicit guarantee and to avoid SIGPIPE
+- Two integration tests: `test_run_foreground_state_written_before_output_issue_124`, `test_run_detached_state_ready_on_return_issue_124`
+
+---
+
 ## Session completed: 2026-03-17 (SHA 21b80d7, v0.58.0)
 
 ### Issues closed this session

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -3854,3 +3854,28 @@ asserts the output contains `127.0.1.1 mycontainer`.
 Failure indicates that the hostname alias is missing from `/etc/hosts`, which would cause
 `getaddrinfo(hostname)` to fail inside the container — matching Docker's behaviour of
 always providing a `127.0.1.1` alias for the container's hostname.
+
+### `test_run_foreground_state_written_before_output_issue_124`
+**Requires:** root, network (alpine image pull)
+**Module:** `issue_124_run_state_ordering`
+
+Spawns `pelagos run` (foreground, no `--detach`) with stdout piped. Reads until
+the container's first output line (`echo ready`) appears, then immediately reads
+`state.json` and asserts `pid > 0`.
+
+Failure indicates that container output reached the caller before `state.json`
+was written with the real PID — the ordering bug described in issue #124.  Any
+tool using container stdout as a readiness signal would call `pelagos exec` and
+see `pid=0`, causing exec-into to fail.
+
+### `test_run_detached_state_ready_on_return_issue_124`
+**Requires:** root, network (alpine image pull)
+**Module:** `issue_124_run_state_ordering`
+
+Runs `pelagos run --detach` and immediately reads `state.json` the moment the
+command returns.  Asserts `pid > 0`.
+
+Failure indicates the parent returned (printed the container name) before the
+watcher had written state with the real PID — the sync-pipe guarantee is broken.
+A concurrent `pelagos exec` immediately after `pelagos run --detach` would see
+`pid=0` and fail.

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -31,7 +31,7 @@ use super::{
 use pelagos::container::{Capability, Command, Namespace, Stdio, Volume};
 use pelagos::network::NetworkMode;
 use pelagos::wasm::WasmRuntime;
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::path::PathBuf;
 
 #[derive(Debug, clap::Args)]
@@ -860,55 +860,95 @@ fn run_foreground(
     spawn_config: Option<SpawnConfig>,
     labels: std::collections::HashMap<String, String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // Use Piped for stdout/stderr so we can write state with the real PID
+    // before any container output reaches the caller (issue #124).
+    // stdin stays Inherit so the user's terminal input flows to the container.
     cmd = cmd
         .stdin(Stdio::Inherit)
-        .stdout(Stdio::Inherit)
-        .stderr(Stdio::Inherit);
+        .stdout(Stdio::Piped)
+        .stderr(Stdio::Piped);
 
-    // Write initial state
     std::fs::create_dir_all(containers_dir())?;
-    let state = ContainerState {
+
+    let mut child = cmd.spawn().map_err(|e| format!("spawn failed: {}", e))?;
+    let pid = child.pid();
+
+    // Gather network info before writing state.
+    let mnt_ns_inode = super::read_mnt_ns_inode(pid);
+    let bridge_ip = child.container_ip();
+    let all_ips: Vec<(String, String)> = child
+        .container_ips()
+        .into_iter()
+        .map(|(name, ip)| (name.to_string(), ip))
+        .collect();
+    let network_ips: std::collections::HashMap<String, String> = all_ips.iter().cloned().collect();
+
+    // Write state with real PID *before* starting the relay threads.
+    // Guarantees concurrent `pelagos ps` / exec-into callers see a valid PID
+    // before any container output reaches them (issue #124).
+    let mut state = ContainerState {
         name: name.clone(),
         rootfs,
         status: ContainerStatus::Running,
-        pid: 0,
+        pid,
         watcher_pid: 0,
         started_at: super::now_iso8601(),
         exit_code: None,
         command: command.clone(),
         stdout_log: None,
         stderr_log: None,
-        bridge_ip: None,
-        network_ips: std::collections::HashMap::new(),
+        bridge_ip,
+        network_ips,
         health: None,
         health_config: None,
         spawn_config,
         labels,
-        mnt_ns_inode: None,
+        mnt_ns_inode,
     };
     write_state(&state)?;
-
-    let mut child = cmd.spawn().map_err(|e| format!("spawn failed: {}", e))?;
-    let pid = child.pid();
-
-    // Update state with real PID, mount-namespace inode, and network IPs.
-    let mut state2 = state;
-    state2.pid = pid;
-    state2.mnt_ns_inode = super::read_mnt_ns_inode(pid);
-    state2.bridge_ip = child.container_ip();
-    let all_ips: Vec<(String, String)> = child
-        .container_ips()
-        .into_iter()
-        .map(|(name, ip)| (name.to_string(), ip))
-        .collect();
-    state2.network_ips = all_ips.iter().cloned().collect();
-    write_state(&state2)?;
 
     // Register container with embedded DNS daemon for each bridge network.
     register_dns(&name, &all_ips);
 
+    // Relay threads: pipe container stdout/stderr to our stdout/stderr.
+    // Data only flows after write_state above, satisfying the ordering guarantee.
+    let child_stdout = child.take_stdout();
+    let child_stderr = child.take_stderr();
+    let stdout_relay = std::thread::spawn(move || {
+        if let Some(mut src) = child_stdout {
+            let mut buf = [0u8; 8192];
+            loop {
+                match src.read(&mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        let _ = io::stdout().write_all(&buf[..n]);
+                        let _ = io::stdout().flush();
+                    }
+                }
+            }
+        }
+    });
+    let stderr_relay = std::thread::spawn(move || {
+        if let Some(mut src) = child_stderr {
+            let mut buf = [0u8; 8192];
+            loop {
+                match src.read(&mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        let _ = io::stderr().write_all(&buf[..n]);
+                        let _ = io::stderr().flush();
+                    }
+                }
+            }
+        }
+    });
+
     let exit = child.wait().map_err(|e| format!("wait failed: {}", e))?;
     let code = exit.code().unwrap_or(1);
+
+    // Drain relay threads after container exits.
+    let _ = stdout_relay.join();
+    let _ = stderr_relay.join();
 
     // Deregister container from DNS.
     deregister_dns(&name, &all_ips);
@@ -918,10 +958,9 @@ fn run_foreground(
         let dir = super::container_dir(&name);
         let _ = std::fs::remove_dir_all(&dir);
     } else {
-        // Update final state
-        state2.status = ContainerStatus::Exited;
-        state2.exit_code = Some(code);
-        write_state(&state2)?;
+        state.status = ContainerStatus::Exited;
+        state.exit_code = Some(code);
+        write_state(&state)?;
     }
 
     std::process::exit(code);
@@ -1011,6 +1050,15 @@ fn run_detached(a: DetachedArgs) -> Result<(), Box<dyn std::error::Error>> {
         return Err(io::Error::last_os_error().into());
     }
 
+    // Sync pipe (issue #124): watcher writes 1 byte after write_state(real_pid) so the
+    // parent blocks until state is durably visible to concurrent `pelagos ps` / exec-into
+    // callers.  O_CLOEXEC closes it in the container grandchild's exec().
+    // [0] = read (parent), [1] = write (watcher).
+    let mut sync_pipe: [i32; 2] = [-1, -1];
+    if unsafe { libc::pipe2(sync_pipe.as_mut_ptr(), libc::O_CLOEXEC) } != 0 {
+        return Err(io::Error::last_os_error().into());
+    }
+
     // Fork a watcher child; parent either streams output (attach mode) or prints name and exits.
     let fork_result = unsafe { libc::fork() };
     match fork_result {
@@ -1025,6 +1073,8 @@ fn run_detached(a: DetachedArgs) -> Result<(), Box<dyn std::error::Error>> {
                     unsafe { libc::close(slot[0]) };
                 }
             }
+            // Close read end of sync pipe — only the parent reads it.
+            unsafe { libc::close(sync_pipe[0]) };
             // Detach from parent's session so we're adopted by init when parent exits.
             unsafe { libc::setsid() };
 
@@ -1114,6 +1164,13 @@ fn run_detached(a: DetachedArgs) -> Result<(), Box<dyn std::error::Error>> {
             }
             let _ = write_state(&updated);
 
+            // Signal parent: state with real PID is now visible to concurrent
+            // readers.  Parent blocks on sync_pipe[0] until this write (issue #124).
+            unsafe {
+                libc::write(sync_pipe[1], b"\x00".as_ptr() as *const libc::c_void, 1);
+                libc::close(sync_pipe[1]);
+            }
+
             // Register container with embedded DNS daemon.
             register_dns(&name, &all_ips);
 
@@ -1179,6 +1236,23 @@ fn run_detached(a: DetachedArgs) -> Result<(), Box<dyn std::error::Error>> {
                 if slot[1] >= 0 {
                     unsafe { libc::close(slot[1]) };
                 }
+            }
+
+            // Wait for the watcher to signal that state.json has been written with the
+            // real container PID before we return (or relay output) to the caller.
+            // This eliminates the race between `pelagos run` returning and concurrent
+            // `pelagos ps` / exec-into callers reading a stale pid=0 (issue #124).
+            // In attach mode the attach-pipe mechanism already provides ordering, but
+            // we also wait here to make the guarantee explicit and to avoid SIGPIPE
+            // on the watcher's write end.
+            unsafe { libc::close(sync_pipe[1]) };
+            let mut one = [0u8; 1];
+            let n = unsafe { libc::read(sync_pipe[0], one.as_mut_ptr() as *mut libc::c_void, 1) };
+            unsafe { libc::close(sync_pipe[0]) };
+            if n <= 0 {
+                return Err(
+                    "container failed to start (watcher exited before writing state)".into(),
+                );
             }
 
             if attach_stdout || attach_stderr {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -19612,3 +19612,163 @@ mod issue_120_etc_hosts {
         );
     }
 }
+
+mod issue_124_run_state_ordering {
+    use std::io::BufRead;
+    use std::time::Duration;
+
+    fn bin() -> &'static str {
+        env!("CARGO_BIN_EXE_pelagos")
+    }
+
+    fn cleanup(name: &str) {
+        let _ = std::process::Command::new(bin())
+            .args(["stop", name])
+            .output();
+        std::thread::sleep(Duration::from_millis(300));
+        let _ = std::process::Command::new(bin())
+            .args(["rm", "-f", name])
+            .output();
+    }
+
+    fn pull_alpine() {
+        let _ = std::process::Command::new(bin())
+            .args([
+                "image",
+                "pull",
+                "public.ecr.aws/docker/library/alpine:latest",
+            ])
+            .output();
+    }
+
+    /// Verifies that `pelagos run` (foreground) writes state with a valid PID
+    /// *before* any container output reaches the caller.
+    ///
+    /// Requires root + network (image pull).  A race here produces pid=0 in
+    /// state.json at the moment the first output line appears on stdout.
+    ///
+    /// The fix: switch stdout/stderr to Piped and write state with real PID
+    /// before starting relay threads, so data only flows after state is written.
+    #[test]
+    fn test_run_foreground_state_written_before_output_issue_124() {
+        use crate::is_root;
+        use std::io::BufReader;
+        use std::process::Stdio;
+
+        if !is_root() {
+            eprintln!(
+                "SKIP: test_run_foreground_state_written_before_output_issue_124 requires root"
+            );
+            return;
+        }
+
+        let name = "test-fg-state-124";
+        pull_alpine();
+        cleanup(name);
+
+        // Spawn `pelagos run` (foreground) with piped stdout so we can read
+        // the container's first output line from inside the test.
+        let mut child = std::process::Command::new(bin())
+            .args([
+                "run",
+                "--name",
+                name,
+                "public.ecr.aws/docker/library/alpine:latest",
+                "/bin/sh",
+                "-c",
+                "echo ready; sleep 10",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn pelagos run");
+
+        let stdout = child.stdout.take().unwrap();
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("read first output line");
+
+        assert_eq!(
+            line.trim(),
+            "ready",
+            "expected 'ready' on stdout, got: {:?}",
+            line
+        );
+
+        // At this point the relay has delivered the first line — state must
+        // already have a valid PID (relay starts after write_state in the fix).
+        let state_path = format!("/run/pelagos/containers/{}/state.json", name);
+        let raw = std::fs::read_to_string(&state_path)
+            .expect("state.json missing when first output appeared");
+        let v: serde_json::Value = serde_json::from_str(&raw).expect("state.json parse failed");
+        let pid = v["pid"].as_i64().unwrap_or(0);
+        assert!(
+            pid > 0,
+            "state.pid should be > 0 when first output appears (issue #124), got {}",
+            pid
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
+        cleanup(name);
+    }
+
+    /// Verifies that `pelagos run --detach` writes state with a valid PID
+    /// before it returns to the caller.
+    ///
+    /// Requires root + network (image pull).  Previously the parent process
+    /// exited immediately after fork, before the watcher had written the real
+    /// PID — so any exec-into immediately after would see pid=0 (issue #124).
+    ///
+    /// The fix: a sync pipe causes the parent to block until the watcher writes
+    /// state with the real PID, then returns.
+    #[test]
+    fn test_run_detached_state_ready_on_return_issue_124() {
+        use crate::is_root;
+
+        if !is_root() {
+            eprintln!("SKIP: test_run_detached_state_ready_on_return_issue_124 requires root");
+            return;
+        }
+
+        let name = "test-dtch-state-124";
+        pull_alpine();
+        cleanup(name);
+
+        let out = std::process::Command::new(bin())
+            .args([
+                "run",
+                "--detach",
+                "--name",
+                name,
+                "public.ecr.aws/docker/library/alpine:latest",
+                "sleep",
+                "30",
+            ])
+            .output()
+            .expect("pelagos run --detach");
+
+        assert!(
+            out.status.success(),
+            "pelagos run --detach failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        // Immediately after `pelagos run --detach` returns, state must have
+        // a valid (non-zero) PID — the sync pipe blocks the parent until
+        // the watcher has written it.
+        let state_path = format!("/run/pelagos/containers/{}/state.json", name);
+        let raw = std::fs::read_to_string(&state_path)
+            .expect("state.json missing immediately after pelagos run --detach");
+        let v: serde_json::Value = serde_json::from_str(&raw).expect("state.json parse failed");
+        let pid = v["pid"].as_i64().unwrap_or(0);
+        assert!(
+            pid > 0,
+            "state.pid should be > 0 immediately after `pelagos run --detach` \
+             returns (issue #124), got {}",
+            pid
+        );
+
+        cleanup(name);
+    }
+}


### PR DESCRIPTION
## Summary

- **Race A (`run_foreground`)**: stdout was `Inherit` — container output reached the caller before `write_state(real_pid)`. Fixed by switching to `Piped`, writing state first, then starting relay threads.
- **Race B (`run_detached` non-attach)**: parent exited before watcher wrote the real PID. Fixed with a sync pipe: parent blocks until watcher signals state is written.
- `run_detached -a STDOUT/-a STDERR` was already correctly ordered; sync pipe added for explicitness and to prevent SIGPIPE on the watcher's write end.

## Test plan

- [x] `test_run_foreground_state_written_before_output_issue_124` — reads first output line from piped stdout; asserts `state.pid > 0` at that moment
- [x] `test_run_detached_state_ready_on_return_issue_124` — reads `state.json` immediately after `pelagos run --detach` returns; asserts `state.pid > 0`
- [x] Full integration suite: 297/297 pass locally

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)