### PR TITLE
test: regression tests for ip_forward and stale netns_exists (#144/#145)

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -2215,6 +2215,59 @@ mod tests {
         assert!(h3.len() <= 15);
     }
 
+    // ── netns_exists tests ───────────────────────────────────────────────
+
+    /// `netns_exists` must return false for a name with no file at all.
+    #[test]
+    fn test_netns_exists_nonexistent_returns_false() {
+        assert!(!netns_exists("__no_such_netns_xyzzy__"));
+    }
+
+    /// `netns_exists` must return false for a plain regular file.
+    ///
+    /// Regression test for pelagos#145.  Before the fix, `netns_exists` used
+    /// `Path::exists()` which returns true for any file — including the stale
+    /// ext4 directory entries that persist at `/run/netns/` after a VM restart
+    /// (the bind mounts are gone but the filenames remain).  The fix uses
+    /// `NS_GET_NSTYPE` ioctl which fails with ENOTTY on plain files, so only
+    /// live nsfs inodes return true.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_netns_exists_plain_file_returns_false() {
+        use std::io::Write;
+
+        let name = format!("__test_stale_{}", std::process::id());
+        let path = format!("/run/netns/{}", name);
+
+        // Skip gracefully if we can't write to /run/netns/ (non-root or path
+        // absent) — the integration test suite covers the root-only path.
+        if std::fs::create_dir_all("/run/netns").is_err() {
+            eprintln!(
+                "Skipping test_netns_exists_plain_file_returns_false: \
+                 cannot create /run/netns"
+            );
+            return;
+        }
+        let Ok(mut f) = std::fs::File::create(&path) else {
+            eprintln!(
+                "Skipping test_netns_exists_plain_file_returns_false: \
+                 cannot write to /run/netns/"
+            );
+            return;
+        };
+        let _ = f.write_all(b"stale");
+        drop(f);
+
+        let result = netns_exists(&name);
+        let _ = std::fs::remove_file(&path);
+
+        assert!(
+            !result,
+            "netns_exists must return false for a plain file (not a live \
+             nsfs inode) — pelagos#145 regression"
+        );
+    }
+
     // ── PortProto tests ──────────────────────────────────────────────────
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3710,6 +3710,62 @@ mod networking {
         );
     }
 
+    /// N4-regression: `enable_port_forwards` must set ip_forward=1.
+    ///
+    /// Regression test for pelagos#144.  Before the fix, DNAT'd packets were
+    /// silently dropped because `ip_forward` was 0 — nftables redirects traffic
+    /// from `eth0` to the container IP on `pelagos0`, but the kernel won't
+    /// forward across interfaces without `ip_forward=1`.
+    ///
+    /// This test resets ip_forward to 0, spawns a container with a port
+    /// forward, then asserts the sysctl is 1 immediately after spawn returns.
+    #[test]
+    #[serial(nat)]
+    fn test_ip_forward_enabled_on_port_forward() {
+        if !is_root() {
+            eprintln!("Skipping test_ip_forward_enabled_on_port_forward: requires root");
+            return;
+        }
+
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!(
+                "Skipping test_ip_forward_enabled_on_port_forward: alpine-rootfs not found"
+            );
+            return;
+        };
+
+        // Start from a known bad state: ip_forward disabled.
+        let _ = std::fs::write("/proc/sys/net/ipv4/ip_forward", "0\n");
+
+        let mut child = Command::new("/bin/ash")
+            .args(["-c", "sleep 2"])
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS)
+            .with_network(NetworkMode::Bridge)
+            .with_nat()
+            .with_port_forward(18089, 80)
+            .with_chroot(&rootfs)
+            .env("PATH", ALPINE_PATH)
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Null)
+            .stderr(Stdio::Null)
+            .spawn()
+            .expect("Failed to spawn port-forward container");
+
+        // enable_port_forwards() runs in the parent during spawn(); by the
+        // time spawn() returns the sysctl must already be 1.
+        let val =
+            std::fs::read_to_string("/proc/sys/net/ipv4/ip_forward").unwrap_or_default();
+
+        child.wait().expect("wait for port-forward container");
+
+        assert_eq!(
+            val.trim(),
+            "1",
+            "ip_forward must be 1 after a container with port-forward starts \
+             (pelagos#144 regression)"
+        );
+    }
+
     /// N4-UDP: `with_port_forward_udp` installs a UDP DNAT rule in nftables.
     ///
     /// Spawns a bridge+NAT container with a UDP port mapping.  The nftables


### PR DESCRIPTION
## Summary

- Adds three targeted regression tests for the two bugs fixed in #146, which had no test coverage before.

## Tests added

**`src/network.rs` (unit tests, `cargo test --lib`)**

- `test_netns_exists_nonexistent_returns_false` — baseline: missing path always returns false. No root required.
- `test_netns_exists_plain_file_returns_false` — regression for #145: a plain `ext4` file at `/run/netns/<name>` must return false. The old `Path::exists()` check returned true for stale entries (bind-mount gone after VM restart, filename remains on disk), causing dead container IPs to persist in nftables PREROUTING. Root-only; gracefully skipped otherwise.

**`tests/integration_tests.rs` (integration test, root-only)**

- `test_ip_forward_enabled_on_port_forward` — regression for #144: resets `ip_forward` to 0, spawns a port-forward container, asserts the sysctl is `"1"` once `spawn()` returns. If `enable_port_forwards()` ever loses the `ip_forward` write, DNAT'd packets will be dropped at the `eth0→pelagos0` boundary and this test will catch it.

## Test plan

- [ ] `cargo test --lib -- network::tests::test_netns` (runs on build VM as root: both unit tests pass; on macOS: `test_netns_exists_nonexistent_returns_false` passes, `test_netns_exists_plain_file_returns_false` skips gracefully)
- [ ] `cargo test --test integration_tests -- test_ip_forward_enabled_on_port_forward` (build VM, root)
- [ ] Full integration suite continues to pass

Related to #144, #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)