### PR TITLE
fix(network): log pasta startup diagnostics at debug, strip \r from output

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -2003,7 +2003,26 @@ pub fn teardown_pasta_network(setup: &mut PastaSetup) {
     if let Some(thread) = setup.output_thread.take() {
         match thread.join() {
             Ok(out) if !out.trim().is_empty() => {
-                log::warn!("pasta output:\n{}", out.trim());
+                // Strip \r so pasta's \r\n line endings don't garble the terminal.
+                let cleaned = out
+                    .lines()
+                    .map(|l| l.trim_end_matches('\r'))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                let cleaned = cleaned.trim();
+                // Log at warn only if pasta printed something that looks like an
+                // error; its normal startup summary is purely informational.
+                let looks_like_error = cleaned
+                    .lines()
+                    .any(|l| {
+                        let l = l.to_ascii_lowercase();
+                        l.contains("error") || l.contains("fatal") || l.contains("failed")
+                    });
+                if looks_like_error {
+                    log::warn!("pasta output:\n{}", cleaned);
+                } else {
+                    log::debug!("pasta output:\n{}", cleaned);
+                }
             }
             Ok(_) => {
                 log::debug!("pasta output: (empty)");


### PR DESCRIPTION
## Problem

`teardown_pasta_network` logs pasta's stderr at `WARN` unconditionally. pasta prints its full startup summary (interface config, MAC, DHCP, DNS) to stderr on every launch — this is normal, not an error. The result: users see a wall of WARN text on every clean container exit.

The output is also garbled because pasta uses `\r\n` line endings. When printed after a PTY session ends (terminal restored to cooked mode), the `\r` resets the cursor to column 0 mid-line, producing a staircase layout.

## Fix

- Strip `\r` from each line before logging
- Log at `DEBUG` unless a line contains "error", "fatal", or "failed" — real errors still surface at `WARN`

## Result

Silent on clean exit. Diagnostics still visible with `RUST_LOG=debug`. Actual pasta errors still logged at WARN.

Fixes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)