### PR TITLE
fix(ci): install wasmtime in embedded-wasm job; switch ECR alpine to docker.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,5 +86,9 @@ jobs:
         with:
           targets: wasm32-wasip1,wasm32-wasip2
       - uses: Swatinem/rust-cache@v2
+      - name: Install wasmtime
+        run: |
+          curl -fsSL https://wasmtime.dev/install.sh | bash
+          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
       - name: Run embedded Wasm e2e tests
         run: sudo -E env "PATH=$PATH" bash scripts/test-wasm-embedded-e2e.sh

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -19472,7 +19472,7 @@ mod issue_118_start_returns_promptly {
             .args([
                 "image",
                 "pull",
-                "public.ecr.aws/docker/library/alpine:latest",
+                "docker.io/library/alpine:latest",
             ])
             .output()
             .expect("pelagos image pull");
@@ -19489,7 +19489,7 @@ mod issue_118_start_returns_promptly {
                 "--detach",
                 "--name",
                 name,
-                "public.ecr.aws/docker/library/alpine:latest",
+                "docker.io/library/alpine:latest",
                 "/bin/sh",
                 "-c",
                 "sleep 60",
@@ -19691,7 +19691,7 @@ mod issue_124_run_state_ordering {
             .args([
                 "image",
                 "pull",
-                "public.ecr.aws/docker/library/alpine:latest",
+                "docker.io/library/alpine:latest",
             ])
             .output();
     }
@@ -19728,7 +19728,7 @@ mod issue_124_run_state_ordering {
                 "run",
                 "--name",
                 name,
-                "public.ecr.aws/docker/library/alpine:latest",
+                "docker.io/library/alpine:latest",
                 "/bin/sh",
                 "-c",
                 "echo ready; sleep 10",
@@ -19796,7 +19796,7 @@ mod issue_124_run_state_ordering {
                 "--detach",
                 "--name",
                 name,
-                "public.ecr.aws/docker/library/alpine:latest",
+                "docker.io/library/alpine:latest",
                 "sleep",
                 "30",
             ])


### PR DESCRIPTION
## Two CI failures fixed

### 1. `wasm-embedded-e2e-tests` — wasmtime not installed

The `wasm-e2e-tests` job already had the wasmtime install step; `wasm-embedded-e2e-tests` was missing it. Every run failed with:

```
no Wasm runtime found in PATH — install wasmtime or wasmedge
```

Fix: copy the same install step across.

### 2. `integration-tests` — ECR Public rate limit

`test_start_returns_promptly` (and 4 related tests) pulled `public.ecr.aws/docker/library/alpine:latest`. ECR Public rate-limits unauthenticated requests; GitHub Actions runners share IPs across the fleet and hit the limit regularly.

Switched to `docker.io/library/alpine:latest`. GitHub has a Docker Hub partnership giving Actions runners 5000 pulls/6h — well above what the test suite needs.

(ECR was originally chosen to avoid Docker Hub anonymous limits on dev machines where the local image cache is warm. In CI the cache is cold every run, making ECR the wrong choice.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)