### PR TITLE
fix(seccomp): allow setuid/setgid in docker default and iouring filters

### DIFF
--- a/src/seccomp.rs
+++ b/src/seccomp.rs
@@ -145,9 +145,6 @@ pub fn docker_default_filter() -> Result<BpfProgram, io::Error> {
         "move_pages",    // Move process pages
         // Quota manipulation
         "quotactl", // Filesystem quotas
-        // User namespace credential manipulation (when not using user namespaces)
-        "setuid", // Set user ID (blocked by default, allowed with conditions in real Docker)
-        "setgid", // Set group ID
         // Architecture-specific personality (can bypass security)
         "personality", // Set execution domain
         // ACCT and system accounting
@@ -237,8 +234,6 @@ pub fn docker_iouring_filter() -> Result<BpfProgram, io::Error> {
         "migrate_pages",
         "move_pages",
         "quotactl",
-        "setuid",
-        "setgid",
         "personality",
         "acct",
         "lookup_dcookie",


### PR DESCRIPTION
## Problem

Any container image with a non-root `User` field (e.g. `prometheus` uid=65534, `grafana`, `alertmanager`) fails to start when `--security-opt seccomp=default` is active, reporting `Invalid argument (os error 22)`.

## Root cause

`docker_default_filter()` and `docker_iouring_filter()` both include `setuid` and `setgid` in their blocked syscall lists. The seccomp filter is installed at pre_exec step 4.849, but pelagos calls `setuid(N)` at step 8.5 (after pivot_root + capability drop + no-new-privileges). The syscall is blocked by the filter (EPERM), wrapped as `io::Error::other()` (no raw OS error code), and propagated to the parent as EINVAL via `raw_os_error().unwrap_or(libc::EINVAL)` — masking the real error.

## Fix

Remove `setuid` and `setgid` from the blocked list in both filters. Docker's own default seccomp profile permits these syscalls unconditionally.

## Verification

Tested on aarch64 Apple Silicon via pelagos-mac VM:

```
# root container + seccomp=default — was working, still works
pelagos run --rm --security-opt seccomp=default alpine echo ok  ✅

# non-root container + no seccomp — was working, still works  
pelagos run --rm --user 65534 alpine echo ok  ✅

# non-root container + seccomp=default — was FAILING, now fixed
pelagos run --rm --user 65534 --security-opt seccomp=default alpine echo ok  ✅
pelagos run --rm --user 1 --security-opt seccomp=default alpine echo ok  ✅
```

Also verified `compose-core.reml` (prometheus + alertmanager + grafana): alertmanager and grafana both start successfully after the fix.

Closes #157