### PR TITLE
fix(ci): add musl targets to rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.94.0"
 components = ["rustfmt", "clippy"]
+targets = ["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"]


### PR DESCRIPTION
## Summary

- Adds `targets = ["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"]` to `rust-toolchain.toml`

When `rust-toolchain.toml` does not list targets, cargo's own rustup toolchain-sync overwrites the toolchain to exactly the listed components — stripping the musl std libraries that `dtolnay/rust-toolchain` added via `with: targets:`. This causes `error[E0463]: can't find crate for core` on every release build.

The fix ensures the musl targets are part of the canonical toolchain spec, so both the workflow step and cargo's sync agree on what's installed.

## Test plan

- [ ] Release CI passes both `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` build jobs on first attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)