### PR TITLE
fix(dns): remove stale config on EADDRNOTAVAIL bind failure (#168)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -3918,3 +3918,17 @@ asserts it succeeds without requiring a manual `compose down` first.
 Failure indicates that `cmd_compose_up_reml` is not detecting the dead supervisor
 PID in the project state file, or that `cleanup_stale_project` is failing to
 remove lingering containers and project state before starting fresh (issue #161).
+
+### `test_dns_stale_config_removed_on_bind_failure`
+**Requires:** root (writes to `/run/pelagos/dns/`)
+**Module:** `dns`
+
+Writes a DNS config file for a fictitious network whose gateway IP (192.0.2.1,
+RFC 5737 TEST-NET) has no corresponding network interface on the host.  Starts
+`pelagos-dns` pointing at the config dir and asserts that the stale file is
+deleted and the daemon logs a "stale config" removal message rather than the
+generic "failed to bind" error.
+
+Failure indicates that EADDRNOTAVAIL on bind is not triggering the stale-config
+cleanup path, meaning the daemon will spam "failed to bind" on every SIGHUP for
+the lifetime of any unrelated compose stack (issue #168).

--- a/src/bin/pelagos-dns.rs
+++ b/src/bin/pelagos-dns.rs
@@ -310,34 +310,52 @@ impl ServerState {
 
     /// Rebind UDP sockets to match current config listen IPs.
     fn rebind_sockets(&mut self) {
-        // Collect desired listen addresses.
-        let desired: HashMap<Ipv4Addr, &str> = self
+        // Collect desired listen addresses as owned values so we can mutate
+        // self.configs during the loop when stale entries are removed.
+        let desired: Vec<(Ipv4Addr, String)> = self
             .configs
             .iter()
-            .map(|(name, cfg)| (cfg.listen_ip, name.as_str()))
+            .map(|(name, cfg)| (cfg.listen_ip, name.clone()))
             .collect();
 
+        let desired_ips: Vec<Ipv4Addr> = desired.iter().map(|(ip, _)| *ip).collect();
+
         // Remove sockets for IPs no longer needed.
-        self.sockets.retain(|s| desired.contains_key(&s.gateway_ip));
+        self.sockets.retain(|s| desired_ips.contains(&s.gateway_ip));
 
         // Determine which IPs already have sockets.
         let bound: Vec<Ipv4Addr> = self.sockets.iter().map(|s| s.gateway_ip).collect();
 
         // Bind new sockets for IPs not yet bound.
-        for &ip in desired.keys() {
-            if bound.contains(&ip) {
+        for (ip, network_name) in &desired {
+            if bound.contains(ip) {
                 continue;
             }
 
-            let bind_addr = SocketAddr::new(std::net::IpAddr::V4(ip), 53);
+            let bind_addr = SocketAddr::new(std::net::IpAddr::V4(*ip), 53);
             match UdpSocket::bind(bind_addr) {
                 Ok(sock) => {
                     let _ = sock.set_nonblocking(true);
                     self.sockets.push(ListenSocket {
                         socket: sock,
-                        gateway_ip: ip,
+                        gateway_ip: *ip,
                     });
                     eprintln!("pelagos-dns: listening on {}", bind_addr);
+                }
+                Err(e) if e.raw_os_error() == Some(libc::EADDRNOTAVAIL) => {
+                    // The gateway IP has no corresponding network interface — the
+                    // bridge is down and the config is stale (container exited
+                    // without cleanup).  Remove the file so we don't retry on every
+                    // reload.  When a container next starts on this network,
+                    // dns_add_entry will recreate it.
+                    let config_file = self.config_dir.join(network_name);
+                    let _ = std::fs::remove_file(&config_file);
+                    self.configs.remove(network_name);
+                    eprintln!(
+                        "pelagos-dns: removed stale config for '{}' \
+                         (gateway {} has no interface)",
+                        network_name, ip
+                    );
                 }
                 Err(e) => {
                     eprintln!("pelagos-dns: failed to bind {}: {}", bind_addr, e);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -11082,6 +11082,92 @@ mod dns {
         cleanup_test_network(net_name);
         unsafe { std::env::remove_var("PELAGOS_DNS_BACKEND") };
     }
+
+    /// test_dns_stale_config_removed_on_bind_failure
+    ///
+    /// Requires root (writes to `/run/pelagos/dns/`).
+    /// Does NOT require a rootfs or running container.
+    ///
+    /// Writes a DNS config file for a fictitious network whose gateway IP
+    /// (192.0.2.1, RFC 5737 TEST-NET — never assigned to any real interface)
+    /// has no corresponding network interface.  Starts `pelagos-dns` pointing
+    /// at the config dir and waits briefly.  Asserts that:
+    ///   1. The stale config file has been deleted.
+    ///   2. The daemon exited cleanly (no real entries → auto-exit).
+    ///
+    /// Failure indicates that EADDRNOTAVAIL on bind is not triggering stale-config
+    /// removal, meaning the daemon will spam "failed to bind" on every SIGHUP for
+    /// the lifetime of any unrelated compose stack (issue #168).
+    #[test]
+    fn test_dns_stale_config_removed_on_bind_failure() {
+        if !is_root() {
+            eprintln!("Skipping test_dns_stale_config_removed_on_bind_failure (requires root)");
+            return;
+        }
+
+        let config_dir = pelagos::paths::dns_config_dir();
+        std::fs::create_dir_all(&config_dir).unwrap();
+
+        // Write a config file that looks like a real network but whose gateway
+        // IP (192.0.2.1) is not assigned to any interface on this host.
+        let stale_net = "stale-168";
+        let stale_config = config_dir.join(stale_net);
+        // Config format: "<gateway_ip> <upstream,...>\n<name> <ip>\n..."
+        std::fs::write(
+            &stale_config,
+            "192.0.2.1 8.8.8.8\norphan-container 192.0.2.10\n",
+        )
+        .unwrap();
+        assert!(
+            stale_config.exists(),
+            "stale config should exist before test"
+        );
+
+        // Start the daemon binary directly, pointing at the same config dir.
+        let dns_bin = std::path::Path::new(env!("CARGO_BIN_EXE_pelagos-dns"));
+        let mut daemon = std::process::Command::new(dns_bin)
+            .arg("--config-dir")
+            .arg(&config_dir)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn pelagos-dns");
+
+        // Give the daemon time to reload and attempt the bind.
+        std::thread::sleep(std::time::Duration::from_millis(800));
+
+        // The stale config file must have been removed.
+        assert!(
+            !stale_config.exists(),
+            "stale config '{}' should have been removed by the daemon after EADDRNOTAVAIL",
+            stale_config.display()
+        );
+
+        // With no entries remaining, the daemon should have auto-exited.
+        // Give it a bit longer if it hasn't quit yet.
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        let exited = daemon.try_wait().unwrap().is_some();
+        if !exited {
+            // Force-kill in case it's still running (not a test failure by itself).
+            let _ = daemon.kill();
+        }
+        let output = daemon.wait_with_output().unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        // The daemon must have logged the stale-config removal message, not the
+        // generic "failed to bind" error loop.
+        assert!(
+            stderr.contains("stale config"),
+            "expected 'stale config' message in daemon stderr, got: {}",
+            stderr
+        );
+        assert!(
+            !stderr.contains("failed to bind"),
+            "daemon should not log 'failed to bind' for a stale config, got: {}",
+            stderr
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- When `pelagos-dns` tries to bind a gateway IP and gets `EADDRNOTAVAIL`, it now deletes the stale config file and removes the network from in-memory state instead of logging an error on every reload
- `EADDRNOTAVAIL` is unambiguous: the bridge interface is down, no container can be live on that network, all entries are orphaned
- Other bind errors (EACCES, EADDRINUSE) are unaffected

## Test plan

- [ ] `test_dns_stale_config_removed_on_bind_failure`: writes a config for `192.0.2.1` (RFC 5737 TEST-NET), starts daemon, asserts file deleted and `"stale config"` in stderr with no `"failed to bind"`
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `cargo test --lib` (321 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)