### PR TITLE
fix(landlock): probe ABI mask downward on EINVAL from create_ruleset

### DIFF
--- a/src/landlock.rs
+++ b/src/landlock.rs
@@ -176,28 +176,39 @@ pub fn apply_landlock(rules: &[LandlockRule]) -> io::Result<()> {
         return Ok(()); // Kernel < 5.13 or Landlock not compiled in.
     }
 
-    // handled_access_fs: the set of rights this ruleset controls (deny by default).
-    // We restrict all rights the running ABI version knows about.
-    let handled_access = fs_access_mask_for_abi(abi);
-
-    let attr = LandlockRulesetAttr {
-        handled_access_fs: handled_access,
-    };
-    let ruleset_fd = unsafe {
-        let ret = libc::syscall(
-            libc::SYS_landlock_create_ruleset,
-            &attr as *const LandlockRulesetAttr,
-            std::mem::size_of::<LandlockRulesetAttr>() as libc::size_t,
-            0i64,
-        );
-        if ret < 0 {
-            let e = io::Error::last_os_error();
-            if e.raw_os_error() == Some(libc::ENOSYS) {
-                return Ok(()); // Race: ABI check passed but create failed.
+    // Create the ruleset, probing downward through ABI versions on EINVAL.
+    //
+    // Some vendor-patched kernels (e.g. Ubuntu 6.8.0 HWE) report ABI=4 via the
+    // version query but return EINVAL when LANDLOCK_ACCESS_FS_IOCTL_DEV (bit 15)
+    // is included in handled_access_fs.  We fall back to successively lower ABI
+    // masks until landlock_create_ruleset accepts the request.
+    let (ruleset_fd, handled_access) = {
+        let mut abi_try = abi;
+        loop {
+            let mask = fs_access_mask_for_abi(abi_try);
+            let attr = LandlockRulesetAttr {
+                handled_access_fs: mask,
+            };
+            let ret = unsafe {
+                libc::syscall(
+                    libc::SYS_landlock_create_ruleset,
+                    &attr as *const LandlockRulesetAttr,
+                    std::mem::size_of::<LandlockRulesetAttr>() as libc::size_t,
+                    0i64,
+                )
+            };
+            if ret >= 0 {
+                break (ret as i32, mask);
             }
-            return Err(e);
+            let e = io::Error::last_os_error();
+            match e.raw_os_error() {
+                Some(libc::ENOSYS) => return Ok(()), // Race: ABI check passed but create failed.
+                Some(libc::EINVAL) if abi_try > 1 => {
+                    abi_try -= 1; // Retry with next lower ABI mask.
+                }
+                _ => return Err(e),
+            }
         }
-        ret as i32
     };
 
     for rule in rules {


### PR DESCRIPTION
## Summary

- Ubuntu 6.8.0 HWE kernel reports Landlock ABI=4 but rejects `LANDLOCK_ACCESS_FS_IOCTL_DEV` (bit 15) in `handled_access_fs`, returning `EINVAL` from `landlock_create_ruleset`
- All tests using `.with_landlock_ro()` / `.with_landlock_rw()` were failing with spawn error 22 on this kernel
- Fix: when `landlock_create_ruleset` returns `EINVAL`, decrement the ABI version and retry with the next lower mask until the call succeeds

## Root cause

`get_abi_version()` probes via `landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION)` which returns 4 on Ubuntu 6.8.0-106. However, the actual `create_ruleset` call with the v4 mask (0xFFFF, bits 0–15 including `IOCTL_DEV`) fails with `EINVAL`. The v3 mask (0x7FFF, bits 0–14) succeeds. The TCP network rights (ABI v4 `handled_access_net`) also work — only the FS IOCTL bit is broken in this kernel.

## Verified on Ubuntu 6.8.0-106-generic (aarch64)

| Test | Before | After |
|---|---|---|
| `test_landlock_read_only_allows_read` | FAIL (EINVAL) | PASS |
| `test_landlock_denies_write` | FAIL (EINVAL) | PASS |
| `test_landlock_rw_allows_write` | FAIL (EINVAL) | PASS |
| `test_landlock_partial_path_allow` | FAIL (EINVAL) | PASS |
| `test_landlock_no_rules_no_effect` | PASS | PASS |

## Test plan

- [x] Run `cargo test security::test_landlock` on Ubuntu 6.8.0-106-generic — all 5 pass
- [x] Run full non-network integration suite — 284 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)