### PR TITLE
fix(image): surface auth hints on pull/push failures

### DIFF
--- a/src/cli/image.rs
+++ b/src/cli/image.rs
@@ -8,6 +8,40 @@ use std::io::{Read as _, Write};
 
 use super::auth::{parse_docker_config, remove_docker_config, resolve_auth, write_docker_config};
 
+fn oci_err(registry: &str, e: oci_client::errors::OciDistributionError) -> String {
+    use oci_client::errors::{OciDistributionError, OciErrorCode};
+    let auth_hint = format!(
+        "\n  hint: run 'pelagos image login {}' if authentication is required",
+        registry
+    );
+    match &e {
+        OciDistributionError::UnauthorizedError { .. }
+        | OciDistributionError::AuthenticationFailure(_) => {
+            format!("{}{}", e, auth_hint)
+        }
+        OciDistributionError::RegistryError { envelope, .. } => {
+            let is_auth = envelope.errors.iter().any(|err| {
+                matches!(err.code, OciErrorCode::Unauthorized | OciErrorCode::Denied)
+            });
+            if is_auth {
+                format!("{}{}", e, auth_hint)
+            } else {
+                e.to_string()
+            }
+        }
+        OciDistributionError::RequestError(req_err) => {
+            let msg = req_err.to_string();
+            let lower = msg.to_lowercase();
+            if lower.contains("401") || lower.contains("403") || lower.contains("unauthorized") {
+                format!("{}{}", msg, auth_hint)
+            } else {
+                msg
+            }
+        }
+        _ => e.to_string(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Client config helper
 // ---------------------------------------------------------------------------
@@ -259,7 +293,7 @@ async fn pull_image(
     let (manifest, digest, config_json) = client
         .pull_manifest_and_config(&oci_ref, &auth)
         .await
-        .map_err(|e| format!("failed to pull manifest: {}", e))?;
+        .map_err(|e| format!("failed to pull manifest: {}", oci_err(registry, e)))?;
 
     println!(
         "  Manifest: {} ({} layers)",
@@ -393,7 +427,7 @@ async fn push_image(
     let response = client
         .push(&dest_oci_ref, &layers, config, &auth, None)
         .await
-        .map_err(|e| format!("push failed: {}", e))?;
+        .map_err(|e| format!("push failed: {}", oci_err(registry, e)))?;
 
     println!("Pushed {}", dest_ref);
     println!("  manifest: {}", response.manifest_url);


### PR DESCRIPTION
## Summary

- Adds `oci_err()` helper that inspects `OciDistributionError` variants and appends a `pelagos image login` hint when the failure is auth-related
- Replaces raw `.map_err(|e| e.to_string())` in `pull_manifest_and_config` and `push` call sites
- Auth hint fires for: `UnauthorizedError`, `AuthenticationFailure`, `RegistryError` with `UNAUTHORIZED`/`DENIED` codes, request errors containing 401/403

## Test plan

- [ ] `pelagos image pull <private-ecr-image>` without login → shows registry error + login hint
- [ ] `pelagos image pull <non-existent-image>` DNS failure → transport error, no spurious auth hint
- [ ] `pelagos image pull <ghcr.io-private>` without login → "Not authorized" + login hint

Verified manually in build VM against three cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)