### PR TITLE
fix(oci): retry manifest fetch on stale-connection transport errors

### DIFF
--- a/src/cli/image.rs
+++ b/src/cli/image.rs
@@ -8,6 +8,25 @@ use std::io::{Read as _, Write};
 
 use super::auth::{parse_docker_config, remove_docker_config, resolve_auth, write_docker_config};
 
+/// Returns true if `e` is a transport-level failure (broken connection, EOF,
+/// connect reset) rather than a registry-protocol error.  Used to decide
+/// whether to retry with a fresh connection.
+///
+/// Background: registry load balancers (Docker Hub, ECR) silently drop idle
+/// TCP connections after ~30 s.  With a kernel-level NAT relay the VM's
+/// socket has no way to learn about the server-side close until the next
+/// write times out.  A single retry with a freshly-created client is
+/// sufficient because the new client opens a new connection.
+fn is_transport_error(e: &oci_client::errors::OciDistributionError) -> bool {
+    use oci_client::errors::OciDistributionError;
+    match e {
+        OciDistributionError::RequestError(re) => {
+            re.is_connect() || re.is_request() || re.is_timeout()
+        }
+        _ => false,
+    }
+}
+
 fn oci_err(registry: &str, e: oci_client::errors::OciDistributionError) -> String {
     use oci_client::errors::{OciDistributionError, OciErrorCode};
     let auth_hint = format!(
@@ -290,10 +309,19 @@ async fn pull_image(
 
     let client = Client::new(oci_client_config(registry, insecure));
 
-    let (manifest, digest, config_json) = client
-        .pull_manifest_and_config(&oci_ref, &auth)
-        .await
-        .map_err(|e| format!("failed to pull manifest: {}", oci_err(registry, e)))?;
+    let manifest_result = client.pull_manifest_and_config(&oci_ref, &auth).await;
+    let (manifest, digest, config_json) = match manifest_result {
+        Ok(r) => r,
+        Err(e) if is_transport_error(&e) => {
+            // Stale pooled connection — create a fresh client and retry once.
+            log::debug!("pull: manifest transport error, retrying with fresh connection: {e}");
+            Client::new(oci_client_config(registry, insecure))
+                .pull_manifest_and_config(&oci_ref, &auth)
+                .await
+                .map_err(|e| format!("failed to pull manifest: {}", oci_err(registry, e)))?
+        }
+        Err(e) => return Err(format!("failed to pull manifest: {}", oci_err(registry, e)).into()),
+    };
 
     println!(
         "  Manifest: {} ({} layers)",


### PR DESCRIPTION
## Problem

`pelagos image pull` fails for any registry (docker.io, ECR public) with:

```
pelagos: error: failed to pull manifest: error sending request for url (https://index.docker.io/v2/library/alpine/manifests/latest)
```

With `RUST_LOG=debug`, the failure is a 30-second hang after auth succeeds, ending in `BrokenPipe` on a reused pooled connection.

## Root cause

Registry load balancers silently drop idle TCP connections after ~30 s. The OCI client's auth token exchange takes ~1 s; during that time the initial registry connection sits pooled-but-idle. When the manifest request reuses that pooled connection, the server has already dropped it. The client sends the request, gets no response for 30 s, then errors.

This was invisible with pelagos-mac's old smoltcp TCP proxy (which maintained its own internet-side sockets and would detect dead connections). After pelagos-mac switched to a kernel-level pf NAT relay (direct IP translation), the VM's TCP socket IS the internet socket — stale connections are now visible.

## Fix

Detect transport-level errors (`is_connect() || is_request() || is_timeout()`) on the manifest fetch and retry once with a freshly-created client. The new client opens a new TCP connection that succeeds.

## Test

Built for `aarch64-unknown-linux-musl`, deployed to the VM:

```
Pulling docker.io/library/alpine:latest...
  Manifest: sha256:378c4c5418f7 (1 layers)
  Layer 1/1: d17f077ada11 (cached)
Done: 0 layers downloaded, 1 cached
```

Fixes pelagos-containers/pelagos-mac#202

🤖 Generated with [Claude Code](https://claude.com/claude-code)