### PR TITLE
fix(test): add missing no_nat field to SpawnConfig serde test

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -768,6 +768,7 @@ mod tests {
             read_only: true,
             rm: false,
             nat: true,
+            no_nat: false,
             labels: vec!["env=staging".to_string(), "managed=true".to_string()],
             tmpfs: vec!["/run".to_string(), "/tmp:size=64m".to_string()],
         };


### PR DESCRIPTION
## Summary

- `SpawnConfig` gained a `no_nat: bool` field but the struct literal in `test_spawn_config_serde_roundtrip` was not updated
- This caused a compile error when running `cargo test`, blocking the full test suite
- Fix: add `no_nat: false` to the literal

## Test plan

- [x] `cargo test` passes on build VM (720 passed, 0 failed)