### PR TITLE
feat(netns): persist network_ns_name/cgroup_name; add --net=container:NAME

### DIFF
--- a/src/cli/compose.rs
+++ b/src/cli/compose.rs
@@ -710,6 +710,8 @@ fn spawn_service(
         labels: std::collections::HashMap::new(),
         mnt_ns_inode: super::read_mnt_ns_inode(pid),
         upper_dir: None,
+        network_ns_name: child.netns_name().map(|s| s.to_string()),
+        cgroup_name: child.cgroup_path(),
     };
     write_state(&cstate)?;
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -272,6 +272,15 @@ pub struct ContainerState {
     /// overlay upper dir so filesystem changes survive stop/start cycles.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub upper_dir: Option<std::path::PathBuf>,
+    /// Named network namespace for this container's primary bridge interface.
+    /// Lives at `/run/netns/{name}` and persists after the container exits.
+    /// Used by `--net=container:NAME` to join another container's netns.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_ns_name: Option<String>,
+    /// Cgroup path for this container (e.g. `pelagos-12345-0`).
+    /// Used by `pelagos-dockerd` to read CPU/memory stats from the cgroup fs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cgroup_name: Option<String>,
 }
 
 pub fn now_iso8601() -> String {
@@ -848,6 +857,8 @@ mod tests {
                     .collect(),
                 mnt_ns_inode: None,
                 upper_dir: None,
+                network_ns_name: None,
+                cgroup_name: None,
             }
         }
 
@@ -909,6 +920,8 @@ mod tests {
             labels,
             mnt_ns_inode: None,
             upper_dir: None,
+            network_ns_name: None,
+            cgroup_name: None,
         };
 
         let json = serde_json::to_string(&state).unwrap();

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -669,7 +669,33 @@ fn apply_cli_options(
         network_mode,
         NetworkMode::Bridge | NetworkMode::BridgeNamed(_)
     );
-    if network_mode != NetworkMode::None {
+    if let NetworkMode::Container(ref target_name) = network_mode {
+        // Join the target container's named network namespace instead of creating
+        // a new one.  The target must have been started with bridge networking so
+        // that its network_ns_name is populated in its ContainerState.
+        let target_state = super::read_state(target_name).map_err(|_| {
+            format!(
+                "container '{}' not found — cannot join its network namespace",
+                target_name
+            )
+        })?;
+        let ns_name = target_state.network_ns_name.ok_or_else(|| {
+            format!(
+                "container '{}' has no named network namespace \
+                 (must be a bridge-networked container)",
+                target_name
+            )
+        })?;
+        let netns_path = format!("/run/netns/{}", ns_name);
+        if !std::path::Path::new(&netns_path).exists() {
+            return Err(format!(
+                "network namespace '{}' not found — is container '{}' still running?",
+                netns_path, target_name
+            )
+            .into());
+        }
+        cmd = cmd.with_namespace_join(netns_path, Namespace::NET);
+    } else if network_mode != NetworkMode::None {
         cmd = cmd.with_network(network_mode);
     }
     for net_name in additional_networks {
@@ -894,6 +920,13 @@ fn apply_cli_options(
 }
 
 fn parse_network_mode(s: &str) -> Result<NetworkMode, Box<dyn std::error::Error>> {
+    // Handle container:NAME before lowercasing so container names are case-preserved.
+    if let Some(target) = s.strip_prefix("container:") {
+        if target.is_empty() {
+            return Err("--network container: requires a container name".into());
+        }
+        return Ok(NetworkMode::Container(target.to_string()));
+    }
     match s.to_ascii_lowercase().as_str() {
         "none" | "" => Ok(NetworkMode::None),
         "loopback" => Ok(NetworkMode::Loopback),
@@ -1021,6 +1054,8 @@ fn run_foreground(
     // Gather network info before writing state.
     let mnt_ns_inode = super::read_mnt_ns_inode(pid);
     let bridge_ip = child.container_ip();
+    let network_ns_name = child.netns_name().map(|s| s.to_string());
+    let cgroup_name = child.cgroup_path();
     let all_ips: Vec<(String, String)> = child
         .container_ips()
         .into_iter()
@@ -1050,6 +1085,8 @@ fn run_foreground(
         labels,
         mnt_ns_inode,
         upper_dir,
+        network_ns_name,
+        cgroup_name,
     };
     write_state(&state)?;
 
@@ -1137,6 +1174,8 @@ fn run_interactive(
     // so `pelagos ps` sees the container immediately (mirrors run_foreground).
     let mnt_ns_inode = super::read_mnt_ns_inode(pid);
     let bridge_ip = session.child.container_ip();
+    let network_ns_name = session.child.netns_name().map(|s| s.to_string());
+    let cgroup_name = session.child.cgroup_path();
     let all_ips: Vec<(String, String)> = session
         .child
         .container_ips()
@@ -1165,6 +1204,8 @@ fn run_interactive(
         labels,
         mnt_ns_inode,
         upper_dir,
+        network_ns_name,
+        cgroup_name,
     };
     write_state(&state)?;
     register_dns(&name, &all_ips);
@@ -1250,6 +1291,8 @@ fn run_detached(a: DetachedArgs) -> Result<(), Box<dyn std::error::Error>> {
         labels,
         mnt_ns_inode: None,
         upper_dir,
+        network_ns_name: None,
+        cgroup_name: None,
     };
     write_state(&state)?;
 
@@ -1365,6 +1408,8 @@ fn run_detached(a: DetachedArgs) -> Result<(), Box<dyn std::error::Error>> {
             updated.mnt_ns_inode = super::read_mnt_ns_inode(pid);
             updated.watcher_pid = watcher_pid;
             updated.bridge_ip = child.container_ip();
+            updated.network_ns_name = child.netns_name().map(|s| s.to_string());
+            updated.cgroup_name = child.cgroup_path();
             let all_ips: Vec<(String, String)> = child
                 .container_ips()
                 .into_iter()

--- a/src/network.rs
+++ b/src/network.rs
@@ -423,6 +423,12 @@ pub enum NetworkMode {
     /// relays packets to/from the host using ordinary userspace sockets, requiring
     /// no kernel privileges. Works for both root and rootless containers.
     Pasta,
+    /// Join an existing container's named network namespace.
+    ///
+    /// The string is the target container name. At spawn time the container's
+    /// `network_ns_name` is resolved to `/run/netns/{name}` and joined via
+    /// `setns(CLONE_NEWNET)`. No new network namespace is created.
+    Container(String),
 }
 
 impl NetworkMode {


### PR DESCRIPTION
## Summary

- Adds `network_ns_name` and `cgroup_name` optional fields to `ContainerState` (serde default + skip_serializing_if for backward compat)
- Populates `network_ns_name` from `child.netns_name()` in `run_foreground`, `run_interactive`, `run_detached`, and `compose` paths
- Adds `NetworkMode::Container(String)` variant to the `NetworkMode` enum
- Implements `--network container:NAME` in `parse_network_mode()` and the network-application block in `run.rs`: reads target container's state, resolves `/run/netns/{ns_name}`, calls `with_namespace_join()` — joining the existing netns rather than creating a new one
- No loopback setup, no `with_network()` call — joining container inherits the target's already-configured net namespace

## Test plan

- [x] Unit tests: 335 passed, 0 failed
- [x] Functional: `pelagos run --name=base --detach --network=bridge alpine sleep 60` → state.json shows `"network_ns_name": "rem-XXXX-0"`
- [x] Functional: `pelagos run --network=container:base alpine ip addr` → shows same eth0 IP as base container

## Related

Part of #207 (rusternetes integration prerequisites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)