### PR TITLE
feat: pelagos-dockerd — Docker Engine API shim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2414,6 +2414,7 @@ dependencies = [
  "env_logger",
  "flate2",
  "hyper",
+ "hyper-util",
  "ignore",
  "libc",
  "log",
@@ -2429,6 +2430,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml",
+ "tower 0.4.13",
  "ureq",
  "uuid",
  "wasmtime",
@@ -2977,7 +2979,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -3794,6 +3796,17 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -3821,7 +3834,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,6 +1613,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +1631,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -2041,6 +2103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2078,6 +2146,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2331,6 +2405,7 @@ dependencies = [
 name = "pelagos"
 version = "0.60.9"
 dependencies = [
+ "axum",
  "bitflags 2.11.0",
  "bzip2",
  "cgroups-rs 0.5.0",
@@ -2338,6 +2413,7 @@ dependencies = [
  "containerd-shim",
  "env_logger",
  "flate2",
+ "hyper",
  "ignore",
  "libc",
  "log",
@@ -2354,6 +2430,7 @@ dependencies = [
  "tokio",
  "toml",
  "ureq",
+ "uuid",
  "wasmtime",
  "wasmtime-wasi",
  "xz2",
@@ -3180,6 +3257,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3593,6 +3681,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -3716,6 +3805,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3945,6 +4035,7 @@ version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
+ "getrandom 0.4.1",
  "js-sys",
  "serde_core",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos"
-version = "0.60.7"
+version = "0.60.9"
 dependencies = [
  "bitflags 2.11.0",
  "bzip2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ path = "src/bin/pelagos-dockerd/main.rs"
 [target.'cfg(target_os = "linux")'.dependencies]
 axum = "0.7"
 hyper = { version = "1", features = ["http1"] }
-hyper-util = { version = "0.1", features = ["tokio"] }
+hyper-util = { version = "0.1", features = ["tokio", "service"] }
 tower = "0.4"
 uuid = { version = "1", features = ["v4"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ seccompiler = "0.5.0"  # Pure Rust seccomp-BPF for syscall filtering (used by Fi
 serde = { version = "1", features = ["derive"] }  # JSON serialization for OCI config.json / state.json
 serde_json = "1"  # JSON parsing for OCI bundle config and state files
 oci-client = "0.16"  # OCI registry client for image pulls
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "net", "time", "io-util"] }  # Async runtime: image pulls + async TCP port proxy
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "net", "time", "io-util", "process", "fs", "signal", "macros"] }  # Async runtime: image pulls + async TCP port proxy
 flate2 = "1"  # Gzip decompression for OCI layer tarballs
 tar = "0.4"  # Tar extraction for OCI layers
 tempfile = "3"  # Temp files for layer downloads
@@ -60,6 +60,15 @@ path = "src/bin/pelagos-dns.rs"
 [[bin]]
 name = "pelagos-shim-wasm"
 path = "src/bin/pelagos-shim-wasm.rs"
+
+[[bin]]
+name = "pelagos-dockerd"
+path = "src/bin/pelagos-dockerd/main.rs"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+axum = "0.7"
+hyper = { version = "1", features = ["http1"] }
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 serial_test = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 serial_test = "3"
+bollard = { version = "0.17", default-features = false, features = ["ssl"] }
 
 # Removed unused dependencies:
 # - subprocess (never used)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,8 @@ path = "src/bin/pelagos-dockerd/main.rs"
 [target.'cfg(target_os = "linux")'.dependencies]
 axum = "0.7"
 hyper = { version = "1", features = ["http1"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+tower = "0.4"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]

--- a/docs/RUSTERNETES_INTEGRATION.md
+++ b/docs/RUSTERNETES_INTEGRATION.md
@@ -1,0 +1,132 @@
+# Rusternetes on Pelagos — Integration Plan
+
+*2026-04-29.*
+
+---
+
+## The Model: Everything Runs in Linux
+
+The correct architecture — confirmed by how Docker Desktop, Rancher Desktop, and Colima all solve the same problem on macOS — is that the entire Kubernetes stack runs **inside a Linux VM**. The Mac is a client. kubectl on macOS reaches the API server via a port-forwarded endpoint. There is no networking topology problem because the kubelet and the containers it manages are on the same network.
+
+```
+macOS host
+  kubectl ──────────────────────────────────────────────── port-forward :6443
+  pelagos --profile build vm ssh ──────────────────────── SSH / vsock shell
+
+  pelagos build VM (Ubuntu 24.04, 192.168.106.2)
+    rusternetes (api-server, scheduler, controller-manager, kubelet)
+    pelagos-dockerd                ← new binary, pelagos repo
+    pelagos (runtime)
+    containers                     ← same network as kubelet, no gap
+```
+
+This is not a compromise or workaround — it is the correct architecture. Running the control plane inside Linux and exposing only the API port to the Mac is exactly what every production-quality macOS Kubernetes implementation does.
+
+---
+
+## Development Environment: The Build VM
+
+All implementation and testing happens inside the **pelagos build VM** (Ubuntu 24.04, glibc, aarch64, at `192.168.106.2`). It already has:
+- Rust toolchain installed
+- pelagos source virtiofs-mounted at `/mnt/Projects/pelagos`
+- Standard `cargo build --release` works (glibc, no zigbuild needed)
+- SSH access via `pelagos --profile build vm ssh`
+
+Rusternetes is compiled for Linux glibc inside this VM. Containers run in this VM via pelagos. The kubelet talks to pelagos-dockerd on a local Unix socket. Everything is local to one Linux environment.
+
+---
+
+## The Integration Point in Rusternetes
+
+The kubelet isolates all container operations in one struct: `ContainerRuntime` in `crates/kubelet/src/runtime.rs`, wrapping a `bollard::Docker` client. It connects via:
+
+```rust
+let docker = Docker::connect_with_local_defaults()?;
+```
+
+`connect_with_local_defaults()` respects `DOCKER_HOST`. Pointing it at the pelagos Docker socket requires no code change in rusternetes — only an environment variable.
+
+The kubelet uses approximately 12 Docker Engine API calls:
+
+| bollard call | Purpose |
+|---|---|
+| `docker.inspect_image()` | Check if image is cached locally |
+| `docker.create_image()` | Pull image from registry |
+| `docker.list_containers()` | Find containers by label |
+| `docker.create_container()` | Create (not yet start) a container |
+| `docker.start_container()` | Start a created container |
+| `docker.stop_container()` | Graceful stop |
+| `docker.kill_container()` | SIGKILL |
+| `docker.remove_container()` | Remove stopped container |
+| `docker.inspect_container()` | Get state, IP address, status |
+| `docker.create_exec()` / `start_exec()` | kubectl exec |
+| `docker.logs()` | Container log streaming |
+| `docker.stats()` | CPU/memory metrics |
+
+---
+
+## The Work: pelagos-dockerd
+
+A new binary in the **pelagos** repo. A Unix socket HTTP server implementing the subset of the Docker Engine REST API that rusternetes's kubelet actually calls. It translates each Docker API call into the equivalent pelagos library or CLI operation.
+
+This lives in pelagos, not pelagos-mac. It is a Linux binary. It has no knowledge of VMs, vsock, or macOS.
+
+**What it implements:**
+- HTTP server on a configurable Unix socket path
+- The ~12 Docker API endpoints listed above
+- Docker JSON request/response schemas mapped to pelagos operations
+- Docker exec HTTP upgrade + stdio framing (the most complex part)
+- Log streaming via chunked HTTP
+
+**What it does not implement:**
+- The full Docker Engine API (swarm, plugins, system events, etc.)
+- Anything rusternetes doesn't call
+
+**rusternetes changes:** Zero for the integration. `DOCKER_HOST=unix:///run/pelagos/dockerd.sock` in the environment is all that changes.
+
+---
+
+## Key Differences to Bridge (in pelagos-dockerd)
+
+| Docker/bollard behaviour | pelagos equivalent |
+|---|---|
+| Pause container for pod network namespace sharing | pelagos named bridge networks (N2b) handle multi-container net-ns sharing natively; shim synthesises fake pause container responses without starting one |
+| Container labels for pod tracking | pelagos has no label system — encode pod/container identity into container names |
+| Docker bridge assigns pod IPs, returned via inspect | pelagos N2 bridge assigns IPs — same concept, different query path |
+| `hostPath` / `emptyDir` as bind mounts | pelagos `with_bind_mount()` / `with_volume()` — direct equivalents |
+| Exec via HTTP upgrade + raw stdio | pelagos exec via framed binary protocol (type + u32 len + data) — translate in shim |
+| Log streaming via chunked HTTP | pelagos captures stdout/stderr — bridge to chunked HTTP in shim |
+| Stats from daemon (CPU, memory) | pelagos `child.resource_stats()` via cgroups-rs — map to Docker stats JSON |
+
+---
+
+## Phases
+
+**Phase 1 — pelagos-dockerd (pelagos repo)**
+New binary implementing the Docker Engine API subset. Test independently with `docker` CLI and bollard before involving rusternetes. Validate: `docker ps`, `docker run`, `docker exec`, `docker logs`.
+
+**Phase 2 — wire up rusternetes**
+Set `DOCKER_HOST=unix:///run/pelagos/dockerd.sock` in the kubelet environment. No code changes. Validate with a simple pod (`nginx`), then work up to Deployments, Services, and health probes.
+
+**Phase 3 — optional: expose API server to macOS**
+Run rusternetes with `-p 6443:6443` on the build VM profile. Set kubeconfig on macOS to `https://127.0.0.1:6443`. kubectl and the rusternetes web console become accessible from the Mac without SSH.
+
+**Phase 4 — optional: native Pelagos backend in rusternetes**
+Trait-ify `ContainerRuntime` in rusternetes's kubelet and add a `PelagosRuntime` that calls pelagos directly, removing the Docker API translation layer. Separable cleanup once the integration is proven.
+
+---
+
+## What pelagos-mac Does Not Need to Change
+
+Nothing, for this integration. pelagos-mac already supports port-forwarding (`-p host:guest`) for API server access. The Docker socket shim is a Linux binary in the pelagos repo. The networking topology problem that exists when running rusternetes on the macOS host does not exist when rusternetes runs inside the VM — which is the correct architecture.
+
+---
+
+## Files to Create / Modify
+
+| Location | What |
+|---|---|
+| `pelagos/src/bin/pelagos-dockerd.rs` (or `pelagos/crates/dockerd/`) | New Docker Engine API server |
+| `rusternetes/` — environment config | `DOCKER_HOST` pointing at pelagos socket |
+| `rusternetes/crates/kubelet/src/runtime.rs` | (Phase 4 only) Extract `ContainerRuntimeTrait` |
+| `rusternetes/crates/kubelet/src/kubelet.rs` | (Phase 4 only) `Arc<ContainerRuntime>` → `Arc<dyn ContainerRuntimeTrait>` |

--- a/src/bin/pelagos-dockerd/handlers/containers.rs
+++ b/src/bin/pelagos-dockerd/handlers/containers.rs
@@ -1,13 +1,13 @@
 use axum::{
     Json,
-    extract::{Path, Query},
+    extract::{Path, Query, State},
     http::StatusCode,
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
 use crate::{
     pelagos_state::{self, ContainerState},
-    state,
+    state::{self, AppState},
     types::{ContainerCreateBody, PendingContainer},
 };
 
@@ -110,11 +110,10 @@ pub async fn inspect(Path(id): Path<String>) -> (StatusCode, Json<Value>) {
 
 // ── Start ─────────────────────────────────────────────────────────────────────
 
-pub async fn start(Path(id): Path<String>) -> (StatusCode, Json<Value>) {
+pub async fn start(Path(id): Path<String>, State(app): State<AppState>) -> (StatusCode, Json<Value>) {
     let pending = match state::load_pending(&id) {
         Ok(p) => p,
         Err(_) => {
-            // Maybe already started?
             if pelagos_state::read_state(&id).is_ok() {
                 return (StatusCode::NOT_MODIFIED, Json(json!({})));
             }
@@ -126,7 +125,7 @@ pub async fn start(Path(id): Path<String>) -> (StatusCode, Json<Value>) {
     };
 
     log::info!("starting container: {}", id);
-    if let Err(e) = pelagos_state::run_container(&pending).await {
+    if let Err(e) = pelagos_state::run_container(app.pelagos_bin(), &pending).await {
         log::error!("start {}: {}", id, e);
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -145,9 +144,9 @@ pub struct StopQuery {
     pub t: Option<u32>,
 }
 
-pub async fn stop(Path(id): Path<String>, Query(q): Query<StopQuery>) -> (StatusCode, Json<Value>) {
+pub async fn stop(Path(id): Path<String>, Query(q): Query<StopQuery>, State(app): State<AppState>) -> (StatusCode, Json<Value>) {
     log::info!("stopping container: {}", id);
-    match pelagos_state::stop_container(&id, q.t).await {
+    match pelagos_state::stop_container(app.pelagos_bin(), &id, q.t).await {
         Ok(_) => (StatusCode::NO_CONTENT, Json(json!({}))),
         Err(e) => {
             if e.contains("not found") || e.contains("no such") {
@@ -166,10 +165,9 @@ pub struct KillQuery {
     pub signal: Option<String>,
 }
 
-pub async fn kill(Path(id): Path<String>, Query(_q): Query<KillQuery>) -> (StatusCode, Json<Value>) {
-    // pelagos stop sends SIGTERM; use it for kill too
+pub async fn kill(Path(id): Path<String>, Query(_q): Query<KillQuery>, State(app): State<AppState>) -> (StatusCode, Json<Value>) {
     log::info!("killing container: {}", id);
-    match pelagos_state::stop_container(&id, Some(0)).await {
+    match pelagos_state::stop_container(app.pelagos_bin(), &id, Some(0)).await {
         Ok(_) => (StatusCode::NO_CONTENT, Json(json!({}))),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"message": e}))),
     }
@@ -185,11 +183,11 @@ pub struct RemoveQuery {
     pub v: Option<String>,
 }
 
-pub async fn remove(Path(id): Path<String>, Query(q): Query<RemoveQuery>) -> (StatusCode, Json<Value>) {
+pub async fn remove(Path(id): Path<String>, Query(q): Query<RemoveQuery>, State(app): State<AppState>) -> (StatusCode, Json<Value>) {
     let force = q.force.as_deref().map(|v| v == "true" || v == "1").unwrap_or(false);
     state::remove_pending(&id);
     log::info!("removing container: {} (force={})", id, force);
-    match pelagos_state::remove_container(&id, force).await {
+    match pelagos_state::remove_container(app.pelagos_bin(), &id, force).await {
         Ok(_) => (StatusCode::NO_CONTENT, Json(json!({}))),
         Err(e) => {
             if e.contains("not found") || e.contains("no such") {

--- a/src/bin/pelagos-dockerd/handlers/containers.rs
+++ b/src/bin/pelagos-dockerd/handlers/containers.rs
@@ -1,0 +1,454 @@
+use axum::{
+    Json,
+    extract::{Path, Query},
+    http::StatusCode,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use crate::{
+    pelagos_state::{self, ContainerState},
+    state,
+    types::{ContainerCreateBody, PendingContainer},
+};
+
+// ── List ─────────────────────────────────────────────────────────────────────
+
+#[derive(Deserialize, Default)]
+pub struct ListQuery {
+    #[serde(default)]
+    pub all: Option<String>,
+    #[serde(default)]
+    pub filters: Option<String>,
+}
+
+pub async fn list(Query(q): Query<ListQuery>) -> (StatusCode, Json<Value>) {
+    let show_all = q.all.as_deref().map(|v| v == "true" || v == "1").unwrap_or(false);
+
+    let label_filters = parse_label_filters(q.filters.as_deref());
+
+    let mut items: Vec<Value> = Vec::new();
+
+    // Running/exited containers from pelagos state
+    for c in pelagos_state::list_states() {
+        if !show_all && !c.is_running() {
+            continue;
+        }
+        if !label_filters.is_empty() && !matches_labels(&c.labels, &label_filters) {
+            continue;
+        }
+        items.push(container_summary_json(&c));
+    }
+
+    // Pending (created but not started) containers
+    for p in state::list_pending() {
+        if !show_all {
+            continue;
+        }
+        if !label_filters.is_empty() && !matches_labels(&p.labels, &label_filters) {
+            continue;
+        }
+        items.push(pending_summary_json(&p));
+    }
+
+    (StatusCode::OK, Json(Value::Array(items)))
+}
+
+// ── Create ────────────────────────────────────────────────────────────────────
+
+#[derive(Deserialize, Default)]
+pub struct CreateQuery {
+    pub name: Option<String>,
+}
+
+pub async fn create(
+    Query(q): Query<CreateQuery>,
+    Json(body): Json<ContainerCreateBody>,
+) -> (StatusCode, Json<Value>) {
+    let name = match q.name {
+        Some(n) if !n.is_empty() => n,
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"message": "container name is required"})),
+            );
+        }
+    };
+
+    if pelagos_state::read_state(&name).is_ok() || state::load_pending(&name).is_ok() {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({"message": format!("container '{}' already exists", name)})),
+        );
+    }
+
+    let pending = PendingContainer::from_create(name.clone(), body);
+    if let Err(e) = state::save_pending(&pending) {
+        log::error!("save pending {}: {}", name, e);
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"message": e.to_string()})),
+        );
+    }
+
+    log::info!("created container: {}", name);
+    (StatusCode::CREATED, Json(json!({"Id": name, "Warnings": []})))
+}
+
+// ── Inspect ───────────────────────────────────────────────────────────────────
+
+pub async fn inspect(Path(id): Path<String>) -> (StatusCode, Json<Value>) {
+    // Running/exited container
+    if let Ok(c) = pelagos_state::read_state(&id) {
+        return (StatusCode::OK, Json(container_inspect_json(&c)));
+    }
+    // Pending (created, not started)
+    if let Ok(p) = state::load_pending(&id) {
+        return (StatusCode::OK, Json(pending_inspect_json(&p)));
+    }
+    (StatusCode::NOT_FOUND, Json(json!({"message": format!("container '{}' not found", id)})))
+}
+
+// ── Start ─────────────────────────────────────────────────────────────────────
+
+pub async fn start(Path(id): Path<String>) -> (StatusCode, Json<Value>) {
+    let pending = match state::load_pending(&id) {
+        Ok(p) => p,
+        Err(_) => {
+            // Maybe already started?
+            if pelagos_state::read_state(&id).is_ok() {
+                return (StatusCode::NOT_MODIFIED, Json(json!({})));
+            }
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"message": format!("container '{}' not found", id)})),
+            );
+        }
+    };
+
+    log::info!("starting container: {}", id);
+    if let Err(e) = pelagos_state::run_container(&pending).await {
+        log::error!("start {}: {}", id, e);
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"message": e})),
+        );
+    }
+
+    state::remove_pending(&id);
+    (StatusCode::NO_CONTENT, Json(json!({})))
+}
+
+// ── Stop ──────────────────────────────────────────────────────────────────────
+
+#[derive(Deserialize, Default)]
+pub struct StopQuery {
+    pub t: Option<u32>,
+}
+
+pub async fn stop(Path(id): Path<String>, Query(q): Query<StopQuery>) -> (StatusCode, Json<Value>) {
+    log::info!("stopping container: {}", id);
+    match pelagos_state::stop_container(&id, q.t).await {
+        Ok(_) => (StatusCode::NO_CONTENT, Json(json!({}))),
+        Err(e) => {
+            if e.contains("not found") || e.contains("no such") {
+                (StatusCode::NOT_FOUND, Json(json!({"message": e})))
+            } else {
+                (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"message": e})))
+            }
+        }
+    }
+}
+
+// ── Kill ──────────────────────────────────────────────────────────────────────
+
+#[derive(Deserialize, Default)]
+pub struct KillQuery {
+    pub signal: Option<String>,
+}
+
+pub async fn kill(Path(id): Path<String>, Query(_q): Query<KillQuery>) -> (StatusCode, Json<Value>) {
+    // pelagos stop sends SIGTERM; use it for kill too
+    log::info!("killing container: {}", id);
+    match pelagos_state::stop_container(&id, Some(0)).await {
+        Ok(_) => (StatusCode::NO_CONTENT, Json(json!({}))),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"message": e}))),
+    }
+}
+
+// ── Remove ────────────────────────────────────────────────────────────────────
+
+#[derive(Deserialize, Default)]
+pub struct RemoveQuery {
+    #[serde(default)]
+    pub force: Option<String>,
+    #[serde(default)]
+    pub v: Option<String>,
+}
+
+pub async fn remove(Path(id): Path<String>, Query(q): Query<RemoveQuery>) -> (StatusCode, Json<Value>) {
+    let force = q.force.as_deref().map(|v| v == "true" || v == "1").unwrap_or(false);
+    state::remove_pending(&id);
+    log::info!("removing container: {} (force={})", id, force);
+    match pelagos_state::remove_container(&id, force).await {
+        Ok(_) => (StatusCode::NO_CONTENT, Json(json!({}))),
+        Err(e) => {
+            if e.contains("not found") || e.contains("no such") {
+                (StatusCode::NOT_FOUND, Json(json!({"message": e})))
+            } else {
+                (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"message": e})))
+            }
+        }
+    }
+}
+
+// ── Wait ──────────────────────────────────────────────────────────────────────
+
+pub async fn wait(Path(id): Path<String>) -> (StatusCode, Json<Value>) {
+    // Poll until container exits
+    loop {
+        match pelagos_state::read_state(&id) {
+            Ok(c) if !c.is_running() => {
+                return (StatusCode::OK, Json(json!({"StatusCode": c.exit_code.unwrap_or(0)})));
+            }
+            Err(_) => {
+                return (StatusCode::NOT_FOUND, Json(json!({"message": format!("container '{}' not found", id)})));
+            }
+            _ => {}
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+}
+
+// ── Logs ──────────────────────────────────────────────────────────────────────
+
+#[derive(Deserialize, Default)]
+pub struct LogsQuery {
+    #[serde(default)]
+    pub stdout: Option<String>,
+    #[serde(default)]
+    pub stderr: Option<String>,
+    #[serde(default)]
+    pub tail: Option<String>,
+}
+
+pub async fn logs(Path(id): Path<String>, Query(_q): Query<LogsQuery>) -> (StatusCode, Json<Value>) {
+    let c = match pelagos_state::read_state(&id) {
+        Ok(c) => c,
+        Err(_) => {
+            return (StatusCode::NOT_FOUND, Json(json!({"message": format!("container '{}' not found", id)})));
+        }
+    };
+
+    let mut output = String::new();
+    if let Some(log_path) = &c.stdout_log {
+        if let Ok(data) = std::fs::read_to_string(log_path) {
+            output.push_str(&data);
+        }
+    }
+
+    // Return raw text for now (exec logs use multiplexed stream format, but
+    // a plain text body works for simple log reading use cases)
+    (StatusCode::OK, Json(json!({"logs": output})))
+}
+
+// ── Stats ─────────────────────────────────────────────────────────────────────
+
+pub async fn stats(Path(id): Path<String>) -> (StatusCode, Json<Value>) {
+    let c = match pelagos_state::read_state(&id) {
+        Ok(c) => c,
+        Err(_) => {
+            return (StatusCode::NOT_FOUND, Json(json!({"message": format!("container '{}' not found", id)})));
+        }
+    };
+
+    let (cpu_ns, mem_bytes) = read_cgroup_stats(c.cgroup_name.as_deref());
+
+    (StatusCode::OK, Json(json!({
+        "id": id,
+        "cpu_stats": {
+            "cpu_usage": {
+                "total_usage": cpu_ns
+            },
+            "system_cpu_usage": read_system_cpu_ns()
+        },
+        "memory_stats": {
+            "usage": mem_bytes
+        },
+        "networks": {}
+    })))
+}
+
+fn read_cgroup_stats(cgroup: Option<&str>) -> (u64, u64) {
+    let Some(cg) = cgroup else { return (0, 0) };
+    let cpu = read_cpu_ns(cg);
+    let mem = read_mem_bytes(cg);
+    (cpu, mem)
+}
+
+fn read_cpu_ns(cg: &str) -> u64 {
+    let path = format!("/sys/fs/cgroup/{}/cpu.stat", cg);
+    let Ok(data) = std::fs::read_to_string(&path) else { return 0 };
+    for line in data.lines() {
+        if let Some(rest) = line.strip_prefix("usage_usec ") {
+            if let Ok(usec) = rest.trim().parse::<u64>() {
+                return usec * 1000; // to nanoseconds
+            }
+        }
+    }
+    0
+}
+
+fn read_mem_bytes(cg: &str) -> u64 {
+    let path = format!("/sys/fs/cgroup/{}/memory.current", cg);
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(0)
+}
+
+fn read_system_cpu_ns() -> u64 {
+    let Ok(data) = std::fs::read_to_string("/proc/stat") else { return 0 };
+    let line = data.lines().next().unwrap_or("");
+    let fields: Vec<&str> = line.split_whitespace().collect();
+    // Fields 1..=8: user nice system idle iowait irq softirq steal
+    let ticks: u64 = fields[1..].iter()
+        .take(8)
+        .filter_map(|s| s.parse::<u64>().ok())
+        .sum();
+    // Convert jiffies (typically 100Hz) to nanoseconds
+    ticks * 10_000_000
+}
+
+// ── JSON builders ─────────────────────────────────────────────────────────────
+
+fn container_summary_json(c: &ContainerState) -> Value {
+    let status_str = if c.is_running() {
+        "Up".to_string()
+    } else {
+        format!("Exited ({})", c.exit_code.unwrap_or(0))
+    };
+    json!({
+        "Id": c.name,
+        "Names": [format!("/{}", c.name)],
+        "Image": c.image(),
+        "ImageID": "",
+        "State": c.docker_status_str(),
+        "Status": status_str,
+        "Labels": c.labels,
+        "Created": 0
+    })
+}
+
+fn pending_summary_json(p: &PendingContainer) -> Value {
+    json!({
+        "Id": p.name,
+        "Names": [format!("/{}", p.name)],
+        "Image": p.image,
+        "ImageID": "",
+        "State": "created",
+        "Status": "Created",
+        "Labels": p.labels,
+        "Created": 0
+    })
+}
+
+fn container_inspect_json(c: &ContainerState) -> Value {
+    let ip = c.bridge_ip.clone().unwrap_or_default();
+    let mut networks = serde_json::Map::new();
+    if !ip.is_empty() {
+        networks.insert("bridge".to_string(), json!({
+            "IPAddress": ip,
+            "Gateway": "172.19.0.1",
+            "MacAddress": ""
+        }));
+    }
+    json!({
+        "Id": c.name,
+        "Name": format!("/{}", c.name),
+        "State": {
+            "Status": c.docker_status_str(),
+            "Running": c.is_running(),
+            "Paused": false,
+            "Restarting": false,
+            "Dead": false,
+            "Pid": c.pid,
+            "ExitCode": c.exit_code.unwrap_or(0),
+            "StartedAt": c.started_at,
+            "FinishedAt": if c.is_running() { "0001-01-01T00:00:00Z".to_string() } else { c.started_at.clone() }
+        },
+        "Config": {
+            "Image": c.image(),
+            "Cmd": c.command,
+            "Env": c.env(),
+            "Labels": c.labels,
+            "WorkingDir": c.spawn_config.as_ref().and_then(|sc| sc.working_dir.as_deref()).unwrap_or("")
+        },
+        "HostConfig": {
+            "NetworkMode": c.network_mode(),
+            "Binds": c.binds()
+        },
+        "NetworkSettings": {
+            "IPAddress": ip,
+            "Networks": networks
+        }
+    })
+}
+
+fn pending_inspect_json(p: &PendingContainer) -> Value {
+    json!({
+        "Id": p.name,
+        "Name": format!("/{}", p.name),
+        "State": {
+            "Status": "created",
+            "Running": false,
+            "Paused": false,
+            "Restarting": false,
+            "Dead": false,
+            "Pid": 0,
+            "ExitCode": 0,
+            "StartedAt": "0001-01-01T00:00:00Z",
+            "FinishedAt": "0001-01-01T00:00:00Z"
+        },
+        "Config": {
+            "Image": p.image,
+            "Cmd": p.cmd,
+            "Env": p.env,
+            "Labels": p.labels,
+            "WorkingDir": p.working_dir.as_deref().unwrap_or("")
+        },
+        "HostConfig": {
+            "NetworkMode": p.network_mode,
+            "Binds": p.binds
+        },
+        "NetworkSettings": {
+            "IPAddress": "",
+            "Networks": {}
+        }
+    })
+}
+
+fn parse_label_filters(raw: Option<&str>) -> Vec<(String, String)> {
+    let Some(raw) = raw else { return Vec::new() };
+    // filters={"label":["key=value","key2=value2"]}
+    let Ok(parsed) = serde_json::from_str::<Value>(raw) else { return Vec::new() };
+    let Some(labels) = parsed.get("label").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    labels
+        .iter()
+        .filter_map(|v| v.as_str())
+        .filter_map(|s| {
+            let (k, v) = s.split_once('=')?;
+            Some((k.to_string(), v.to_string()))
+        })
+        .collect()
+}
+
+fn matches_labels(
+    container_labels: &std::collections::HashMap<String, String>,
+    filters: &[(String, String)],
+) -> bool {
+    filters.iter().all(|(k, v)| {
+        container_labels.get(k).map(|cv| cv == v).unwrap_or(false)
+    })
+}

--- a/src/bin/pelagos-dockerd/handlers/exec.rs
+++ b/src/bin/pelagos-dockerd/handlers/exec.rs
@@ -4,6 +4,7 @@ use axum::{
     http::StatusCode,
 };
 use serde_json::{json, Value};
+use tokio::process::Command;
 use uuid::Uuid;
 use crate::{
     pelagos_state,
@@ -64,7 +65,7 @@ pub async fn start(
         body.detach
     );
 
-    let mut cmd = tokio::process::Command::new("pelagos");
+    let mut cmd = Command::new(app.pelagos_bin());
     cmd.arg("exec");
 
     if let Some(wd) = &session.working_dir {

--- a/src/bin/pelagos-dockerd/handlers/exec.rs
+++ b/src/bin/pelagos-dockerd/handlers/exec.rs
@@ -65,7 +65,7 @@ pub async fn start(
         body.detach
     );
 
-    let mut cmd = Command::new(app.pelagos_bin());
+    let mut cmd = Command::new(state.pelagos_bin());
     cmd.arg("exec");
 
     if let Some(wd) = &session.working_dir {

--- a/src/bin/pelagos-dockerd/handlers/exec.rs
+++ b/src/bin/pelagos-dockerd/handlers/exec.rs
@@ -1,0 +1,130 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+};
+use serde_json::{json, Value};
+use uuid::Uuid;
+use crate::{
+    pelagos_state,
+    state::AppState,
+    types::{ExecCreateBody, ExecSession, ExecStartBody},
+};
+
+/// POST /containers/{id}/exec — create an exec instance.
+pub async fn create(
+    Path(container_id): Path<String>,
+    State(state): State<AppState>,
+    Json(body): Json<ExecCreateBody>,
+) -> (StatusCode, Json<Value>) {
+    // Verify container exists
+    if pelagos_state::read_state(&container_id).is_err() {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({"message": format!("container '{}' not found", container_id)})),
+        );
+    }
+
+    let exec_id = Uuid::new_v4().to_string();
+    let session = ExecSession {
+        container_name: container_id.clone(),
+        cmd: body.cmd,
+        tty: body.tty,
+        env: body.env.unwrap_or_default(),
+        working_dir: body.working_dir,
+        user: body.user,
+    };
+    state.add_exec(exec_id.clone(), session).await;
+
+    log::debug!("created exec {} for container {}", exec_id, container_id);
+    (StatusCode::CREATED, Json(json!({"Id": exec_id})))
+}
+
+/// POST /exec/{id}/start — run the exec instance.
+pub async fn start(
+    Path(exec_id): Path<String>,
+    State(state): State<AppState>,
+    Json(body): Json<ExecStartBody>,
+) -> (StatusCode, Json<Value>) {
+    let session = match state.get_exec(&exec_id).await {
+        Some(s) => s,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"message": format!("exec '{}' not found", exec_id)})),
+            );
+        }
+    };
+
+    log::info!(
+        "exec {} on {}: {:?} (detach={})",
+        exec_id,
+        session.container_name,
+        session.cmd,
+        body.detach
+    );
+
+    let mut cmd = tokio::process::Command::new("pelagos");
+    cmd.arg("exec");
+
+    if let Some(wd) = &session.working_dir {
+        cmd.arg("--workdir").arg(wd);
+    }
+    if let Some(user) = &session.user {
+        cmd.arg("--user").arg(user);
+    }
+    for e in &session.env {
+        cmd.arg("--env").arg(e);
+    }
+
+    cmd.arg("--");
+    cmd.arg(&session.container_name);
+    for arg in &session.cmd {
+        cmd.arg(arg);
+    }
+
+    match cmd.output().await {
+        Ok(out) => {
+            let exit_code = out.status.code().unwrap_or(1);
+            let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+            let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+            state.remove_exec(&exec_id).await;
+            if body.detach {
+                (StatusCode::OK, Json(json!({})))
+            } else {
+                (StatusCode::OK, Json(json!({
+                    "ExitCode": exit_code,
+                    "Stdout": stdout,
+                    "Stderr": stderr
+                })))
+            }
+        }
+        Err(e) => {
+            log::error!("exec {} failed: {}", exec_id, e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"message": e.to_string()})),
+            )
+        }
+    }
+}
+
+/// GET /exec/{id}/json — inspect an exec instance.
+pub async fn inspect(
+    Path(exec_id): Path<String>,
+    State(state): State<AppState>,
+) -> (StatusCode, Json<Value>) {
+    match state.get_exec(&exec_id).await {
+        Some(s) => (StatusCode::OK, Json(json!({
+            "ID": exec_id,
+            "ContainerID": s.container_name,
+            "Running": true,
+            "ExitCode": null,
+            "ProcessConfig": {
+                "entrypoint": s.cmd.first().cloned().unwrap_or_default(),
+                "arguments": s.cmd.get(1..).unwrap_or(&[]).to_vec()
+            }
+        }))),
+        None => (StatusCode::NOT_FOUND, Json(json!({"message": "exec not found"}))),
+    }
+}

--- a/src/bin/pelagos-dockerd/handlers/images.rs
+++ b/src/bin/pelagos-dockerd/handlers/images.rs
@@ -1,11 +1,11 @@
 use axum::{
     Json,
-    extract::{Path, Query},
+    extract::{Path, Query, State},
     http::StatusCode,
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
-use crate::pelagos_state;
+use crate::{pelagos_state, state::AppState};
 
 #[derive(Deserialize)]
 pub struct CreateQuery {
@@ -15,7 +15,7 @@ pub struct CreateQuery {
 }
 
 /// POST /images/create?fromImage=...&tag=...
-pub async fn create(Query(q): Query<CreateQuery>) -> (StatusCode, Json<Value>) {
+pub async fn create(Query(q): Query<CreateQuery>, State(app): State<AppState>) -> (StatusCode, Json<Value>) {
     let Some(from_image) = q.from_image else {
         return (StatusCode::BAD_REQUEST, Json(json!({"message": "fromImage is required"})));
     };
@@ -26,7 +26,7 @@ pub async fn create(Query(q): Query<CreateQuery>) -> (StatusCode, Json<Value>) {
     };
 
     log::info!("pulling image: {}", image);
-    match pelagos_state::pull_image(&image).await {
+    match pelagos_state::pull_image(app.pelagos_bin(), &image).await {
         Ok(output) => {
             let text = String::from_utf8_lossy(&output);
             // Emit Docker-style progress lines
@@ -51,9 +51,9 @@ pub async fn create(Query(q): Query<CreateQuery>) -> (StatusCode, Json<Value>) {
 }
 
 /// GET /images/{name}/json
-pub async fn inspect(Path(name): Path<String>) -> (StatusCode, Json<Value>) {
+pub async fn inspect(Path(name): Path<String>, State(app): State<AppState>) -> (StatusCode, Json<Value>) {
     let name = urlencoding_decode(&name);
-    let images = match pelagos_state::list_images_json().await {
+    let images = match pelagos_state::list_images_json(app.pelagos_bin()).await {
         Ok(v) => v,
         Err(e) => {
             log::warn!("list images failed: {}", e);

--- a/src/bin/pelagos-dockerd/handlers/images.rs
+++ b/src/bin/pelagos-dockerd/handlers/images.rs
@@ -1,0 +1,118 @@
+use axum::{
+    Json,
+    extract::{Path, Query},
+    http::StatusCode,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use crate::pelagos_state;
+
+#[derive(Deserialize)]
+pub struct CreateQuery {
+    #[serde(rename = "fromImage")]
+    pub from_image: Option<String>,
+    pub tag: Option<String>,
+}
+
+/// POST /images/create?fromImage=...&tag=...
+pub async fn create(Query(q): Query<CreateQuery>) -> (StatusCode, Json<Value>) {
+    let Some(from_image) = q.from_image else {
+        return (StatusCode::BAD_REQUEST, Json(json!({"message": "fromImage is required"})));
+    };
+    let image = if let Some(tag) = q.tag.filter(|t| !t.is_empty()) {
+        format!("{}:{}", from_image, tag)
+    } else {
+        from_image
+    };
+
+    log::info!("pulling image: {}", image);
+    match pelagos_state::pull_image(&image).await {
+        Ok(output) => {
+            let text = String::from_utf8_lossy(&output);
+            // Emit Docker-style progress lines
+            let mut lines = Vec::new();
+            for line in text.lines() {
+                if !line.is_empty() {
+                    lines.push(format!("{{\"status\":\"{}\",\"progressDetail\":{{}}}}", escape_json_str(line)));
+                }
+            }
+            lines.push(format!(
+                "{{\"status\":\"Status: Downloaded newer image for {}\",\"progressDetail\":{{}}}}",
+                image
+            ));
+            let body = lines.join("\n");
+            (StatusCode::OK, Json(json!({"status": "pull complete", "raw": body})))
+        }
+        Err(e) => {
+            log::error!("pull {} failed: {}", image, e);
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"message": e})))
+        }
+    }
+}
+
+/// GET /images/{name}/json
+pub async fn inspect(Path(name): Path<String>) -> (StatusCode, Json<Value>) {
+    let name = urlencoding_decode(&name);
+    let images = match pelagos_state::list_images_json().await {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn!("list images failed: {}", e);
+            return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"message": e})));
+        }
+    };
+
+    let matched = images.iter().find(|img| {
+        img.get("reference")
+            .and_then(|r| r.as_str())
+            .map(|r| image_matches(r, &name))
+            .unwrap_or(false)
+    });
+
+    match matched {
+        Some(img) => {
+            let reference = img.get("reference").and_then(|r| r.as_str()).unwrap_or(&name);
+            let digest = img.get("digest").and_then(|d| d.as_str()).unwrap_or("");
+            (StatusCode::OK, Json(json!({
+                "Id": format!("{}", digest),
+                "RepoTags": [reference],
+                "RepoDigests": [format!("{}@{}", reference, digest)],
+                "Size": 10000000,
+                "VirtualSize": 10000000,
+                "Os": "linux",
+                "Architecture": "arm64",
+                "Created": "2024-01-01T00:00:00Z"
+            })))
+        }
+        None => (StatusCode::NOT_FOUND, Json(json!({"message": format!("image {} not found", name)}))),
+    }
+}
+
+fn image_matches(stored: &str, requested: &str) -> bool {
+    if stored == requested {
+        return true;
+    }
+    // "alpine" matches "alpine:latest"
+    let stored_norm = normalize_ref(stored);
+    let req_norm = normalize_ref(requested);
+    stored_norm == req_norm
+        || stored_norm.ends_with(&format!("/{}", req_norm))
+        || req_norm.ends_with(&format!("/{}", stored_norm))
+}
+
+fn normalize_ref(r: &str) -> String {
+    if r.contains(':') || r.contains('@') {
+        r.to_string()
+    } else {
+        format!("{}:latest", r)
+    }
+}
+
+fn urlencoding_decode(s: &str) -> String {
+    // Axum already URL-decodes path segments, but handle the special case
+    // where Docker clients encode "/" in image names as "%2F".
+    s.replace("%2F", "/").replace("%3A", ":")
+}
+
+fn escape_json_str(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}

--- a/src/bin/pelagos-dockerd/handlers/mod.rs
+++ b/src/bin/pelagos-dockerd/handlers/mod.rs
@@ -1,0 +1,40 @@
+//! Axum router and handler modules for the Docker Engine API.
+
+use axum::{Router, routing};
+use crate::state::AppState;
+
+mod containers;
+mod exec;
+mod images;
+mod version;
+
+pub fn router(state: AppState) -> Router {
+    Router::new()
+        // Ping / version / info
+        .route("/_ping", routing::get(ping).head(ping))
+        .route("/version", routing::get(version::version))
+        .route("/info", routing::get(version::info))
+        // Images — literal routes before parameterized ones
+        .route("/images/create", routing::post(images::create))
+        .route("/images/:name/json", routing::get(images::inspect))
+        // Containers — literal /json before /:id
+        .route("/containers/json", routing::get(containers::list))
+        .route("/containers/create", routing::post(containers::create))
+        .route("/containers/:id/json", routing::get(containers::inspect))
+        .route("/containers/:id/start", routing::post(containers::start))
+        .route("/containers/:id/stop", routing::post(containers::stop))
+        .route("/containers/:id/kill", routing::post(containers::kill))
+        .route("/containers/:id", routing::delete(containers::remove))
+        .route("/containers/:id/wait", routing::post(containers::wait))
+        .route("/containers/:id/logs", routing::get(containers::logs))
+        .route("/containers/:id/stats", routing::get(containers::stats))
+        // Exec
+        .route("/containers/:id/exec", routing::post(exec::create))
+        .route("/exec/:id/start", routing::post(exec::start))
+        .route("/exec/:id/json", routing::get(exec::inspect))
+        .with_state(state)
+}
+
+async fn ping() -> &'static str {
+    "OK"
+}

--- a/src/bin/pelagos-dockerd/handlers/version.rs
+++ b/src/bin/pelagos-dockerd/handlers/version.rs
@@ -1,0 +1,60 @@
+use axum::{Json, http::StatusCode};
+use serde_json::{json, Value};
+
+pub async fn version() -> (StatusCode, Json<Value>) {
+    let arch = if cfg!(target_arch = "aarch64") { "arm64" } else { "amd64" };
+    (StatusCode::OK, Json(json!({
+        "Version": "24.0.0",
+        "ApiVersion": "1.41",
+        "MinAPIVersion": "1.24",
+        "Os": "linux",
+        "Arch": arch,
+        "KernelVersion": "6.1.0",
+        "BuildTime": "2024-01-01T00:00:00.000000000+00:00",
+        "GitCommit": "pelagos-dockerd",
+        "GoVersion": "go1.21.0",
+        "Components": []
+    })))
+}
+
+pub async fn info() -> (StatusCode, Json<Value>) {
+    let arch = if cfg!(target_arch = "aarch64") { "aarch64" } else { "x86_64" };
+    (StatusCode::OK, Json(json!({
+        "ID": "pelagos-dockerd",
+        "Containers": 0,
+        "ContainersRunning": 0,
+        "ContainersPaused": 0,
+        "ContainersStopped": 0,
+        "Images": 0,
+        "Driver": "overlay2",
+        "MemoryLimit": true,
+        "SwapLimit": true,
+        "KernelMemory": false,
+        "CpuCfsPeriod": true,
+        "CpuCfsQuota": true,
+        "CPUShares": true,
+        "CPUSet": true,
+        "IPv4Forwarding": true,
+        "BridgeNfIptables": false,
+        "BridgeNfIp6tables": false,
+        "Debug": false,
+        "OomKillDisable": false,
+        "NGoroutines": 1,
+        "NEventsListener": 0,
+        "LoggingDriver": "json-file",
+        "CgroupDriver": "cgroupfs",
+        "CgroupVersion": "2",
+        "DockerRootDir": "/var/lib/pelagos",
+        "HttpProxy": "",
+        "HttpsProxy": "",
+        "NoProxy": "",
+        "Name": "pelagos-dockerd",
+        "ServerVersion": "24.0.0",
+        "OperatingSystem": "Ubuntu 24.04",
+        "OSType": "linux",
+        "Architecture": arch,
+        "NCPU": 1,
+        "MemTotal": 0,
+        "IndexServerAddress": "https://index.docker.io/v1/"
+    })))
+}

--- a/src/bin/pelagos-dockerd/main.rs
+++ b/src/bin/pelagos-dockerd/main.rs
@@ -27,6 +27,9 @@ struct Args {
     /// Unix socket path to listen on.
     #[clap(long, default_value = "/var/run/pelagos-dockerd.sock")]
     socket: String,
+    /// Path to the pelagos binary.
+    #[clap(long, default_value = "pelagos")]
+    pelagos_bin: String,
 }
 
 #[cfg(target_os = "linux")]
@@ -59,7 +62,7 @@ async fn async_run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         std::fs::create_dir_all(parent)?;
     }
 
-    let app_state = state::AppState::new();
+    let app_state = state::AppState::new_with_bin(args.pelagos_bin.clone());
     let mut make_service = handlers::router(app_state).into_make_service();
 
     let listener = UnixListener::bind(&args.socket)?;

--- a/src/bin/pelagos-dockerd/main.rs
+++ b/src/bin/pelagos-dockerd/main.rs
@@ -47,6 +47,7 @@ fn linux_run() {
 async fn async_run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     use hyper::server::conn::http1;
     use hyper_util::rt::TokioIo;
+    use hyper_util::service::TowerToHyperService;
     use std::os::unix::fs::PermissionsExt;
     use tokio::net::UnixListener;
     use tower::Service;
@@ -71,6 +72,7 @@ async fn async_run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         let io = TokioIo::new(stream);
         let svc = make_service.call(()).await?;
         tokio::spawn(async move {
+            let svc = TowerToHyperService::new(svc);
             if let Err(e) = http1::Builder::new().serve_connection(io, svc).await {
                 log::debug!("connection error: {}", e);
             }

--- a/src/bin/pelagos-dockerd/main.rs
+++ b/src/bin/pelagos-dockerd/main.rs
@@ -1,0 +1,68 @@
+//! Docker Engine API server that delegates to the `pelagos` CLI.
+//! Linux-only binary.
+
+#[cfg(target_os = "linux")]
+mod pelagos_state;
+#[cfg(target_os = "linux")]
+mod state;
+#[cfg(target_os = "linux")]
+mod types;
+#[cfg(target_os = "linux")]
+mod handlers;
+
+fn main() {
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("pelagos-dockerd only runs on Linux");
+        std::process::exit(1);
+    }
+    #[cfg(target_os = "linux")]
+    linux_run();
+}
+
+#[cfg(target_os = "linux")]
+#[derive(clap::Parser)]
+#[clap(name = "pelagos-dockerd", about = "Docker Engine API shim for pelagos")]
+struct Args {
+    /// Unix socket path to listen on.
+    #[clap(long, default_value = "/var/run/pelagos-dockerd.sock")]
+    socket: String,
+}
+
+#[cfg(target_os = "linux")]
+fn linux_run() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    use clap::Parser;
+    let args = Args::parse();
+
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    if let Err(e) = rt.block_on(async_run(args)) {
+        log::error!("{}", e);
+        std::process::exit(1);
+    }
+}
+
+#[cfg(target_os = "linux")]
+async fn async_run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    use std::os::unix::fs::PermissionsExt;
+    use tokio::net::UnixListener;
+
+    if std::path::Path::new(&args.socket).exists() {
+        std::fs::remove_file(&args.socket)?;
+    }
+    if let Some(parent) = std::path::Path::new(&args.socket).parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let app_state = state::AppState::new();
+    let router = handlers::router(app_state);
+
+    let listener = UnixListener::bind(&args.socket)?;
+    std::fs::set_permissions(&args.socket, std::fs::Permissions::from_mode(0o660))?;
+
+    log::info!("listening on {}", args.socket);
+
+    axum::serve(listener, router).await?;
+    Ok(())
+}

--- a/src/bin/pelagos-dockerd/main.rs
+++ b/src/bin/pelagos-dockerd/main.rs
@@ -45,8 +45,11 @@ fn linux_run() {
 
 #[cfg(target_os = "linux")]
 async fn async_run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    use hyper::server::conn::http1;
+    use hyper_util::rt::TokioIo;
     use std::os::unix::fs::PermissionsExt;
     use tokio::net::UnixListener;
+    use tower::Service;
 
     if std::path::Path::new(&args.socket).exists() {
         std::fs::remove_file(&args.socket)?;
@@ -56,13 +59,21 @@ async fn async_run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let app_state = state::AppState::new();
-    let router = handlers::router(app_state);
+    let mut make_service = handlers::router(app_state).into_make_service();
 
     let listener = UnixListener::bind(&args.socket)?;
     std::fs::set_permissions(&args.socket, std::fs::Permissions::from_mode(0o660))?;
 
     log::info!("listening on {}", args.socket);
 
-    axum::serve(listener, router).await?;
-    Ok(())
+    loop {
+        let (stream, _) = listener.accept().await?;
+        let io = TokioIo::new(stream);
+        let svc = make_service.call(()).await?;
+        tokio::spawn(async move {
+            if let Err(e) = http1::Builder::new().serve_connection(io, svc).await {
+                log::debug!("connection error: {}", e);
+            }
+        });
+    }
 }

--- a/src/bin/pelagos-dockerd/pelagos_state.rs
+++ b/src/bin/pelagos-dockerd/pelagos_state.rs
@@ -141,8 +141,8 @@ pub fn list_states() -> Vec<ContainerState> {
 
 // ── CLI helpers ──────────────────────────────────────────────────────────────
 
-pub async fn run_container(p: &crate::types::PendingContainer) -> Result<(), String> {
-    let mut cmd = Command::new("pelagos");
+pub async fn run_container(bin: &str, p: &crate::types::PendingContainer) -> Result<(), String> {
+    let mut cmd = Command::new(bin);
     cmd.arg("run");
     cmd.arg("--name").arg(&p.name);
     cmd.arg("--detach");
@@ -198,8 +198,8 @@ pub async fn run_container(p: &crate::types::PendingContainer) -> Result<(), Str
     }
 }
 
-pub async fn stop_container(name: &str, timeout: Option<u32>) -> Result<(), String> {
-    let mut cmd = Command::new("pelagos");
+pub async fn stop_container(bin: &str, name: &str, timeout: Option<u32>) -> Result<(), String> {
+    let mut cmd = Command::new(bin);
     cmd.arg("stop");
     if let Some(t) = timeout {
         cmd.arg("--time").arg(t.to_string());
@@ -216,8 +216,8 @@ pub async fn stop_container(name: &str, timeout: Option<u32>) -> Result<(), Stri
     }
 }
 
-pub async fn remove_container(name: &str, force: bool) -> Result<(), String> {
-    let mut cmd = Command::new("pelagos");
+pub async fn remove_container(bin: &str, name: &str, force: bool) -> Result<(), String> {
+    let mut cmd = Command::new(bin);
     cmd.arg("rm");
     if force {
         cmd.arg("--force");
@@ -235,8 +235,8 @@ pub async fn remove_container(name: &str, force: bool) -> Result<(), String> {
 }
 
 /// Pull an image, returning stdout+stderr output for progress reporting.
-pub async fn pull_image(image: &str) -> Result<Vec<u8>, String> {
-    let out = Command::new("pelagos")
+pub async fn pull_image(bin: &str, image: &str) -> Result<Vec<u8>, String> {
+    let out = Command::new(bin)
         .args(["image", "pull", image])
         .output()
         .await
@@ -249,8 +249,8 @@ pub async fn pull_image(image: &str) -> Result<Vec<u8>, String> {
 }
 
 /// List images as JSON (calls `pelagos image ls --json`).
-pub async fn list_images_json() -> Result<Vec<serde_json::Value>, String> {
-    let out = Command::new("pelagos")
+pub async fn list_images_json(bin: &str) -> Result<Vec<serde_json::Value>, String> {
+    let out = Command::new(bin)
         .args(["image", "ls", "--json"])
         .output()
         .await

--- a/src/bin/pelagos-dockerd/pelagos_state.rs
+++ b/src/bin/pelagos-dockerd/pelagos_state.rs
@@ -1,0 +1,276 @@
+//! Read pelagos container state from disk and invoke the pelagos CLI.
+
+use serde::Deserialize;
+use std::collections::HashMap;
+use tokio::process::Command;
+
+const CONTAINERS_DIR: &str = "/run/pelagos/containers";
+
+// ── ContainerState (subset) ─────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContainerState {
+    pub name: String,
+    #[serde(rename = "status")]
+    pub status: ContainerStatus,
+    pub pid: i32,
+    pub started_at: String,
+    #[serde(default)]
+    pub exit_code: Option<i32>,
+    pub command: Vec<String>,
+    #[serde(default)]
+    pub stdout_log: Option<String>,
+    #[serde(default)]
+    pub stderr_log: Option<String>,
+    #[serde(default)]
+    pub bridge_ip: Option<String>,
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+    #[serde(default)]
+    pub spawn_config: Option<SpawnConfig>,
+    #[serde(default)]
+    pub network_ns_name: Option<String>,
+    #[serde(default)]
+    pub cgroup_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ContainerStatus {
+    Running,
+    Exited,
+    #[serde(other)]
+    Unknown,
+}
+
+impl ContainerState {
+    pub fn is_running(&self) -> bool {
+        self.status == ContainerStatus::Running
+    }
+
+    pub fn docker_status_str(&self) -> &str {
+        match self.status {
+            ContainerStatus::Running => "running",
+            ContainerStatus::Exited => "exited",
+            ContainerStatus::Unknown => "dead",
+        }
+    }
+
+    pub fn image(&self) -> &str {
+        self.spawn_config
+            .as_ref()
+            .and_then(|sc| sc.image.as_deref())
+            .unwrap_or("")
+    }
+
+    pub fn network_mode(&self) -> &str {
+        self.spawn_config
+            .as_ref()
+            .and_then(|sc| sc.network.first())
+            .map(|s| s.as_str())
+            .unwrap_or("bridge")
+    }
+
+    pub fn env(&self) -> Vec<String> {
+        self.spawn_config
+            .as_ref()
+            .map(|sc| sc.env.clone())
+            .unwrap_or_default()
+    }
+
+    pub fn binds(&self) -> Vec<String> {
+        self.spawn_config
+            .as_ref()
+            .map(|sc| {
+                let mut b = sc.bind.clone();
+                b.extend(sc.bind_ro.iter().map(|s| format!("{}:ro", s)));
+                b
+            })
+            .unwrap_or_default()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct SpawnConfig {
+    #[serde(default)]
+    pub image: Option<String>,
+    pub exe: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub env: Vec<String>,
+    #[serde(default)]
+    pub bind: Vec<String>,
+    #[serde(default)]
+    pub bind_ro: Vec<String>,
+    #[serde(default)]
+    pub network: Vec<String>,
+    #[serde(default)]
+    pub publish: Vec<String>,
+    #[serde(default)]
+    pub working_dir: Option<String>,
+    #[serde(default)]
+    pub user: Option<String>,
+    #[serde(default)]
+    pub hostname: Option<String>,
+    #[serde(default)]
+    pub labels: Vec<String>,
+}
+
+// ── State file I/O ───────────────────────────────────────────────────────────
+
+pub fn read_state(name: &str) -> std::io::Result<ContainerState> {
+    let path = format!("{}/{}/state.json", CONTAINERS_DIR, name);
+    let data = std::fs::read_to_string(&path)?;
+    serde_json::from_str(&data).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+pub fn list_states() -> Vec<ContainerState> {
+    let Ok(entries) = std::fs::read_dir(CONTAINERS_DIR) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            read_state(&name).ok()
+        })
+        .collect()
+}
+
+// ── CLI helpers ──────────────────────────────────────────────────────────────
+
+pub async fn run_container(p: &crate::types::PendingContainer) -> Result<(), String> {
+    let mut cmd = Command::new("pelagos");
+    cmd.arg("run");
+    cmd.arg("--name").arg(&p.name);
+    cmd.arg("--detach");
+
+    let net = translate_network_mode(&p.network_mode);
+    cmd.arg("--network").arg(&net);
+
+    for e in &p.env {
+        cmd.arg("--env").arg(e);
+    }
+    for b in &p.binds {
+        cmd.arg("--volume").arg(b);
+    }
+    for (k, v) in &p.labels {
+        cmd.arg("--label").arg(format!("{}={}", k, v));
+    }
+    if let Some(wd) = &p.working_dir {
+        cmd.arg("--workdir").arg(wd);
+    }
+    if let Some(user) = &p.user {
+        cmd.arg("--user").arg(user);
+    }
+    if let Some(hostname) = &p.hostname {
+        cmd.arg("--hostname").arg(hostname);
+    }
+    if let Some(mem) = p.memory {
+        if mem > 0 {
+            cmd.arg("--memory").arg(mem.to_string());
+        }
+    }
+    for cap in &p.cap_add {
+        cmd.arg("--cap-add").arg(cap);
+    }
+    for cap in &p.cap_drop {
+        cmd.arg("--cap-drop").arg(cap);
+    }
+
+    cmd.arg("--");
+    cmd.arg(&p.image);
+    for arg in &p.cmd {
+        cmd.arg(arg);
+    }
+
+    let out = cmd
+        .output()
+        .await
+        .map_err(|e| format!("exec pelagos: {}", e))?;
+
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&out.stderr).trim().to_string())
+    }
+}
+
+pub async fn stop_container(name: &str, timeout: Option<u32>) -> Result<(), String> {
+    let mut cmd = Command::new("pelagos");
+    cmd.arg("stop");
+    if let Some(t) = timeout {
+        cmd.arg("--time").arg(t.to_string());
+    }
+    cmd.arg(name);
+    let out = cmd
+        .output()
+        .await
+        .map_err(|e| format!("exec pelagos: {}", e))?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&out.stderr).trim().to_string())
+    }
+}
+
+pub async fn remove_container(name: &str, force: bool) -> Result<(), String> {
+    let mut cmd = Command::new("pelagos");
+    cmd.arg("rm");
+    if force {
+        cmd.arg("--force");
+    }
+    cmd.arg(name);
+    let out = cmd
+        .output()
+        .await
+        .map_err(|e| format!("exec pelagos: {}", e))?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&out.stderr).trim().to_string())
+    }
+}
+
+/// Pull an image, returning stdout+stderr output for progress reporting.
+pub async fn pull_image(image: &str) -> Result<Vec<u8>, String> {
+    let out = Command::new("pelagos")
+        .args(["image", "pull", image])
+        .output()
+        .await
+        .map_err(|e| format!("exec pelagos: {}", e))?;
+    if out.status.success() {
+        Ok(out.stdout)
+    } else {
+        Err(String::from_utf8_lossy(&out.stderr).trim().to_string())
+    }
+}
+
+/// List images as JSON (calls `pelagos image ls --json`).
+pub async fn list_images_json() -> Result<Vec<serde_json::Value>, String> {
+    let out = Command::new("pelagos")
+        .args(["image", "ls", "--json"])
+        .output()
+        .await
+        .map_err(|e| format!("exec pelagos: {}", e))?;
+    if !out.status.success() {
+        return Err(String::from_utf8_lossy(&out.stderr).trim().to_string());
+    }
+    let parsed: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout)
+        .unwrap_or_default();
+    Ok(parsed)
+}
+
+fn translate_network_mode(mode: &str) -> String {
+    match mode {
+        "bridge" | "" => "bridge".to_string(),
+        "none" => "loopback".to_string(),
+        "host" => {
+            log::warn!("network mode 'host' is not supported by pelagos; using no isolation");
+            "none".to_string()
+        }
+        other => other.to_string(), // "container:NAME" passes through unchanged
+    }
+}

--- a/src/bin/pelagos-dockerd/state.rs
+++ b/src/bin/pelagos-dockerd/state.rs
@@ -14,16 +14,26 @@ pub struct AppState {
 
 struct Inner {
     exec_sessions: Mutex<HashMap<String, ExecSession>>,
+    pub pelagos_bin: String,
 }
 
 impl AppState {
     pub fn new() -> Self {
+        Self::new_with_bin("pelagos".to_string())
+    }
+
+    pub fn new_with_bin(pelagos_bin: String) -> Self {
         let _ = std::fs::create_dir_all(PENDING_DIR);
         Self {
             inner: Arc::new(Inner {
                 exec_sessions: Mutex::new(HashMap::new()),
+                pelagos_bin,
             }),
         }
+    }
+
+    pub fn pelagos_bin(&self) -> &str {
+        &self.inner.pelagos_bin
     }
 
     pub async fn add_exec(&self, id: String, session: ExecSession) {

--- a/src/bin/pelagos-dockerd/state.rs
+++ b/src/bin/pelagos-dockerd/state.rs
@@ -1,0 +1,75 @@
+//! Shared daemon state: in-memory exec sessions + pending container configs.
+
+use crate::types::{ExecSession, PendingContainer};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+const PENDING_DIR: &str = "/run/pelagos-dockerd/pending";
+
+#[derive(Clone)]
+pub struct AppState {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    exec_sessions: Mutex<HashMap<String, ExecSession>>,
+}
+
+impl AppState {
+    pub fn new() -> Self {
+        let _ = std::fs::create_dir_all(PENDING_DIR);
+        Self {
+            inner: Arc::new(Inner {
+                exec_sessions: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+
+    pub async fn add_exec(&self, id: String, session: ExecSession) {
+        self.inner.exec_sessions.lock().await.insert(id, session);
+    }
+
+    pub async fn get_exec(&self, id: &str) -> Option<ExecSession> {
+        self.inner.exec_sessions.lock().await.get(id).cloned()
+    }
+
+    pub async fn remove_exec(&self, id: &str) {
+        self.inner.exec_sessions.lock().await.remove(id);
+    }
+}
+
+// ── Pending container persistence ───────────────────────────────────────────
+
+pub fn save_pending(c: &PendingContainer) -> std::io::Result<()> {
+    let _ = std::fs::create_dir_all(PENDING_DIR);
+    let path = format!("{}/{}.json", PENDING_DIR, c.name);
+    let json = serde_json::to_string(c)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    std::fs::write(path, json)
+}
+
+pub fn load_pending(name: &str) -> std::io::Result<PendingContainer> {
+    let path = format!("{}/{}.json", PENDING_DIR, name);
+    let data = std::fs::read_to_string(&path)?;
+    serde_json::from_str(&data).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+pub fn remove_pending(name: &str) {
+    let _ = std::fs::remove_file(format!("{}/{}.json", PENDING_DIR, name));
+}
+
+pub fn list_pending() -> Vec<PendingContainer> {
+    let Ok(entries) = std::fs::read_dir(PENDING_DIR) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().map(|x| x == "json").unwrap_or(false))
+        .filter_map(|e| {
+            std::fs::read_to_string(e.path())
+                .ok()
+                .and_then(|d| serde_json::from_str(&d).ok())
+        })
+        .collect()
+}

--- a/src/bin/pelagos-dockerd/types.rs
+++ b/src/bin/pelagos-dockerd/types.rs
@@ -1,0 +1,139 @@
+//! Docker API request/response types for pelagos-dockerd.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// ── Requests ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ContainerCreateBody {
+    pub image: String,
+    #[serde(default)]
+    pub cmd: Option<Vec<String>>,
+    #[serde(default)]
+    pub entrypoint: Option<Vec<String>>,
+    #[serde(default)]
+    pub env: Option<Vec<String>>,
+    #[serde(default)]
+    pub labels: Option<HashMap<String, String>>,
+    #[serde(default)]
+    pub working_dir: Option<String>,
+    #[serde(default)]
+    pub user: Option<String>,
+    #[serde(default)]
+    pub hostname: Option<String>,
+    #[serde(default)]
+    pub host_config: Option<HostConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct HostConfig {
+    #[serde(default)]
+    pub network_mode: Option<String>,
+    #[serde(default)]
+    pub binds: Option<Vec<String>>,
+    #[serde(default)]
+    pub memory: Option<i64>,
+    #[serde(default)]
+    pub cap_add: Option<Vec<String>>,
+    #[serde(default)]
+    pub cap_drop: Option<Vec<String>>,
+    #[serde(default)]
+    pub security_opt: Option<Vec<String>>,
+    #[serde(default)]
+    pub privileged: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ExecCreateBody {
+    #[serde(default)]
+    pub cmd: Vec<String>,
+    #[serde(default)]
+    pub attach_stdin: bool,
+    #[serde(default)]
+    pub attach_stdout: bool,
+    #[serde(default)]
+    pub attach_stderr: bool,
+    #[serde(default)]
+    pub tty: bool,
+    #[serde(default)]
+    pub env: Option<Vec<String>>,
+    #[serde(default)]
+    pub working_dir: Option<String>,
+    #[serde(default)]
+    pub user: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ExecStartBody {
+    #[serde(default)]
+    pub detach: bool,
+    #[serde(default)]
+    pub tty: bool,
+}
+
+// ── Pending container (stored locally, not yet started) ─────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingContainer {
+    pub name: String,
+    pub image: String,
+    pub cmd: Vec<String>,
+    pub env: Vec<String>,
+    pub labels: HashMap<String, String>,
+    pub network_mode: String,
+    pub binds: Vec<String>,
+    pub working_dir: Option<String>,
+    pub user: Option<String>,
+    pub hostname: Option<String>,
+    pub memory: Option<i64>,
+    pub cap_add: Vec<String>,
+    pub cap_drop: Vec<String>,
+}
+
+impl PendingContainer {
+    pub fn from_create(name: String, body: ContainerCreateBody) -> Self {
+        let hc = body.host_config.unwrap_or_default();
+        let cmd = if let Some(ep) = body.entrypoint {
+            let mut v = ep;
+            if let Some(c) = body.cmd {
+                v.extend(c);
+            }
+            v
+        } else {
+            body.cmd.unwrap_or_default()
+        };
+
+        Self {
+            name,
+            image: body.image,
+            cmd,
+            env: body.env.unwrap_or_default(),
+            labels: body.labels.unwrap_or_default(),
+            network_mode: hc.network_mode.unwrap_or_else(|| "bridge".to_string()),
+            binds: hc.binds.unwrap_or_default(),
+            working_dir: body.working_dir,
+            user: body.user,
+            hostname: body.hostname,
+            memory: hc.memory,
+            cap_add: hc.cap_add.unwrap_or_default(),
+            cap_drop: hc.cap_drop.unwrap_or_default(),
+        }
+    }
+}
+
+// ── Exec session ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct ExecSession {
+    pub container_name: String,
+    pub cmd: Vec<String>,
+    pub tty: bool,
+    pub env: Vec<String>,
+    pub working_dir: Option<String>,
+    pub user: Option<String>,
+}

--- a/tests/dockerd_smoke.rs
+++ b/tests/dockerd_smoke.rs
@@ -1,0 +1,108 @@
+//! Bollard smoke test against a running pelagos-dockerd instance.
+//!
+//! Requires pelagos-dockerd listening at /var/run/pelagos-dockerd.sock.
+//! Run with:
+//!   PELAGOS_DOCKERD_SOCK=/var/run/pelagos-dockerd.sock cargo test --test dockerd_smoke
+
+#[cfg(target_os = "linux")]
+mod smoke {
+    use bollard::Docker;
+    use bollard::container::{CreateContainerOptions, Config, StartContainerOptions, RemoveContainerOptions};
+    use bollard::models::HostConfig;
+
+    fn connect() -> Docker {
+        let sock = std::env::var("PELAGOS_DOCKERD_SOCK")
+            .unwrap_or_else(|_| "/var/run/pelagos-dockerd.sock".to_string());
+        Docker::connect_with_unix(&sock, 30, bollard::API_DEFAULT_VERSION).expect("connect")
+    }
+
+    #[tokio::test]
+    async fn version_returns_api_version() {
+        let docker = connect();
+        let v = docker.version().await.expect("version()");
+        let api = v.api_version.expect("ApiVersion missing");
+        assert!(!api.is_empty(), "ApiVersion is empty");
+        println!("ApiVersion: {}", api);
+    }
+
+    #[tokio::test]
+    async fn list_containers_returns_vec() {
+        let docker = connect();
+        let containers = docker
+            .list_containers(Some(bollard::container::ListContainersOptions::<String> {
+                all: true,
+                ..Default::default()
+            }))
+            .await
+            .expect("list_containers()");
+        println!("containers: {} found", containers.len());
+    }
+
+    #[tokio::test]
+    async fn create_start_inspect_remove() {
+        let docker = connect();
+        let name = "bollard-smoke-test";
+
+        // Clean up any leftover from previous run
+        let _ = docker
+            .remove_container(
+                name,
+                Some(RemoveContainerOptions { force: true, ..Default::default() }),
+            )
+            .await;
+
+        // Create
+        docker
+            .create_container(
+                Some(CreateContainerOptions { name, platform: None }),
+                Config {
+                    image: Some("alpine:latest"),
+                    cmd: Some(vec!["sleep", "10"]),
+                    host_config: Some(HostConfig {
+                        network_mode: Some("bridge".to_string()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("create_container()");
+
+        // Start
+        docker
+            .start_container(name, None::<StartContainerOptions<String>>)
+            .await
+            .expect("start_container()");
+
+        // Inspect
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        let info = docker.inspect_container(name, None).await.expect("inspect_container()");
+        let state = info.state.expect("State missing");
+        assert_eq!(state.running, Some(true), "container not running");
+        let ip = info
+            .network_settings
+            .expect("NetworkSettings missing")
+            .networks
+            .expect("Networks missing")
+            .get("bridge")
+            .and_then(|ep| ep.ip_address.clone())
+            .unwrap_or_default();
+        assert!(!ip.is_empty(), "bridge IP is empty");
+        println!("bridge IP: {}", ip);
+
+        // Remove (force stops + removes)
+        docker
+            .remove_container(
+                name,
+                Some(RemoveContainerOptions { force: true, ..Default::default() }),
+            )
+            .await
+            .expect("remove_container()");
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn smoke_tests_linux_only() {
+    // No-op on non-Linux.
+}


### PR DESCRIPTION
## Summary

Adds `pelagos-dockerd`, a new Linux-only binary that implements the Docker Engine API subset needed by bollard/rusternetes kubelet. It acts as a bridge between the Docker API and the `pelagos` CLI.

**Endpoints implemented:**
- `GET /_ping`, `GET /version`, `GET /info`
- `GET /images/{name}/json` — check if image exists locally
- `POST /images/create` — pull image via `pelagos image pull`
- `GET /containers/json` — list containers (supports `all` and `filters` params)
- `POST /containers/create` — store pending config (create/start are split as Docker requires)
- `GET /containers/{id}/json` — inspect container (running/exited/pending)
- `POST /containers/{id}/start` — start a previously created container
- `POST /containers/{id}/stop`, `/kill`, `/wait`
- `DELETE /containers/{id}`
- `GET /containers/{id}/logs`, `GET /containers/{id}/stats`
- `POST /containers/{id}/exec` + `POST /exec/{id}/start` (non-streaming Phase A)

**Architecture:**
- axum 0.7 on a `tokio::net::UnixListener`, using hyper accept loop (axum::serve only accepts TcpListener)
- Delegates all container operations to the `pelagos` CLI subprocess
- Reads state from `/run/pelagos/containers/`
- Stores pending (created-not-started) containers in `/run/pelagos-dockerd/pending/`
- `--pelagos-bin` arg for specifying binary path (defaults to `pelagos` in PATH)

**New deps (Linux-only):** axum 0.7, hyper 1, hyper-util 0.1, tower 0.4, uuid 1
tokio gains `process`/`fs`/`signal`/`macros` features.

## Test plan

- [x] Phase A: curl tests — 11/11 API endpoints verified (ping, version, info, image inspect, image pull, container create/inspect/start/stop/remove/list)
- [x] Phase B: bollard smoke tests — 3/3 passing: `version_returns_api_version`, `list_containers_returns_vec`, `create_start_inspect_remove`

## Usage

```bash
# Start (run as root in the build VM)
pelagos-dockerd --socket /var/run/pelagos-dockerd.sock --pelagos-bin /path/to/pelagos

# Test
DOCKER_HOST=unix:///var/run/pelagos-dockerd.sock docker version
PELAGOS_DOCKERD_SOCK=/var/run/pelagos-dockerd.sock cargo test --test dockerd_smoke
```

Part of #207 (rusternetes integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)