### PR TITLE
chore: cargo fmt, fix clippy warnings in pelagos-dockerd, bump to v0.60.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos"
-version = "0.60.9"
+version = "0.60.11"
 dependencies = [
  "axum",
  "bitflags 2.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pelagos"
-version = "0.60.9"
+version = "0.60.11"
 edition = "2021"
 rust-version = "1.76"
 description = "Fast Linux container runtime — OCI-compatible, namespaces, cgroups v2, seccomp, networking, image management"

--- a/src/bin/pelagos-dockerd/handlers/containers.rs
+++ b/src/bin/pelagos-dockerd/handlers/containers.rs
@@ -1,18 +1,17 @@
-use axum::{
-    Json,
-    body::Body,
-    extract::{Path, Query, State},
-    http::{Response, StatusCode},
-    response::IntoResponse,
-};
-use serde::Deserialize;
-use serde_json::{json, Value};
-use tokio::io::{AsyncBufReadExt, BufReader};
 use crate::{
     pelagos_state::{self, ContainerState},
     state::{self, AppState},
     types::{ContainerCreateBody, PendingContainer},
 };
+use axum::{
+    body::Body,
+    extract::{Path, Query, State},
+    http::{Response, StatusCode},
+    response::IntoResponse,
+    Json,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
 
 // ── List ─────────────────────────────────────────────────────────────────────
 
@@ -25,7 +24,11 @@ pub struct ListQuery {
 }
 
 pub async fn list(Query(q): Query<ListQuery>) -> (StatusCode, Json<Value>) {
-    let show_all = q.all.as_deref().map(|v| v == "true" || v == "1").unwrap_or(false);
+    let show_all = q
+        .all
+        .as_deref()
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false);
     let filters = parse_filters(q.filters.as_deref());
 
     let mut items: Vec<Value> = Vec::new();
@@ -40,7 +43,9 @@ pub async fn list(Query(q): Query<ListQuery>) -> (StatusCode, Json<Value>) {
         if !filters.names.is_empty() && !matches_name(&c.name, &filters.names) {
             continue;
         }
-        if !filters.statuses.is_empty() && !filters.statuses.iter().any(|s| s == c.docker_status_str()) {
+        if !filters.statuses.is_empty()
+            && !filters.statuses.iter().any(|s| s == c.docker_status_str())
+        {
             continue;
         }
         items.push(container_summary_json(&c));
@@ -103,7 +108,10 @@ pub async fn create(
     }
 
     log::info!("created container: {}", name);
-    (StatusCode::CREATED, Json(json!({"Id": name, "Warnings": []})))
+    (
+        StatusCode::CREATED,
+        Json(json!({"Id": name, "Warnings": []})),
+    )
 }
 
 // ── Inspect ───────────────────────────────────────────────────────────────────
@@ -117,12 +125,18 @@ pub async fn inspect(Path(id): Path<String>) -> (StatusCode, Json<Value>) {
     if let Ok(p) = state::load_pending(&id) {
         return (StatusCode::OK, Json(pending_inspect_json(&p)));
     }
-    (StatusCode::NOT_FOUND, Json(json!({"message": format!("container '{}' not found", id)})))
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({"message": format!("container '{}' not found", id)})),
+    )
 }
 
 // ── Start ─────────────────────────────────────────────────────────────────────
 
-pub async fn start(Path(id): Path<String>, State(app): State<AppState>) -> (StatusCode, Json<Value>) {
+pub async fn start(
+    Path(id): Path<String>,
+    State(app): State<AppState>,
+) -> (StatusCode, Json<Value>) {
     let pending = match state::load_pending(&id) {
         Ok(p) => p,
         Err(_) => {
@@ -156,7 +170,11 @@ pub struct StopQuery {
     pub t: Option<u32>,
 }
 
-pub async fn stop(Path(id): Path<String>, Query(q): Query<StopQuery>, State(app): State<AppState>) -> (StatusCode, Json<Value>) {
+pub async fn stop(
+    Path(id): Path<String>,
+    Query(q): Query<StopQuery>,
+    State(app): State<AppState>,
+) -> (StatusCode, Json<Value>) {
     log::info!("stopping container: {}", id);
     match pelagos_state::stop_container(app.pelagos_bin(), &id, q.t).await {
         Ok(_) => (StatusCode::NO_CONTENT, Json(json!({}))),
@@ -164,7 +182,10 @@ pub async fn stop(Path(id): Path<String>, Query(q): Query<StopQuery>, State(app)
             if e.contains("not found") || e.contains("no such") {
                 (StatusCode::NOT_FOUND, Json(json!({"message": e})))
             } else {
-                (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"message": e})))
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"message": e})),
+                )
             }
         }
     }
@@ -173,21 +194,30 @@ pub async fn stop(Path(id): Path<String>, Query(q): Query<StopQuery>, State(app)
 // ── Kill ──────────────────────────────────────────────────────────────────────
 
 #[derive(Deserialize, Default)]
+#[allow(dead_code)]
 pub struct KillQuery {
     pub signal: Option<String>,
 }
 
-pub async fn kill(Path(id): Path<String>, Query(_q): Query<KillQuery>, State(app): State<AppState>) -> (StatusCode, Json<Value>) {
+pub async fn kill(
+    Path(id): Path<String>,
+    Query(_q): Query<KillQuery>,
+    State(app): State<AppState>,
+) -> (StatusCode, Json<Value>) {
     log::info!("killing container: {}", id);
     match pelagos_state::stop_container(app.pelagos_bin(), &id, Some(0)).await {
         Ok(_) => (StatusCode::NO_CONTENT, Json(json!({}))),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"message": e}))),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"message": e})),
+        ),
     }
 }
 
 // ── Remove ────────────────────────────────────────────────────────────────────
 
 #[derive(Deserialize, Default)]
+#[allow(dead_code)]
 pub struct RemoveQuery {
     #[serde(default)]
     pub force: Option<String>,
@@ -195,8 +225,16 @@ pub struct RemoveQuery {
     pub v: Option<String>,
 }
 
-pub async fn remove(Path(id): Path<String>, Query(q): Query<RemoveQuery>, State(app): State<AppState>) -> (StatusCode, Json<Value>) {
-    let force = q.force.as_deref().map(|v| v == "true" || v == "1").unwrap_or(false);
+pub async fn remove(
+    Path(id): Path<String>,
+    Query(q): Query<RemoveQuery>,
+    State(app): State<AppState>,
+) -> (StatusCode, Json<Value>) {
+    let force = q
+        .force
+        .as_deref()
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false);
     state::remove_pending(&id);
     log::info!("removing container: {} (force={})", id, force);
     match pelagos_state::remove_container(app.pelagos_bin(), &id, force).await {
@@ -205,7 +243,10 @@ pub async fn remove(Path(id): Path<String>, Query(q): Query<RemoveQuery>, State(
             if e.contains("not found") || e.contains("no such") {
                 (StatusCode::NOT_FOUND, Json(json!({"message": e})))
             } else {
-                (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"message": e})))
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"message": e})),
+                )
             }
         }
     }
@@ -218,10 +259,16 @@ pub async fn wait(Path(id): Path<String>) -> (StatusCode, Json<Value>) {
     loop {
         match pelagos_state::read_state(&id) {
             Ok(c) if !c.is_running() => {
-                return (StatusCode::OK, Json(json!({"StatusCode": c.exit_code.unwrap_or(0)})));
+                return (
+                    StatusCode::OK,
+                    Json(json!({"StatusCode": c.exit_code.unwrap_or(0)})),
+                );
             }
             Err(_) => {
-                return (StatusCode::NOT_FOUND, Json(json!({"message": format!("container '{}' not found", id)})));
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(json!({"message": format!("container '{}' not found", id)})),
+                );
             }
             _ => {}
         }
@@ -232,6 +279,7 @@ pub async fn wait(Path(id): Path<String>) -> (StatusCode, Json<Value>) {
 // ── Logs ──────────────────────────────────────────────────────────────────────
 
 #[derive(Deserialize, Default)]
+#[allow(dead_code)]
 pub struct LogsQuery {
     #[serde(default)]
     pub stdout: Option<String>,
@@ -247,7 +295,11 @@ pub async fn logs(Path(id): Path<String>, Query(q): Query<LogsQuery>) -> Respons
     let c = match pelagos_state::read_state(&id) {
         Ok(c) => c,
         Err(_) => {
-            return (StatusCode::NOT_FOUND, Json(json!({"message": format!("container '{}' not found", id)}))).into_response();
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"message": format!("container '{}' not found", id)})),
+            )
+                .into_response();
         }
     };
 
@@ -258,12 +310,18 @@ pub async fn logs(Path(id): Path<String>, Query(q): Query<LogsQuery>) -> Respons
         }
     };
 
-    let follow = q.follow.as_deref().map(|v| v == "true" || v == "1").unwrap_or(false);
+    let follow = q
+        .follow
+        .as_deref()
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false);
     let container_name = id.clone();
 
     if !follow {
         // Non-follow: read the whole log file and return it as a single framed body.
-        let data = tokio::fs::read_to_string(&log_path).await.unwrap_or_default();
+        let data = tokio::fs::read_to_string(&log_path)
+            .await
+            .unwrap_or_default();
         let mut body: Vec<u8> = Vec::new();
         for line in data.lines() {
             let mut payload = line.as_bytes().to_vec();
@@ -318,7 +376,10 @@ pub async fn logs(Path(id): Path<String>, Query(q): Query<LogsQuery>) -> Respons
 
 fn docker_frame_header(stream_type: u8, len: u32) -> Vec<u8> {
     vec![
-        stream_type, 0, 0, 0,
+        stream_type,
+        0,
+        0,
+        0,
         (len >> 24) as u8,
         (len >> 16) as u8,
         (len >> 8) as u8,
@@ -332,25 +393,31 @@ pub async fn stats(Path(id): Path<String>) -> (StatusCode, Json<Value>) {
     let c = match pelagos_state::read_state(&id) {
         Ok(c) => c,
         Err(_) => {
-            return (StatusCode::NOT_FOUND, Json(json!({"message": format!("container '{}' not found", id)})));
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"message": format!("container '{}' not found", id)})),
+            );
         }
     };
 
     let (cpu_ns, mem_bytes) = read_cgroup_stats(c.cgroup_name.as_deref());
 
-    (StatusCode::OK, Json(json!({
-        "id": id,
-        "cpu_stats": {
-            "cpu_usage": {
-                "total_usage": cpu_ns
+    (
+        StatusCode::OK,
+        Json(json!({
+            "id": id,
+            "cpu_stats": {
+                "cpu_usage": {
+                    "total_usage": cpu_ns
+                },
+                "system_cpu_usage": read_system_cpu_ns()
             },
-            "system_cpu_usage": read_system_cpu_ns()
-        },
-        "memory_stats": {
-            "usage": mem_bytes
-        },
-        "networks": {}
-    })))
+            "memory_stats": {
+                "usage": mem_bytes
+            },
+            "networks": {}
+        })),
+    )
 }
 
 fn read_cgroup_stats(cgroup: Option<&str>) -> (u64, u64) {
@@ -362,7 +429,9 @@ fn read_cgroup_stats(cgroup: Option<&str>) -> (u64, u64) {
 
 fn read_cpu_ns(cg: &str) -> u64 {
     let path = format!("/sys/fs/cgroup/{}/cpu.stat", cg);
-    let Ok(data) = std::fs::read_to_string(&path) else { return 0 };
+    let Ok(data) = std::fs::read_to_string(&path) else {
+        return 0;
+    };
     for line in data.lines() {
         if let Some(rest) = line.strip_prefix("usage_usec ") {
             if let Ok(usec) = rest.trim().parse::<u64>() {
@@ -382,11 +451,14 @@ fn read_mem_bytes(cg: &str) -> u64 {
 }
 
 fn read_system_cpu_ns() -> u64 {
-    let Ok(data) = std::fs::read_to_string("/proc/stat") else { return 0 };
+    let Ok(data) = std::fs::read_to_string("/proc/stat") else {
+        return 0;
+    };
     let line = data.lines().next().unwrap_or("");
     let fields: Vec<&str> = line.split_whitespace().collect();
     // Fields 1..=8: user nice system idle iowait irq softirq steal
-    let ticks: u64 = fields[1..].iter()
+    let ticks: u64 = fields[1..]
+        .iter()
         .take(8)
         .filter_map(|s| s.parse::<u64>().ok())
         .sum();
@@ -431,11 +503,14 @@ fn container_inspect_json(c: &ContainerState) -> Value {
     let ip = c.bridge_ip.clone().unwrap_or_default();
     let mut networks = serde_json::Map::new();
     if !ip.is_empty() {
-        networks.insert("bridge".to_string(), json!({
-            "IPAddress": ip,
-            "Gateway": "172.19.0.1",
-            "MacAddress": ""
-        }));
+        networks.insert(
+            "bridge".to_string(),
+            json!({
+                "IPAddress": ip,
+                "Gateway": "172.19.0.1",
+                "MacAddress": ""
+            }),
+        );
     }
     json!({
         "Id": c.name,
@@ -514,7 +589,10 @@ pub async fn remove_volume(Path(_name): Path<String>) -> StatusCode {
 
 /// GET /containers/{id}/archive — download file from container (kubelet fallback path)
 pub async fn archive(Path(id): Path<String>) -> (StatusCode, Json<Value>) {
-    (StatusCode::NOT_FOUND, Json(json!({"message": format!("archive not supported for '{}'", id)})))
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({"message": format!("archive not supported for '{}'", id)})),
+    )
 }
 
 struct Filters {
@@ -524,23 +602,41 @@ struct Filters {
 }
 
 fn parse_filters(raw: Option<&str>) -> Filters {
-    let mut f = Filters { labels: Vec::new(), names: Vec::new(), statuses: Vec::new() };
+    let mut f = Filters {
+        labels: Vec::new(),
+        names: Vec::new(),
+        statuses: Vec::new(),
+    };
     let Some(raw) = raw else { return f };
-    let Ok(parsed) = serde_json::from_str::<Value>(raw) else { return f };
+    let Ok(parsed) = serde_json::from_str::<Value>(raw) else {
+        return f;
+    };
 
     if let Some(labels) = parsed.get("label").and_then(|v| v.as_array()) {
-        f.labels = labels.iter()
+        f.labels = labels
+            .iter()
             .filter_map(|v| v.as_str())
-            .filter_map(|s| { let (k, v) = s.split_once('=')?; Some((k.to_string(), v.to_string())) })
+            .filter_map(|s| {
+                let (k, v) = s.split_once('=')?;
+                Some((k.to_string(), v.to_string()))
+            })
             .collect();
     }
     if let Some(names) = parsed.get("name").and_then(|v| v.as_array()) {
-        f.names = names.iter().filter_map(|v| v.as_str()).map(|s| s.to_string()).collect();
+        f.names = names
+            .iter()
+            .filter_map(|v| v.as_str())
+            .map(|s| s.to_string())
+            .collect();
     }
     if let Some(statuses) = parsed.get("status").and_then(|v| v.as_array()) {
         // Docker status values: "running","exited","created","paused","restarting","dead"
         // Map Docker status names to our docker_status_str() equivalents
-        f.statuses = statuses.iter().filter_map(|v| v.as_str()).map(|s| s.to_string()).collect();
+        f.statuses = statuses
+            .iter()
+            .filter_map(|v| v.as_str())
+            .map(|s| s.to_string())
+            .collect();
     }
     f
 }
@@ -549,9 +645,9 @@ fn matches_labels(
     container_labels: &std::collections::HashMap<String, String>,
     filters: &[(String, String)],
 ) -> bool {
-    filters.iter().all(|(k, v)| {
-        container_labels.get(k).map(|cv| cv == v).unwrap_or(false)
-    })
+    filters
+        .iter()
+        .all(|(k, v)| container_labels.get(k).map(|cv| cv == v).unwrap_or(false))
 }
 
 fn matches_name(container_name: &str, patterns: &[String]) -> bool {
@@ -559,8 +655,7 @@ fn matches_name(container_name: &str, patterns: &[String]) -> bool {
     patterns.iter().any(|pat| {
         // Docker name filter supports regex; handle the common prefix case (^/name)
         // and substring match
-        if pat.starts_with('^') {
-            let prefix = &pat[1..];
+        if let Some(prefix) = pat.strip_prefix('^') {
             full_name.starts_with(prefix) || container_name.starts_with(prefix)
         } else {
             full_name.contains(pat.as_str()) || container_name.contains(pat.as_str())

--- a/src/bin/pelagos-dockerd/handlers/exec.rs
+++ b/src/bin/pelagos-dockerd/handlers/exec.rs
@@ -1,19 +1,19 @@
-use axum::{
-    Json,
-    body::Body,
-    extract::{Path, Request, State},
-    http::{Response, StatusCode},
-    response::IntoResponse,
-};
-use hyper_util::rt::TokioIo;
-use serde_json::{json, Value};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use uuid::Uuid;
 use crate::{
     pelagos_state,
     state::AppState,
     types::{ExecCreateBody, ExecSession, ExecStartBody},
 };
+use axum::{
+    body::Body,
+    extract::{Path, Request, State},
+    http::{Response, StatusCode},
+    response::IntoResponse,
+    Json,
+};
+use hyper_util::rt::TokioIo;
+use serde_json::{json, Value};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use uuid::Uuid;
 
 /// POST /containers/{id}/exec — register an exec instance.
 pub async fn create(
@@ -134,26 +134,35 @@ pub async fn inspect(
     State(state): State<AppState>,
 ) -> (StatusCode, Json<Value>) {
     if let Some(exit_code) = state.get_completed_exec(&exec_id).await {
-        return (StatusCode::OK, Json(json!({
-            "ID": exec_id,
-            "Running": false,
-            "ExitCode": exit_code,
-            "ProcessConfig": {"entrypoint": "", "arguments": []}
-        })));
+        return (
+            StatusCode::OK,
+            Json(json!({
+                "ID": exec_id,
+                "Running": false,
+                "ExitCode": exit_code,
+                "ProcessConfig": {"entrypoint": "", "arguments": []}
+            })),
+        );
     }
     if let Some(s) = state.get_exec(&exec_id).await {
-        return (StatusCode::OK, Json(json!({
-            "ID": exec_id,
-            "ContainerID": s.container_name,
-            "Running": true,
-            "ExitCode": null,
-            "ProcessConfig": {
-                "entrypoint": s.cmd.first().cloned().unwrap_or_default(),
-                "arguments": s.cmd.get(1..).unwrap_or(&[]).to_vec()
-            }
-        })));
+        return (
+            StatusCode::OK,
+            Json(json!({
+                "ID": exec_id,
+                "ContainerID": s.container_name,
+                "Running": true,
+                "ExitCode": null,
+                "ProcessConfig": {
+                    "entrypoint": s.cmd.first().cloned().unwrap_or_default(),
+                    "arguments": s.cmd.get(1..).unwrap_or(&[]).to_vec()
+                }
+            })),
+        );
     }
-    (StatusCode::NOT_FOUND, Json(json!({"message": "exec not found"})))
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({"message": "exec not found"})),
+    )
 }
 
 // ── Internal helpers ─────────────────────────────────────────────────────────
@@ -259,7 +268,10 @@ async fn write_docker_frame<W: tokio::io::AsyncWrite + Unpin>(
 ) -> std::io::Result<()> {
     let len = data.len() as u32;
     let header = [
-        stream_type, 0, 0, 0,
+        stream_type,
+        0,
+        0,
+        0,
         (len >> 24) as u8,
         (len >> 16) as u8,
         (len >> 8) as u8,

--- a/src/bin/pelagos-dockerd/handlers/images.rs
+++ b/src/bin/pelagos-dockerd/handlers/images.rs
@@ -1,11 +1,11 @@
+use crate::{pelagos_state, state::AppState};
 use axum::{
-    Json,
     extract::{Path, Query, State},
     http::StatusCode,
+    Json,
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
-use crate::{pelagos_state, state::AppState};
 
 #[derive(Deserialize)]
 pub struct CreateQuery {
@@ -15,9 +15,15 @@ pub struct CreateQuery {
 }
 
 /// POST /images/create?fromImage=...&tag=...
-pub async fn create(Query(q): Query<CreateQuery>, State(app): State<AppState>) -> (StatusCode, Json<Value>) {
+pub async fn create(
+    Query(q): Query<CreateQuery>,
+    State(app): State<AppState>,
+) -> (StatusCode, Json<Value>) {
     let Some(from_image) = q.from_image else {
-        return (StatusCode::BAD_REQUEST, Json(json!({"message": "fromImage is required"})));
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"message": "fromImage is required"})),
+        );
     };
     let image = if let Some(tag) = q.tag.filter(|t| !t.is_empty()) {
         format!("{}:{}", from_image, tag)
@@ -33,7 +39,10 @@ pub async fn create(Query(q): Query<CreateQuery>, State(app): State<AppState>) -
             let mut lines = Vec::new();
             for line in text.lines() {
                 if !line.is_empty() {
-                    lines.push(format!("{{\"status\":\"{}\",\"progressDetail\":{{}}}}", escape_json_str(line)));
+                    lines.push(format!(
+                        "{{\"status\":\"{}\",\"progressDetail\":{{}}}}",
+                        escape_json_str(line)
+                    ));
                 }
             }
             lines.push(format!(
@@ -41,23 +50,35 @@ pub async fn create(Query(q): Query<CreateQuery>, State(app): State<AppState>) -
                 image
             ));
             let body = lines.join("\n");
-            (StatusCode::OK, Json(json!({"status": "pull complete", "raw": body})))
+            (
+                StatusCode::OK,
+                Json(json!({"status": "pull complete", "raw": body})),
+            )
         }
         Err(e) => {
             log::error!("pull {} failed: {}", image, e);
-            (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"message": e})))
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"message": e})),
+            )
         }
     }
 }
 
 /// GET /images/{name}/json
-pub async fn inspect(Path(name): Path<String>, State(app): State<AppState>) -> (StatusCode, Json<Value>) {
+pub async fn inspect(
+    Path(name): Path<String>,
+    State(app): State<AppState>,
+) -> (StatusCode, Json<Value>) {
     let name = urlencoding_decode(&name);
     let images = match pelagos_state::list_images_json(app.pelagos_bin()).await {
         Ok(v) => v,
         Err(e) => {
             log::warn!("list images failed: {}", e);
-            return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"message": e})));
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"message": e})),
+            );
         }
     };
 
@@ -70,20 +91,29 @@ pub async fn inspect(Path(name): Path<String>, State(app): State<AppState>) -> (
 
     match matched {
         Some(img) => {
-            let reference = img.get("reference").and_then(|r| r.as_str()).unwrap_or(&name);
+            let reference = img
+                .get("reference")
+                .and_then(|r| r.as_str())
+                .unwrap_or(&name);
             let digest = img.get("digest").and_then(|d| d.as_str()).unwrap_or("");
-            (StatusCode::OK, Json(json!({
-                "Id": format!("{}", digest),
-                "RepoTags": [reference],
-                "RepoDigests": [format!("{}@{}", reference, digest)],
-                "Size": 10000000,
-                "VirtualSize": 10000000,
-                "Os": "linux",
-                "Architecture": "arm64",
-                "Created": "2024-01-01T00:00:00Z"
-            })))
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "Id": format!("{}", digest),
+                    "RepoTags": [reference],
+                    "RepoDigests": [format!("{}@{}", reference, digest)],
+                    "Size": 10000000,
+                    "VirtualSize": 10000000,
+                    "Os": "linux",
+                    "Architecture": "arm64",
+                    "Created": "2024-01-01T00:00:00Z"
+                })),
+            )
         }
-        None => (StatusCode::NOT_FOUND, Json(json!({"message": format!("image {} not found", name)}))),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"message": format!("image {} not found", name)})),
+        ),
     }
 }
 

--- a/src/bin/pelagos-dockerd/handlers/mod.rs
+++ b/src/bin/pelagos-dockerd/handlers/mod.rs
@@ -1,7 +1,7 @@
 //! Axum router and handler modules for the Docker Engine API.
 
-use axum::{Router, routing, middleware, extract::Request, response::Response};
 use crate::state::AppState;
+use axum::{extract::Request, middleware, response::Response, routing, Router};
 
 async fn log_requests(req: Request, next: axum::middleware::Next) -> Response {
     let method = req.method().clone();

--- a/src/bin/pelagos-dockerd/handlers/version.rs
+++ b/src/bin/pelagos-dockerd/handlers/version.rs
@@ -1,60 +1,74 @@
-use axum::{Json, http::StatusCode};
+use axum::{http::StatusCode, Json};
 use serde_json::{json, Value};
 
 pub async fn version() -> (StatusCode, Json<Value>) {
-    let arch = if cfg!(target_arch = "aarch64") { "arm64" } else { "amd64" };
-    (StatusCode::OK, Json(json!({
-        "Version": "24.0.0",
-        "ApiVersion": "1.41",
-        "MinAPIVersion": "1.24",
-        "Os": "linux",
-        "Arch": arch,
-        "KernelVersion": "6.1.0",
-        "BuildTime": "2024-01-01T00:00:00.000000000+00:00",
-        "GitCommit": "pelagos-dockerd",
-        "GoVersion": "go1.21.0",
-        "Components": []
-    })))
+    let arch = if cfg!(target_arch = "aarch64") {
+        "arm64"
+    } else {
+        "amd64"
+    };
+    (
+        StatusCode::OK,
+        Json(json!({
+            "Version": "24.0.0",
+            "ApiVersion": "1.41",
+            "MinAPIVersion": "1.24",
+            "Os": "linux",
+            "Arch": arch,
+            "KernelVersion": "6.1.0",
+            "BuildTime": "2024-01-01T00:00:00.000000000+00:00",
+            "GitCommit": "pelagos-dockerd",
+            "GoVersion": "go1.21.0",
+            "Components": []
+        })),
+    )
 }
 
 pub async fn info() -> (StatusCode, Json<Value>) {
-    let arch = if cfg!(target_arch = "aarch64") { "aarch64" } else { "x86_64" };
-    (StatusCode::OK, Json(json!({
-        "ID": "pelagos-dockerd",
-        "Containers": 0,
-        "ContainersRunning": 0,
-        "ContainersPaused": 0,
-        "ContainersStopped": 0,
-        "Images": 0,
-        "Driver": "overlay2",
-        "MemoryLimit": true,
-        "SwapLimit": true,
-        "KernelMemory": false,
-        "CpuCfsPeriod": true,
-        "CpuCfsQuota": true,
-        "CPUShares": true,
-        "CPUSet": true,
-        "IPv4Forwarding": true,
-        "BridgeNfIptables": false,
-        "BridgeNfIp6tables": false,
-        "Debug": false,
-        "OomKillDisable": false,
-        "NGoroutines": 1,
-        "NEventsListener": 0,
-        "LoggingDriver": "json-file",
-        "CgroupDriver": "cgroupfs",
-        "CgroupVersion": "2",
-        "DockerRootDir": "/var/lib/pelagos",
-        "HttpProxy": "",
-        "HttpsProxy": "",
-        "NoProxy": "",
-        "Name": "pelagos-dockerd",
-        "ServerVersion": "24.0.0",
-        "OperatingSystem": "Ubuntu 24.04",
-        "OSType": "linux",
-        "Architecture": arch,
-        "NCPU": 1,
-        "MemTotal": 0,
-        "IndexServerAddress": "https://index.docker.io/v1/"
-    })))
+    let arch = if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        "x86_64"
+    };
+    (
+        StatusCode::OK,
+        Json(json!({
+            "ID": "pelagos-dockerd",
+            "Containers": 0,
+            "ContainersRunning": 0,
+            "ContainersPaused": 0,
+            "ContainersStopped": 0,
+            "Images": 0,
+            "Driver": "overlay2",
+            "MemoryLimit": true,
+            "SwapLimit": true,
+            "KernelMemory": false,
+            "CpuCfsPeriod": true,
+            "CpuCfsQuota": true,
+            "CPUShares": true,
+            "CPUSet": true,
+            "IPv4Forwarding": true,
+            "BridgeNfIptables": false,
+            "BridgeNfIp6tables": false,
+            "Debug": false,
+            "OomKillDisable": false,
+            "NGoroutines": 1,
+            "NEventsListener": 0,
+            "LoggingDriver": "json-file",
+            "CgroupDriver": "cgroupfs",
+            "CgroupVersion": "2",
+            "DockerRootDir": "/var/lib/pelagos",
+            "HttpProxy": "",
+            "HttpsProxy": "",
+            "NoProxy": "",
+            "Name": "pelagos-dockerd",
+            "ServerVersion": "24.0.0",
+            "OperatingSystem": "Ubuntu 24.04",
+            "OSType": "linux",
+            "Architecture": arch,
+            "NCPU": 1,
+            "MemTotal": 0,
+            "IndexServerAddress": "https://index.docker.io/v1/"
+        })),
+    )
 }

--- a/src/bin/pelagos-dockerd/main.rs
+++ b/src/bin/pelagos-dockerd/main.rs
@@ -2,13 +2,13 @@
 //! Linux-only binary.
 
 #[cfg(target_os = "linux")]
+mod handlers;
+#[cfg(target_os = "linux")]
 mod pelagos_state;
 #[cfg(target_os = "linux")]
 mod state;
 #[cfg(target_os = "linux")]
 mod types;
-#[cfg(target_os = "linux")]
-mod handlers;
 
 fn main() {
     #[cfg(not(target_os = "linux"))]

--- a/src/bin/pelagos-dockerd/pelagos_state.rs
+++ b/src/bin/pelagos-dockerd/pelagos_state.rs
@@ -9,6 +9,7 @@ const CONTAINERS_DIR: &str = "/run/pelagos/containers";
 // ── ContainerState (subset) ─────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
 pub struct ContainerState {
     pub name: String,
     #[serde(rename = "status")]
@@ -91,6 +92,7 @@ impl ContainerState {
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
+#[allow(dead_code)]
 pub struct SpawnConfig {
     #[serde(default)]
     pub image: Option<String>,
@@ -258,8 +260,7 @@ pub async fn list_images_json(bin: &str) -> Result<Vec<serde_json::Value>, Strin
     if !out.status.success() {
         return Err(String::from_utf8_lossy(&out.stderr).trim().to_string());
     }
-    let parsed: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout)
-        .unwrap_or_default();
+    let parsed: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap_or_default();
     Ok(parsed)
 }
 

--- a/src/bin/pelagos-dockerd/state.rs
+++ b/src/bin/pelagos-dockerd/state.rs
@@ -19,6 +19,7 @@ struct Inner {
 }
 
 impl AppState {
+    #[allow(dead_code)]
     pub fn new() -> Self {
         Self::new_with_bin("pelagos".to_string())
     }
@@ -46,13 +47,18 @@ impl AppState {
         self.inner.exec_sessions.lock().await.get(id).cloned()
     }
 
+    #[allow(dead_code)]
     pub async fn remove_exec(&self, id: &str) {
         self.inner.exec_sessions.lock().await.remove(id);
     }
 
     pub async fn complete_exec(&self, id: String, exit_code: i64) {
         self.inner.exec_sessions.lock().await.remove(&id);
-        self.inner.completed_execs.lock().await.insert(id, exit_code);
+        self.inner
+            .completed_execs
+            .lock()
+            .await
+            .insert(id, exit_code);
     }
 
     pub async fn get_completed_exec(&self, id: &str) -> Option<i64> {

--- a/src/bin/pelagos-dockerd/types.rs
+++ b/src/bin/pelagos-dockerd/types.rs
@@ -29,6 +29,7 @@ pub struct ContainerCreateBody {
 
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(rename_all = "PascalCase")]
+#[allow(dead_code)]
 pub struct HostConfig {
     #[serde(default)]
     pub network_mode: Option<String>,
@@ -48,6 +49,7 @@ pub struct HostConfig {
 
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(rename_all = "PascalCase")]
+#[allow(dead_code)]
 pub struct ExecCreateBody {
     #[serde(default)]
     pub cmd: Vec<String>,
@@ -69,6 +71,7 @@ pub struct ExecCreateBody {
 
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(rename_all = "PascalCase")]
+#[allow(dead_code)]
 pub struct ExecStartBody {
     #[serde(default)]
     pub detach: Option<bool>,

--- a/tests/dockerd_smoke.rs
+++ b/tests/dockerd_smoke.rs
@@ -6,10 +6,12 @@
 
 #[cfg(target_os = "linux")]
 mod smoke {
-    use bollard::Docker;
-    use bollard::container::{CreateContainerOptions, Config, StartContainerOptions, RemoveContainerOptions};
+    use bollard::container::{
+        Config, CreateContainerOptions, RemoveContainerOptions, StartContainerOptions,
+    };
     use bollard::exec::{CreateExecOptions, StartExecResults};
     use bollard::models::HostConfig;
+    use bollard::Docker;
     use futures_util::StreamExt;
 
     fn connect() -> Docker {
@@ -49,14 +51,20 @@ mod smoke {
         let _ = docker
             .remove_container(
                 name,
-                Some(RemoveContainerOptions { force: true, ..Default::default() }),
+                Some(RemoveContainerOptions {
+                    force: true,
+                    ..Default::default()
+                }),
             )
             .await;
 
         // Create
         docker
             .create_container(
-                Some(CreateContainerOptions { name, platform: None }),
+                Some(CreateContainerOptions {
+                    name,
+                    platform: None,
+                }),
                 Config {
                     image: Some("alpine:latest"),
                     cmd: Some(vec!["sleep", "10"]),
@@ -78,7 +86,10 @@ mod smoke {
 
         // Inspect
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-        let info = docker.inspect_container(name, None).await.expect("inspect_container()");
+        let info = docker
+            .inspect_container(name, None)
+            .await
+            .expect("inspect_container()");
         let state = info.state.expect("State missing");
         assert_eq!(state.running, Some(true), "container not running");
         let ip = info
@@ -96,7 +107,10 @@ mod smoke {
         docker
             .remove_container(
                 name,
-                Some(RemoveContainerOptions { force: true, ..Default::default() }),
+                Some(RemoveContainerOptions {
+                    force: true,
+                    ..Default::default()
+                }),
             )
             .await
             .expect("remove_container()");
@@ -109,13 +123,22 @@ mod smoke {
 
         // Clean up any leftover
         let _ = docker
-            .remove_container(container, Some(RemoveContainerOptions { force: true, ..Default::default() }))
+            .remove_container(
+                container,
+                Some(RemoveContainerOptions {
+                    force: true,
+                    ..Default::default()
+                }),
+            )
             .await;
 
         // Create and start a long-lived container
         docker
             .create_container(
-                Some(CreateContainerOptions { name: container, platform: None }),
+                Some(CreateContainerOptions {
+                    name: container,
+                    platform: None,
+                }),
                 Config {
                     image: Some("alpine:latest"),
                     cmd: Some(vec!["sleep", "30"]),
@@ -128,7 +151,10 @@ mod smoke {
             )
             .await
             .expect("create_container");
-        docker.start_container(container, None::<StartContainerOptions<String>>).await.expect("start_container");
+        docker
+            .start_container(container, None::<StartContainerOptions<String>>)
+            .await
+            .expect("start_container");
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
         // exec: echo a known string to stdout
@@ -146,10 +172,8 @@ mod smoke {
             .expect("create_exec");
 
         let mut output_text = String::new();
-        if let StartExecResults::Attached { mut output, .. } = docker
-            .start_exec(&exec.id, None)
-            .await
-            .expect("start_exec")
+        if let StartExecResults::Attached { mut output, .. } =
+            docker.start_exec(&exec.id, None).await.expect("start_exec")
         {
             while let Some(Ok(msg)) = output.next().await {
                 output_text.push_str(&msg.to_string());
@@ -159,17 +183,31 @@ mod smoke {
         }
 
         println!("exec output: {:?}", output_text);
-        assert!(output_text.contains("hello-from-exec"), "unexpected output: {}", output_text);
+        assert!(
+            output_text.contains("hello-from-exec"),
+            "unexpected output: {}",
+            output_text
+        );
 
         // Inspect exec — should report completed (Running: false)
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
         let info = docker.inspect_exec(&exec.id).await.expect("inspect_exec");
-        assert_eq!(info.running, Some(false), "exec should not be running after completion");
+        assert_eq!(
+            info.running,
+            Some(false),
+            "exec should not be running after completion"
+        );
         assert_eq!(info.exit_code, Some(0), "exit code should be 0");
 
         // Cleanup
         docker
-            .remove_container(container, Some(RemoveContainerOptions { force: true, ..Default::default() }))
+            .remove_container(
+                container,
+                Some(RemoveContainerOptions {
+                    force: true,
+                    ..Default::default()
+                }),
+            )
             .await
             .expect("remove_container");
     }


### PR DESCRIPTION
## Summary
- `cargo fmt` applied across the workspace
- Fixed 12 clippy warnings in `pelagos-dockerd` (unused imports, `#[allow(dead_code)]` on Docker API serde structs, manual prefix strip replaced with `strip_prefix`)
- Bumped version to `0.60.11` (skipping 0.60.10 which was tagged without a Cargo.toml update)

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes (verified in build VM)
- [x] `cargo test` passes in build VM: 313 passed, 1 pre-existing failure (`tutorial_e2e_p4::test_tut_p4_compose_dns`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)