### PR TITLE
feat(rootless): pre-flight check for AppArmor userns + uidmap setup (#220)

### DIFF
--- a/ONGOING_TASKS.md
+++ b/ONGOING_TASKS.md
@@ -1,5 +1,214 @@
 # Ongoing Tasks
 
+## Session completed: 2026-05-08 (branch feat/220-rootless-setup-check)
+
+### #220 — proactive rootless setup detection (COMPLETE)
+
+Base SHA 93ef39a (main). Follow-up to the #219 errno-masking fix.
+
+**Module** (`src/rootless_check.rs`):
+- `Signals` struct + `Signals::probe()` (apparmor flag, idmap helpers, subuid/subgid entries)
+- `diagnose()` — pure decision: error iff `apparmor_restricted && !newuidmap_path_works`
+- `check()` — `PELAGOS_SKIP_ROOTLESS_CHECK=1` escape hatch with `log::debug!` on bypass
+- `RootlessSetupError::Display` — lists each independent blocker + three numbered workarounds
+
+**Wired in** at `src/container.rs:2635` (`spawn`) and `:5258` (`spawn_interactive`)
+inside the existing `is_rootless && !joining_user_ns && !skip_rootless_user_ns` block.
+
+**Bonus:** clippy fix in `tests/integration_tests.rs:20679`
+(`trim_start().split_whitespace()` → `split_whitespace()`).
+
+**Tests:** 9 unit tests in `rootless_check::tests`; full lib suite 344/344 green.
+**Verified live:** apparmor=0 host → silent (check returns Ok); bypass env var
+emits debug log + container runs to completion.
+
+---
+
+## Earlier planning notes (kept for reference)
+
+Started 2026-05-08, base SHA 93ef39a (main). Follows up on the masking-bug fix
+in #219 / 93ef39a, which made rootless failures report the *real* errno but
+still doesn't tell users *what to do*.
+
+### Goal
+
+Before pelagos calls `unshare(CLONE_NEWUSER)` in a rootless run, detect the
+combination of host conditions that will cause the `/proc/self/setgroups`
+EACCES (or any other rootless setup blocker) and abort with a targeted hint
+listing the precise workarounds — so the user never sees a raw kernel error
+for an environment we can recognise up front.
+
+Target UX (printed by pelagos, not by the OS):
+
+```
+pelagos: error: rootless container setup is not supported in this environment.
+
+Detected:
+  • kernel.apparmor_restrict_unprivileged_userns = 1 (Ubuntu 24.04+ default)
+  • uidmap package not installed (newuidmap/newgidmap missing)
+  • no /etc/subuid entry for chbrown
+  • no /etc/subgid entry for chbrown
+
+Pick one of the following:
+
+  1. Disable the AppArmor userns restriction:
+       sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+       echo 'kernel.apparmor_restrict_unprivileged_userns=0' \
+         | sudo tee /etc/sysctl.d/60-pelagos.conf
+
+  2. Install uidmap and configure subordinate UID/GID:
+       sudo apt install uidmap
+       sudo usermod --add-subuids 100000-165535 chbrown
+       sudo usermod --add-subgids 100000-165535 chbrown
+
+  3. Run as root:  sudo -E pelagos run …
+
+See docs/USER_GUIDE.md → Troubleshooting for details.
+```
+
+### Detection conjunction
+
+The setgroups EACCES fires only when **all** of the following are true. The
+hint must mirror this conjunction so we don't false-positive on systems where
+the newuidmap path would have worked anyway.
+
+1. `kernel.apparmor_restrict_unprivileged_userns == 1`
+   (file at `/proc/sys/kernel/apparmor_restrict_unprivileged_userns`;
+   absence ⇒ treat as 0)
+2. **AND** the newuidmap path will not be taken — i.e. **any** of:
+   - `newuidmap` missing on PATH (`idmap::has_newuidmap()`)
+   - `newgidmap` missing on PATH (`idmap::has_newgidmap()`)
+   - egid ≠ pw_gid (`idmap::newuidmap_will_work()` returns false)
+   - `/etc/subuid` has no entry for the current user
+     (`idmap::parse_subid_file` returns empty)
+   - `/etc/subgid` has no entry for the current user
+
+When (1) is false, AppArmor isn't blocking — proceed silently.
+When (1) is true but (2) is false, newuidmap will run and we never write
+setgroups directly — proceed silently.
+Only when (1) AND (2) both hold do we abort with the hint.
+
+### Module structure
+
+New file `src/rootless_check.rs` (suggested in the issue):
+
+```rust
+pub struct Signals {
+    pub apparmor_restricted: bool,
+    pub has_newuidmap: bool,
+    pub has_newgidmap: bool,
+    pub egid_matches_pw_gid: bool,
+    pub subuid_entries: usize,
+    pub subgid_entries: usize,
+    pub username: Option<String>,
+}
+
+impl Signals {
+    pub fn probe() -> Self { /* read from /proc, idmap helpers */ }
+}
+
+#[derive(Debug)]
+pub struct RootlessSetupError { signals: Signals }
+
+impl std::fmt::Display for RootlessSetupError { /* the bullet list */ }
+impl std::error::Error for RootlessSetupError {}
+
+/// Pure decision function — testable without filesystem.
+pub fn diagnose(s: &Signals) -> Option<RootlessSetupError> { /* the conjunction */ }
+
+/// Probe + diagnose convenience wrapper.
+pub fn check() -> Result<(), RootlessSetupError> {
+    diagnose(&Signals::probe()).map_or(Ok(()), Err)
+}
+```
+
+Add `pub mod rootless_check;` to `src/lib.rs`.
+
+### Wire-in points in `src/container.rs`
+
+Two sites, both right after `is_rootless && !joining_user_ns &&
+!self.skip_rootless_user_ns` is established:
+
+- `spawn()`            — currently line 2635
+- `spawn_interactive()`— currently line 5258 (offsets shift after #219 patch)
+
+```rust
+if is_rootless && !joining_user_ns && !self.skip_rootless_user_ns {
+    crate::rootless_check::check()
+        .map_err(|e| Error::Io(io::Error::other(e.to_string())))?;
+    self.namespaces |= Namespace::USER;
+    // … existing newuidmap / fallback logic unchanged
+}
+```
+
+The check is pre-flight; it does not need to map to a new `Error` variant
+(keeping it as a friendly `io::Error::other` keeps the CLI's existing
+`pelagos: error: …` rendering).
+
+### Escape hatch
+
+`PELAGOS_SKIP_ROOTLESS_CHECK=1` env var to suppress the check. Useful for:
+- Test environments that intentionally exercise the failing path
+- Environments where the conjunction triggers a false positive we haven't
+  anticipated (better to let the real syscall fail than to lock the user
+  out)
+
+### Tests (unit only — integration would need root + sysctl writes)
+
+`src/rootless_check.rs` `#[cfg(test)] mod tests`:
+
+1. all-clear: apparmor=0 → diagnose returns None
+2. apparmor=1, newuidmap fully wired → None (path 2 in spec)
+3. apparmor=1, newuidmap missing → Some, hint mentions "uidmap package"
+4. apparmor=1, helpers present but no /etc/subuid entry → Some, hint
+   mentions subuid
+5. apparmor=1, helpers + entries but egid mismatch → Some, hint mentions
+   newgrp / domain group
+6. all signals tripped → Some, hint lists all of them
+7. Display format includes username when known, generic when not
+8. Display format includes all three numbered workarounds in order
+
+### Out of scope (issue notes them explicitly as bonus refinements)
+
+- `setup.sh --enable-rootless` writing `/etc/sysctl.d/60-pelagos.conf` and
+  appending `/etc/subuid`/`/etc/subgid` entries — **separate follow-up PR**.
+- Shipping an AppArmor profile that lets `pelagos` keep capabilities in its
+  child userns (the `crun`/`bwrap` route on Ubuntu 24.04+) — **separate work**.
+
+### Risk / non-risk notes
+
+- **No behaviour change for environments that already work.** The check
+  short-circuits to Ok() on apparmor=0 *or* on a working newuidmap path.
+- **No behaviour change for root.** The wire-in sites are inside the
+  `is_rootless` block; root paths never see the check.
+- **No behaviour change for `pelagos exec` rootless join.** The check is
+  skipped when joining an existing user namespace
+  (`!joining_user_ns && !skip_rootless_user_ns`).
+- **The check is advisory.** If we false-negative (miss a real blocker),
+  the underlying syscall still fails with the now-faithful errno from #219.
+  The check is purely a UX win, never a correctness change.
+
+### Verification plan once implemented
+
+1. `cargo test --lib` — unit tests pass.
+2. With `apparmor_restrict_unprivileged_userns=1` and no uidmap installed,
+   `pelagos run -it alpine /bin/sh` prints the hint instead of EACCES.
+3. With `apparmor_restrict_unprivileged_userns=0`, same command runs the
+   container — check is silent.
+4. With apparmor=1 + uidmap installed + subuid configured + egid==pw_gid,
+   command runs the container — check is silent.
+5. `PELAGOS_SKIP_ROOTLESS_CHECK=1 pelagos run -it alpine /bin/sh` in case 2
+   bypasses the check and surfaces the underlying EACCES (preserved by
+   the #219 fix).
+
+### Open decisions before coding (asked of user)
+
+- Confirm scope: detection + hint only; defer setup.sh helper to its own PR.
+- Confirm escape hatch: `PELAGOS_SKIP_ROOTLESS_CHECK=1` is acceptable.
+- Branch strategy: feature branch + PR, or direct on main (issue is small).
+
+---
+
 ## Session completed: 2026-04-06 (SHA caf2f17, main)
 
 ### Rootless debian/ubuntu builds — all three root causes fixed (COMPLETE)

--- a/src/container.rs
+++ b/src/container.rs
@@ -2633,6 +2633,11 @@ impl Command {
             .iter()
             .any(|(_, ns)| *ns == Namespace::USER);
         if is_rootless && !joining_user_ns && !self.skip_rootless_user_ns {
+            // Pre-flight: catch host configurations that will fail with a
+            // confusing EACCES on /proc/self/setgroups and emit a targeted
+            // hint instead. Pure UX; bypassed by PELAGOS_SKIP_ROOTLESS_CHECK=1.
+            crate::rootless_check::check()
+                .map_err(|e| Error::Io(io::Error::other(e.to_string())))?;
             // Unprivileged containers require a user namespace.
             self.namespaces |= Namespace::USER;
             let host_uid = unsafe { libc::getuid() };
@@ -5256,6 +5261,11 @@ impl Command {
             .iter()
             .any(|(_, ns)| *ns == Namespace::USER);
         if is_rootless && !joining_user_ns && !self.skip_rootless_user_ns {
+            // Pre-flight: catch host configurations that will fail with a
+            // confusing EACCES on /proc/self/setgroups and emit a targeted
+            // hint instead. Pure UX; bypassed by PELAGOS_SKIP_ROOTLESS_CHECK=1.
+            crate::rootless_check::check()
+                .map_err(|e| Error::Io(io::Error::other(e.to_string())))?;
             self.namespaces |= Namespace::USER;
             let host_uid = unsafe { libc::getuid() };
             let host_gid = unsafe { libc::getgid() };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod notif;
 pub mod oci;
 pub mod paths;
 pub mod pty;
+pub mod rootless_check;
 pub mod seccomp;
 pub mod sexpr;
 pub mod wasm;

--- a/src/rootless_check.rs
+++ b/src/rootless_check.rs
@@ -1,0 +1,332 @@
+//! Pre-flight diagnostic for rootless container setup.
+//!
+//! On Ubuntu 24.04+ (and other distros that enable
+//! `kernel.apparmor_restrict_unprivileged_userns=1`), an unprivileged process
+//! can call `unshare(CLONE_NEWUSER)` successfully, but the resulting user
+//! namespace is stripped of capabilities. Pelagos's single-UID rootless path
+//! then fails with `EACCES` on `/proc/self/setgroups` — a confusing failure
+//! mode unless you know that AppArmor is the cause.
+//!
+//! This module probes the host **before** `unshare` is attempted and, if it
+//! detects the conjunction of conditions that will trigger the failure, emits a
+//! formatted error listing the precise workarounds. The check is purely
+//! advisory: if it false-negatives, the underlying kernel call still produces a
+//! faithful errno (the masking bug fixed in #219). The escape hatch
+//! `PELAGOS_SKIP_ROOTLESS_CHECK=1` bypasses the check entirely.
+
+use std::path::Path;
+
+const APPARMOR_USERNS_PROC: &str = "/proc/sys/kernel/apparmor_restrict_unprivileged_userns";
+const SKIP_ENV: &str = "PELAGOS_SKIP_ROOTLESS_CHECK";
+
+/// Host signals relevant to rootless setup. Pure data so `diagnose` is
+/// testable without touching the filesystem.
+#[derive(Debug, Clone)]
+pub struct Signals {
+    /// AppArmor unprivileged-userns restriction is active
+    /// (`/proc/sys/kernel/apparmor_restrict_unprivileged_userns == 1`).
+    pub apparmor_restricted: bool,
+    /// `newuidmap` binary present on PATH.
+    pub has_newuidmap: bool,
+    /// `newgidmap` binary present on PATH.
+    pub has_newgidmap: bool,
+    /// Effective GID matches the calling user's `pw_gid` from `/etc/passwd`
+    /// (newuidmap/newgidmap reject mismatched callers — common gotcha on
+    /// `newgrp <group>` shells and domain-joined hosts).
+    pub egid_matches_pw_gid: bool,
+    /// Number of `/etc/subuid` ranges allocated to the calling user.
+    pub subuid_entries: usize,
+    /// Number of `/etc/subgid` ranges allocated to the calling user.
+    pub subgid_entries: usize,
+    /// Calling user's name from `/etc/passwd`, if discoverable.
+    pub username: Option<String>,
+}
+
+impl Signals {
+    /// Probe the live host for all relevant signals.
+    pub fn probe() -> Self {
+        let apparmor_restricted = read_apparmor_userns_flag();
+        let has_newuidmap = crate::idmap::has_newuidmap();
+        let has_newgidmap = crate::idmap::has_newgidmap();
+        let egid_matches_pw_gid = crate::idmap::newuidmap_will_work();
+
+        let (username, subuid_entries, subgid_entries) = match crate::idmap::current_user_info() {
+            Ok((name, _pw_gid)) => {
+                let host_uid = unsafe { libc::getuid() };
+                let host_gid = unsafe { libc::getgid() };
+                let subuid =
+                    crate::idmap::parse_subid_file(Path::new("/etc/subuid"), &name, host_uid)
+                        .map(|v| v.len())
+                        .unwrap_or(0);
+                let subgid =
+                    crate::idmap::parse_subid_file(Path::new("/etc/subgid"), &name, host_gid)
+                        .map(|v| v.len())
+                        .unwrap_or(0);
+                (Some(name), subuid, subgid)
+            }
+            Err(_) => (None, 0, 0),
+        };
+
+        Signals {
+            apparmor_restricted,
+            has_newuidmap,
+            has_newgidmap,
+            egid_matches_pw_gid,
+            subuid_entries,
+            subgid_entries,
+            username,
+        }
+    }
+
+    /// True when the newuidmap path will run successfully end-to-end. When this
+    /// is true, pelagos never writes `/proc/self/setgroups` directly, so the
+    /// AppArmor restriction is irrelevant.
+    fn newuidmap_path_works(&self) -> bool {
+        self.has_newuidmap
+            && self.has_newgidmap
+            && self.egid_matches_pw_gid
+            && self.subuid_entries > 0
+            && self.subgid_entries > 0
+    }
+}
+
+/// Diagnostic returned when rootless setup is predicted to fail. Its `Display`
+/// is the user-facing error text.
+#[derive(Debug, Clone)]
+pub struct RootlessSetupError {
+    pub signals: Signals,
+}
+
+impl std::fmt::Display for RootlessSetupError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = &self.signals;
+        let user = s.username.as_deref().unwrap_or("$USER");
+
+        writeln!(
+            f,
+            "rootless container setup is not supported in this environment."
+        )?;
+        writeln!(f)?;
+        writeln!(f, "Detected:")?;
+        if s.apparmor_restricted {
+            writeln!(
+                f,
+                "  • kernel.apparmor_restrict_unprivileged_userns = 1 \
+                 (Ubuntu 24.04+ default)"
+            )?;
+        }
+        if !s.has_newuidmap || !s.has_newgidmap {
+            writeln!(
+                f,
+                "  • uidmap package not installed (newuidmap/newgidmap missing)"
+            )?;
+        }
+        if s.subuid_entries == 0 {
+            writeln!(f, "  • no /etc/subuid entry for {}", user)?;
+        }
+        if s.subgid_entries == 0 {
+            writeln!(f, "  • no /etc/subgid entry for {}", user)?;
+        }
+        // Only fire the egid line when the rest of the newuidmap path would
+        // actually run — otherwise it's noise (you can't hit the egid check
+        // until helpers + subid entries exist).
+        if s.has_newuidmap
+            && s.has_newgidmap
+            && s.subuid_entries > 0
+            && s.subgid_entries > 0
+            && !s.egid_matches_pw_gid
+        {
+            writeln!(
+                f,
+                "  • effective GID does not match passwd pw_gid \
+                 (e.g. running under `newgrp` or with a non-default primary group)"
+            )?;
+        }
+        writeln!(f)?;
+        writeln!(f, "Pick one of the following:")?;
+        writeln!(f)?;
+        writeln!(f, "  1. Disable the AppArmor userns restriction:")?;
+        writeln!(
+            f,
+            "       sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0"
+        )?;
+        writeln!(
+            f,
+            "       echo 'kernel.apparmor_restrict_unprivileged_userns=0' \\"
+        )?;
+        writeln!(f, "         | sudo tee /etc/sysctl.d/60-pelagos.conf")?;
+        writeln!(f)?;
+        writeln!(f, "  2. Install uidmap and configure subordinate UID/GID:")?;
+        writeln!(f, "       sudo apt install uidmap")?;
+        writeln!(
+            f,
+            "       sudo usermod --add-subuids 100000-165535 {}",
+            user
+        )?;
+        writeln!(
+            f,
+            "       sudo usermod --add-subgids 100000-165535 {}",
+            user
+        )?;
+        writeln!(f)?;
+        writeln!(f, "  3. Run as root:  sudo -E pelagos run …")?;
+        writeln!(f)?;
+        write!(
+            f,
+            "See docs/USER_GUIDE.md → Troubleshooting for details. \
+             Set PELAGOS_SKIP_ROOTLESS_CHECK=1 to bypass this check."
+        )
+    }
+}
+
+impl std::error::Error for RootlessSetupError {}
+
+/// Pure decision: given a set of signals, return an error iff rootless setup
+/// is predicted to fail. The conjunction is:
+/// `apparmor_restricted AND NOT newuidmap_path_works`.
+pub fn diagnose(s: &Signals) -> Option<RootlessSetupError> {
+    if s.apparmor_restricted && !s.newuidmap_path_works() {
+        Some(RootlessSetupError { signals: s.clone() })
+    } else {
+        None
+    }
+}
+
+/// Probe the host and return an error if rootless setup is predicted to fail.
+/// Honours `PELAGOS_SKIP_ROOTLESS_CHECK=1`.
+pub fn check() -> Result<(), RootlessSetupError> {
+    if std::env::var_os(SKIP_ENV).is_some() {
+        log::debug!("rootless_check: bypassed via {}", SKIP_ENV);
+        return Ok(());
+    }
+    match diagnose(&Signals::probe()) {
+        None => Ok(()),
+        Some(e) => Err(e),
+    }
+}
+
+/// Read `/proc/sys/kernel/apparmor_restrict_unprivileged_userns`. File absent
+/// (non-Ubuntu kernels, or the LSM not loaded) is treated as `0`.
+fn read_apparmor_userns_flag() -> bool {
+    std::fs::read_to_string(APPARMOR_USERNS_PROC)
+        .map(|s| s.trim() == "1")
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn signals(
+        apparmor: bool,
+        nuid: bool,
+        ngid: bool,
+        egid_ok: bool,
+        subuid: usize,
+        subgid: usize,
+    ) -> Signals {
+        Signals {
+            apparmor_restricted: apparmor,
+            has_newuidmap: nuid,
+            has_newgidmap: ngid,
+            egid_matches_pw_gid: egid_ok,
+            subuid_entries: subuid,
+            subgid_entries: subgid,
+            username: Some("alice".into()),
+        }
+    }
+
+    #[test]
+    fn no_apparmor_restriction_means_no_error() {
+        // AppArmor unrestricted: even with everything else broken, we let the
+        // kernel decide. (In practice newuidmap_will_work etc. matter, but the
+        // EACCES-on-setgroups failure that this check exists to catch only
+        // happens when AppArmor restricts the userns.)
+        let s = signals(false, false, false, false, 0, 0);
+        assert!(diagnose(&s).is_none());
+    }
+
+    #[test]
+    fn apparmor_with_working_newuidmap_path_is_silent() {
+        // AppArmor on, but newuidmap will run end-to-end → we never hit
+        // the setgroups write → no diagnostic.
+        let s = signals(true, true, true, true, 1, 1);
+        assert!(diagnose(&s).is_none());
+    }
+
+    #[test]
+    fn apparmor_plus_no_newuidmap_binary_trips_check() {
+        let s = signals(true, false, false, true, 1, 1);
+        let err = diagnose(&s).expect("should diagnose");
+        let text = format!("{}", err);
+        assert!(text.contains("apparmor_restrict_unprivileged_userns"));
+        assert!(text.contains("uidmap package not installed"));
+    }
+
+    #[test]
+    fn apparmor_plus_no_subuid_entry_trips_check() {
+        let s = signals(true, true, true, true, 0, 1);
+        let err = diagnose(&s).expect("should diagnose");
+        let text = format!("{}", err);
+        assert!(text.contains("no /etc/subuid entry for alice"));
+        // subgid line must NOT fire when subgid is fine
+        assert!(!text.contains("no /etc/subgid entry"));
+    }
+
+    #[test]
+    fn apparmor_plus_no_subgid_entry_trips_check() {
+        let s = signals(true, true, true, true, 1, 0);
+        let err = diagnose(&s).expect("should diagnose");
+        let text = format!("{}", err);
+        assert!(text.contains("no /etc/subgid entry for alice"));
+    }
+
+    #[test]
+    fn apparmor_plus_egid_mismatch_trips_check() {
+        // Helpers present, subids configured, but egid != pw_gid (newgrp shell
+        // or domain primary group)
+        let s = signals(true, true, true, false, 1, 1);
+        let err = diagnose(&s).expect("should diagnose");
+        let text = format!("{}", err);
+        assert!(text.contains("effective GID does not match passwd pw_gid"));
+    }
+
+    #[test]
+    fn full_diagnostic_lists_every_blocker() {
+        let s = signals(true, false, false, false, 0, 0);
+        let err = diagnose(&s).expect("should diagnose");
+        let text = format!("{}", err);
+        for needle in [
+            "apparmor_restrict_unprivileged_userns",
+            "uidmap package not installed",
+            "no /etc/subuid entry for alice",
+            "no /etc/subgid entry for alice",
+        ] {
+            assert!(text.contains(needle), "missing {:?} in:\n{}", needle, text);
+        }
+        // egid line should NOT fire when uidmap helpers are missing
+        // (the user can't even reach the egid check in that case)
+        assert!(!text.contains("effective GID does not match"));
+    }
+
+    #[test]
+    fn display_falls_back_to_user_placeholder() {
+        let mut s = signals(true, true, true, true, 0, 0);
+        s.username = None;
+        let err = diagnose(&s).expect("should diagnose");
+        let text = format!("{}", err);
+        // No real username known → use $USER placeholder in fix instructions
+        assert!(text.contains("$USER"));
+    }
+
+    #[test]
+    fn display_includes_all_three_workarounds_in_order() {
+        let s = signals(true, false, false, false, 0, 0);
+        let text = format!("{}", diagnose(&s).expect("should diagnose"));
+        let p1 = text.find("1. Disable the AppArmor").expect("workaround 1");
+        let p2 = text.find("2. Install uidmap").expect("workaround 2");
+        let p3 = text.find("3. Run as root").expect("workaround 3");
+        assert!(p1 < p2 && p2 < p3, "workarounds out of order");
+        assert!(text.contains("PELAGOS_SKIP_ROOTLESS_CHECK"));
+    }
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -20676,7 +20676,7 @@ mod compose_shutdown_fixes {
                 let pid: u32 = e.file_name().to_string_lossy().parse().ok()?;
                 let stat = std::fs::read_to_string(format!("/proc/{}/stat", pid)).ok()?;
                 let after_comm = stat.rfind(')')?;
-                let mut fields = stat[after_comm + 2..].trim_start().split_whitespace();
+                let mut fields = stat[after_comm + 2..].split_whitespace();
                 let _state = fields.next()?;
                 let _ppid = fields.next()?;
                 let pgrp: u32 = fields.next()?.parse().ok()?;


### PR DESCRIPTION
## Summary

Closes #220.

When `kernel.apparmor_restrict_unprivileged_userns=1` (Ubuntu 24.04+ default) and the `newuidmap` path can't run end-to-end, pelagos's single-UID rootless setup fails with a confusing `EACCES` on `/proc/self/setgroups`. This change detects that conjunction up front and emits a targeted hint listing the precise workarounds, instead of surfacing the raw kernel errno.

Follow-up to #219 (which made the masked errno faithful but didn't tell users what to do about it).

### What's new

- **`src/rootless_check.rs`** — `Signals::probe()` reads the AppArmor flag, idmap helpers, and subuid/subgid entries. `diagnose()` is a pure decision (testable without filesystem) returning an error iff `apparmor_restricted && !newuidmap_path_works`. `check()` wraps probe + diagnose and honours `PELAGOS_SKIP_ROOTLESS_CHECK=1` as an escape hatch.
- **Wire-in** at `Command::spawn()` (`container.rs:2635`) and `Command::spawn_interactive()` (`container.rs:5258`) inside the existing `is_rootless && !joining_user_ns && !skip_rootless_user_ns` block. Advisory only — if the check false-negatives, the underlying syscall still produces the faithful errno from #219.
- **Output** lists each independent blocker the user should fix, plus three numbered workarounds in order: disable AppArmor restriction, install uidmap + add subuid/subgid, or run as root.
- **Fold-in:** clippy fix in `tests/integration_tests.rs:20679` (`trim_start().split_whitespace()` → `split_whitespace()`).

### Sample output (apparmor=1, no uidmap, no subid entries)

```
pelagos: error: rootless container setup is not supported in this environment.

Detected:
  • kernel.apparmor_restrict_unprivileged_userns = 1 (Ubuntu 24.04+ default)
  • uidmap package not installed (newuidmap/newgidmap missing)
  • no /etc/subuid entry for chbrown
  • no /etc/subgid entry for chbrown

Pick one of the following:

  1. Disable the AppArmor userns restriction:
       sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       echo 'kernel.apparmor_restrict_unprivileged_userns=0' \
         | sudo tee /etc/sysctl.d/60-pelagos.conf

  2. Install uidmap and configure subordinate UID/GID:
       sudo apt install uidmap
       sudo usermod --add-subuids 100000-165535 chbrown
       sudo usermod --add-subgids 100000-165535 chbrown

  3. Run as root:  sudo -E pelagos run …

See docs/USER_GUIDE.md → Troubleshooting for details. Set PELAGOS_SKIP_ROOTLESS_CHECK=1 to bypass this check.
```

## Test plan

- [x] `cargo test --lib rootless_check` — 9/9 unit tests pass (covers all-clear, working newuidmap with apparmor on, each individual blocker, all blockers, username-unknown fallback, workaround ordering)
- [x] `cargo test --lib` — 344/344 pass (no regressions)
- [x] `cargo build --bins` — clean
- [x] Live verification on apparmor=0 host: `pelagos run --rm alpine /bin/echo ok` — check is silent, container runs
- [x] Live verification of bypass: `PELAGOS_SKIP_ROOTLESS_CHECK=1 pelagos run …` emits debug log line `rootless_check: bypassed via PELAGOS_SKIP_ROOTLESS_CHECK` and proceeds normally
- [ ] Manual verification on a host with `kernel.apparmor_restrict_unprivileged_userns=1` and no uidmap installed (i.e. fresh Ubuntu 24.04+) — expect the formatted hint above instead of `EACCES`

## Out of scope (deferred to follow-ups per issue)

- `setup.sh --enable-rootless` writing `/etc/sysctl.d/60-pelagos.conf` and appending `/etc/subuid` / `/etc/subgid` entries
- Shipping an AppArmor profile that lets pelagos keep capabilities in its child userns (the crun/bwrap route on Ubuntu 24.04+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)