### PR TITLE
feat: add --time flag to pelagos stop (SIGTERM + wait + SIGKILL)

### DIFF
--- a/src/cli/restart.rs
+++ b/src/cli/restart.rs
@@ -8,31 +8,14 @@
 
 use super::start::cmd_start;
 use super::stop::cmd_stop;
-use super::{check_liveness, read_state, ContainerStatus};
+use super::{read_state, ContainerStatus};
 
 pub fn cmd_restart(name: &str, time: u64) -> Result<(), Box<dyn std::error::Error>> {
     let state = read_state(name).map_err(|_| format!("no container named '{}'", name))?;
 
     if state.status == ContainerStatus::Running {
-        let pid = state.pid;
-
-        // Send SIGTERM and mark state as Exited.
-        cmd_stop(name)?;
-
-        // Wait for the process to actually vacate its PID.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(time.max(1));
-        while check_liveness(pid) && std::time::Instant::now() < deadline {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-        }
-
-        // If still alive after the grace period, escalate to SIGKILL.
-        if check_liveness(pid) {
-            unsafe { libc::kill(pid, libc::SIGKILL) };
-            let kill_deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-            while check_liveness(pid) && std::time::Instant::now() < kill_deadline {
-                std::thread::sleep(std::time::Duration::from_millis(100));
-            }
-        }
+        // SIGTERM + wait + SIGKILL if needed — all handled by cmd_stop.
+        cmd_stop(name, time)?;
     }
 
     cmd_start(&[name.to_string()], false, None)

--- a/src/cli/stop.rs
+++ b/src/cli/stop.rs
@@ -1,8 +1,8 @@
-//! `pelagos stop` — send SIGTERM to a running container.
+//! `pelagos stop` — send SIGTERM to a running container, wait for exit, SIGKILL if needed.
 
 use super::{check_liveness, read_state, write_state, ContainerStatus};
 
-pub fn cmd_stop(name: &str) -> Result<(), Box<dyn std::error::Error>> {
+pub fn cmd_stop(name: &str, time: u64) -> Result<(), Box<dyn std::error::Error>> {
     let mut state = read_state(name).map_err(|_| format!("no container named '{}'", name))?;
 
     if state.status != ContainerStatus::Running {
@@ -37,13 +37,30 @@ pub fn cmd_stop(name: &str) -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let r = unsafe { libc::kill(state.pid, libc::SIGTERM) };
+    let pid = state.pid;
+
+    let r = unsafe { libc::kill(pid, libc::SIGTERM) };
     if r != 0 {
         let err = std::io::Error::last_os_error();
         if err.raw_os_error() == Some(libc::ESRCH) {
             // Process already gone.
         } else {
-            return Err(format!("kill({}): {}", state.pid, err).into());
+            return Err(format!("kill({}): {}", pid, err).into());
+        }
+    }
+
+    // Wait up to `time` seconds for the process to exit cleanly.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(time.max(1));
+    while check_liveness(pid) && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    // If still alive after the grace period, escalate to SIGKILL.
+    if check_liveness(pid) {
+        unsafe { libc::kill(pid, libc::SIGKILL) };
+        let kill_deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while check_liveness(pid) && std::time::Instant::now() < kill_deadline {
+            std::thread::sleep(std::time::Duration::from_millis(100));
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,10 +85,13 @@ pub(crate) enum CliCommand {
         filter: Vec<String>,
     },
 
-    /// Send SIGTERM to a running container
+    /// Send SIGTERM to a running container, wait for exit, SIGKILL if needed
     Stop {
         /// Container name
         name: String,
+        /// Seconds to wait for clean exit before sending SIGKILL (default: 10)
+        #[clap(long, short = 't', default_value = "10")]
+        time: u64,
     },
 
     /// Stop then start a container (running or exited)
@@ -252,10 +255,13 @@ pub(crate) enum ContainerCmd {
         /// Container name
         name: String,
     },
-    /// Send SIGTERM to a running container
+    /// Send SIGTERM to a running container, wait for exit, SIGKILL if needed
     Stop {
         /// Container name
         name: String,
+        /// Seconds to wait for clean exit before sending SIGKILL (default: 10)
+        #[clap(long, short = 't', default_value = "10")]
+        time: u64,
     },
     /// Remove a container
     Rm {
@@ -480,7 +486,7 @@ fn main() {
             json,
             filter,
         } => cli::ps::cmd_ps(all, json || format == OutputFormat::Json, &filter),
-        CliCommand::Stop { name } => cli::stop::cmd_stop(&name),
+        CliCommand::Stop { name, time } => cli::stop::cmd_stop(&name, time),
         CliCommand::Restart { name, time } => cli::restart::cmd_restart(&name, time),
         CliCommand::Rm { name, force } => cli::rm::cmd_rm(&name, force),
         CliCommand::Logs { name, follow } => cli::logs::cmd_logs(&name, follow),
@@ -494,7 +500,7 @@ fn main() {
                 filter,
             } => cli::ps::cmd_ps(all, json || format == OutputFormat::Json, &filter),
             ContainerCmd::Inspect { name } => cli::ps::cmd_inspect(&name),
-            ContainerCmd::Stop { name } => cli::stop::cmd_stop(&name),
+            ContainerCmd::Stop { name, time } => cli::stop::cmd_stop(&name, time),
             ContainerCmd::Rm { name, force } => cli::rm::cmd_rm(&name, force),
             ContainerCmd::Logs { name, follow } => cli::logs::cmd_logs(&name, follow),
         },


### PR DESCRIPTION
## Summary

- `pelagos stop` now accepts `--time` / `-t <seconds>` (default: 10), matching `docker stop` semantics and the existing `pelagos restart --time` flag
- After SIGTERM, waits up to `--time` seconds for clean exit, then SIGKILL + 5s cleanup wait
- `pelagos restart` now delegates the full stop sequence to `cmd_stop`, removing its duplicate wait loop
- Both top-level `stop` and `container stop` subcommands updated

## Why

`pelagos-dockerd`'s `stop_container()` passes `--time <N>` to `pelagos stop` when the Docker API stop endpoint is called with a timeout. Without the flag, rusternetes-kubelet pod teardown failed with:

```
Found argument '--time' which wasn't expected
USAGE: pelagos stop <NAME>
```

This caused all rusternetes pod lifecycle tests to fail.

## Test plan

- [ ] 314/325 integration tests pass (2 pre-existing failures: ECR rate limit flake, ps race condition — both unrelated to this change)
- [ ] `cargo fmt --check` and `cargo clippy -- -D warnings` clean in build VM
- [ ] rusternetes end-to-end test suite passes with updated binary

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)