### PR TITLE
feat: pelagos-cri CRI gRPC server (C2–C6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,6 +1271,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,6 +1520,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,6 +1675,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1657,6 +1705,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,7 +1734,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2435,6 +2496,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pelagos-cri"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "env_logger",
+ "futures-core",
+ "log",
+ "prost 0.13.5",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
+ "uuid",
+]
+
+[[package]]
 name = "pelagos-dockerd"
 version = "0.1.0"
 dependencies = [
@@ -2464,8 +2543,38 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.2.0",
  "indexmap 1.9.1",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "indexmap 2.13.0",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -2653,7 +2762,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.8.0",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
 ]
 
 [[package]]
@@ -2667,11 +2786,31 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "multimap",
- "petgraph",
- "prost",
- "prost-types",
+ "petgraph 0.5.1",
+ "prost 0.8.0",
+ "prost-types 0.8.0",
  "tempfile",
  "which 4.4.2",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph 0.7.1",
+ "prettyplease",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "regex",
+ "syn 2.0.116",
+ "tempfile",
 ]
 
 [[package]]
@@ -2688,13 +2827,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.8.0",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -2784,7 +2945,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2822,7 +2983,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3410,6 +3571,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -3698,7 +3869,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3721,6 +3892,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -3809,11 +3991,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.1",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3940,9 +4175,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa71f4a44711b3b9cc10ed0c7e239ff0fe4b8e6c900a142fb3bb26401385718"
 dependencies = [
  "derive-new",
- "prost",
- "prost-build",
- "prost-types",
+ "prost 0.8.0",
+ "prost-build 0.8.0",
+ "prost-types 0.8.0",
  "protobuf",
  "protobuf-codegen",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "pelagos-dockerd"]
+members = [".", "pelagos-dockerd", "pelagos-cri"]
 resolver = "2"
 
 [package]

--- a/pelagos-cri/Cargo.toml
+++ b/pelagos-cri/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "pelagos-cri"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.76"
+description = "Kubernetes CRI gRPC server that delegates to the pelagos container runtime"
+license = "Apache-2.0"
+
+[[bin]]
+name = "pelagos-cri"
+path = "src/main.rs"
+
+[dependencies]
+log = "0.4"
+env_logger = "0.11"
+clap = { version = "3.1.6", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "net", "time", "io-util", "process", "fs", "macros", "signal"] }
+tokio-stream = { version = "0.1", features = ["net"] }
+tonic = { version = "0.12", features = ["transport"] }
+prost = "0.13"
+uuid = { version = "1", features = ["v4"] }
+futures-core = "0.3"
+
+[build-dependencies]
+tonic-build = "0.12"

--- a/pelagos-cri/build.rs
+++ b/pelagos-cri/build.rs
@@ -1,0 +1,7 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure()
+        .build_server(true)
+        .build_client(false)
+        .compile_protos(&["proto/api.proto"], &["proto"])?;
+    Ok(())
+}

--- a/pelagos-cri/proto/api.proto
+++ b/pelagos-cri/proto/api.proto
@@ -1,0 +1,2279 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// To regenerate api.pb.go run `hack/update-codegen.sh protobindings`
+syntax = "proto3";
+
+package runtime.v1;
+option go_package = "k8s.io/cri-api/pkg/apis/runtime/v1";
+
+// Runtime service defines the public APIs for remote container runtimes
+service RuntimeService {
+    // Version returns the runtime name, runtime version, and runtime API version.
+    rpc Version(VersionRequest) returns (VersionResponse) {}
+
+    // RunPodSandbox creates and starts a pod-level sandbox. Runtimes must ensure
+    // the sandbox is in the ready state on success.
+    rpc RunPodSandbox(RunPodSandboxRequest) returns (RunPodSandboxResponse) {}
+    // StopPodSandbox stops any running process that is part of the sandbox and
+    // reclaims network resources (e.g., IP addresses) allocated to the sandbox.
+    // If there are any running containers in the sandbox, they must be forcibly
+    // terminated.
+    // This call is idempotent, and must not return an error if all relevant
+    // resources have already been reclaimed. kubelet will call StopPodSandbox
+    // at least once before calling RemovePodSandbox. It will also attempt to
+    // reclaim resources eagerly, as soon as a sandbox is not needed. Hence,
+    // multiple StopPodSandbox calls are expected.
+    rpc StopPodSandbox(StopPodSandboxRequest) returns (StopPodSandboxResponse) {}
+    // RemovePodSandbox removes the sandbox. If there are any running containers
+    // in the sandbox, they must be forcibly terminated and removed.
+    // This call is idempotent, and must not return an error if the sandbox has
+    // already been removed.
+    rpc RemovePodSandbox(RemovePodSandboxRequest) returns (RemovePodSandboxResponse) {}
+    // PodSandboxStatus returns the status of the PodSandbox. If the PodSandbox is not
+    // present, returns an error.
+    rpc PodSandboxStatus(PodSandboxStatusRequest) returns (PodSandboxStatusResponse) {}
+    // ListPodSandbox returns a list of PodSandboxes.
+    rpc ListPodSandbox(ListPodSandboxRequest) returns (ListPodSandboxResponse) {}
+    // StreamPodSandboxes returns a stream of PodSandboxes.
+    // This is an alternative to ListPodSandbox that streams results in lists
+    // of at least one item, avoiding the gRPC message size limit for nodes with
+    // many pods. The number of items per list may vary depending on the
+    // container runtime. Each item must appear in exactly one response and must
+    // not be duplicated across responses in the same stream. The server must
+    // close the stream with EOF after all items have been sent. The kubelet
+    // collects all items from the stream and processes them all at once after
+    // the stream completes. The kubelet enforces a timeout on the entire stream
+    // and will discard partial results if the stream is not completed in time.
+    // Feature gate: CRIListStreaming
+    // See https://kep.k8s.io/5825 for more details.
+    rpc StreamPodSandboxes(StreamPodSandboxesRequest) returns (stream StreamPodSandboxesResponse) {}
+
+    // CreateContainer creates a new container in specified PodSandbox
+    rpc CreateContainer(CreateContainerRequest) returns (CreateContainerResponse) {}
+    // StartContainer starts the container.
+    rpc StartContainer(StartContainerRequest) returns (StartContainerResponse) {}
+    // StopContainer stops a running container with a grace period (i.e., timeout).
+    // This call is idempotent, and must not return an error if the container has
+    // already been stopped.
+    // The runtime must forcibly kill the container after the grace period is
+    // reached.
+    rpc StopContainer(StopContainerRequest) returns (StopContainerResponse) {}
+    // RemoveContainer removes the container. If the container is running, the
+    // container must be forcibly removed.
+    // This call is idempotent, and must not return an error if the container has
+    // already been removed.
+    rpc RemoveContainer(RemoveContainerRequest) returns (RemoveContainerResponse) {}
+    // ListContainers lists all containers by filters.
+    rpc ListContainers(ListContainersRequest) returns (ListContainersResponse) {}
+    // StreamContainers returns a stream of containers.
+    // This is an alternative to ListContainers that streams results in lists
+    // of at least one item, avoiding the gRPC message size limit for nodes with
+    // many containers. The number of items per list may vary depending on the
+    // container runtime. Each item must appear in exactly one response and must
+    // not be duplicated across responses in the same stream. The server must
+    // close the stream with EOF after all items have been sent. The kubelet
+    // collects all items from the stream and processes them all at once after
+    // the stream completes. The kubelet enforces a timeout on the entire stream
+    // and will discard partial results if the stream is not completed in time.
+    // Feature gate: CRIListStreaming
+    // See https://kep.k8s.io/5825 for more details.
+    rpc StreamContainers(StreamContainersRequest) returns (stream StreamContainersResponse) {}
+    // ContainerStatus returns status of the container. If the container is not
+    // present, returns an error.
+    rpc ContainerStatus(ContainerStatusRequest) returns (ContainerStatusResponse) {}
+    // UpdateContainerResources updates ContainerConfig of the container synchronously.
+    // If runtime fails to transactionally update the requested resources, an error is returned.
+    rpc UpdateContainerResources(UpdateContainerResourcesRequest) returns (UpdateContainerResourcesResponse) {}
+    // ReopenContainerLog asks runtime to reopen the stdout/stderr log file
+    // for the container. This is often called after the log file has been
+    // rotated. If the container is not running, container runtime can choose
+    // to either create a new log file and return nil, or return an error.
+    // Once it returns error, new container log file MUST NOT be created.
+    rpc ReopenContainerLog(ReopenContainerLogRequest) returns (ReopenContainerLogResponse) {}
+
+    // ExecSync runs a command in a container synchronously.
+    rpc ExecSync(ExecSyncRequest) returns (ExecSyncResponse) {}
+    // Exec prepares a streaming endpoint to execute a command in the container.
+    rpc Exec(ExecRequest) returns (ExecResponse) {}
+    // Attach prepares a streaming endpoint to attach to a running container.
+    rpc Attach(AttachRequest) returns (AttachResponse) {}
+    // PortForward prepares a streaming endpoint to forward ports from a PodSandbox.
+    rpc PortForward(PortForwardRequest) returns (PortForwardResponse) {}
+
+    // ContainerStats returns stats of the container. If the container does not
+    // exist, the call returns an error.
+    rpc ContainerStats(ContainerStatsRequest) returns (ContainerStatsResponse) {}
+    // ListContainerStats returns stats of all running containers.
+    rpc ListContainerStats(ListContainerStatsRequest) returns (ListContainerStatsResponse) {}
+    // StreamContainerStats returns a stream of container stats.
+    // This is an alternative to ListContainerStats that streams results in
+    // lists of at least one item, avoiding the gRPC message size limit for
+    // nodes with many containers. The number of items per list may vary
+    // depending on the container runtime. Each item must appear in exactly one
+    // response and must not be duplicated across responses in the same stream.
+    // The server must close the stream with EOF after all items have been sent.
+    // The kubelet collects all items from the stream and processes them all at
+    // once after the stream completes. The kubelet enforces a timeout on the
+    // entire stream and will discard partial results if the stream is not
+    // completed in time.
+    // Feature gate: CRIListStreaming
+    // See https://kep.k8s.io/5825 for more details.
+    rpc StreamContainerStats(StreamContainerStatsRequest) returns (stream StreamContainerStatsResponse) {}
+
+    // PodSandboxStats returns stats of the pod sandbox. If the pod sandbox does not
+    // exist, the call returns an error.
+    rpc PodSandboxStats(PodSandboxStatsRequest) returns (PodSandboxStatsResponse) {}
+    // ListPodSandboxStats returns stats of the pod sandboxes matching a filter.
+    rpc ListPodSandboxStats(ListPodSandboxStatsRequest) returns (ListPodSandboxStatsResponse) {}
+    // StreamPodSandboxStats returns a stream of pod sandbox stats.
+    // This is an alternative to ListPodSandboxStats that streams results in
+    // lists of at least one item, avoiding the gRPC message size limit for
+    // nodes with many pods. The number of items per list may vary depending on
+    // the container runtime. Each item must appear in exactly one response and
+    // must not be duplicated across responses in the same stream. The server
+    // must close the stream with EOF after all items have been sent. The
+    // kubelet collects all items from the stream and processes them all at once
+    // after the stream completes. The kubelet enforces a timeout on the entire
+    // stream and will discard partial results if the stream is not completed
+    // in time.
+    // Feature gate: CRIListStreaming
+    // See https://kep.k8s.io/5825 for more details.
+    rpc StreamPodSandboxStats(StreamPodSandboxStatsRequest) returns (stream StreamPodSandboxStatsResponse) {}
+
+    // UpdateRuntimeConfig updates the runtime configuration based on the given request.
+    rpc UpdateRuntimeConfig(UpdateRuntimeConfigRequest) returns (UpdateRuntimeConfigResponse) {}
+
+    // Status returns the status of the runtime.
+    rpc Status(StatusRequest) returns (StatusResponse) {}
+
+    // CheckpointContainer checkpoints a container
+    rpc CheckpointContainer(CheckpointContainerRequest) returns (CheckpointContainerResponse) {}
+
+    // GetContainerEvents gets container events from the CRI runtime
+    rpc GetContainerEvents(GetEventsRequest) returns (stream ContainerEventResponse) {}
+
+    // ListMetricDescriptors gets the descriptors for the metrics that will be returned in ListPodSandboxMetrics.
+    // This list should be static at startup: either the client and server restart together when
+    // adding or removing metrics descriptors, or they should not change.
+    // Put differently, if ListPodSandboxMetrics references a name that is not described in the initial
+    // ListMetricDescriptors call, then the metric will not be broadcasted.
+    rpc ListMetricDescriptors(ListMetricDescriptorsRequest) returns (ListMetricDescriptorsResponse) {}
+
+    // ListPodSandboxMetrics gets pod sandbox metrics from CRI Runtime
+    rpc ListPodSandboxMetrics(ListPodSandboxMetricsRequest) returns (ListPodSandboxMetricsResponse) {}
+    // StreamPodSandboxMetrics returns a stream of pod sandbox metrics.
+    // This is an alternative to ListPodSandboxMetrics that streams results in
+    // lists of at least one item, avoiding the gRPC message size limit for
+    // nodes with many pods. The number of items per list may vary depending on
+    // the container runtime. Each item must appear in exactly one response and
+    // must not be duplicated across responses in the same stream. The server
+    // must close the stream with EOF after all items have been sent. The
+    // kubelet collects all items from the stream and processes them all at once
+    // after the stream completes. The kubelet enforces a timeout on the entire
+    // stream and will discard partial results if the stream is not completed
+    // in time.
+    // Feature gate: CRIListStreaming
+    // See https://kep.k8s.io/5825 for more details.
+    rpc StreamPodSandboxMetrics(StreamPodSandboxMetricsRequest) returns (stream StreamPodSandboxMetricsResponse) {}
+
+    // RuntimeConfig returns configuration information of the runtime.
+    // A couple of notes:
+    // - The RuntimeConfigRequest object is not to be confused with the contents of UpdateRuntimeConfigRequest.
+    //   The former is for having runtime tell Kubelet what to do, the latter vice versa.
+    // - It is the expectation of the Kubelet that these fields are static for the lifecycle of the Kubelet.
+    //   The Kubelet will not re-request the RuntimeConfiguration after startup, and CRI implementations should
+    //   avoid updating them without a full node reboot.
+    rpc RuntimeConfig(RuntimeConfigRequest) returns (RuntimeConfigResponse) {}
+
+    // UpdatePodSandboxResources synchronously updates the PodSandboxConfig with
+    // the pod-level resource configuration. This method is called _after_ the
+    // Kubelet reconfigures the pod-level cgroups.
+    // This request is treated as best effort, and failure will not block the
+    // Kubelet with proceeding with a resize.
+    rpc UpdatePodSandboxResources(UpdatePodSandboxResourcesRequest) returns (UpdatePodSandboxResourcesResponse) {}
+}
+
+// ImageService defines the public APIs for managing images.
+service ImageService {
+    // ListImages lists existing images.
+    rpc ListImages(ListImagesRequest) returns (ListImagesResponse) {}
+    // StreamImages returns a stream of images.
+    // This is an alternative to ListImages that streams results in lists of at
+    // least one item, avoiding the gRPC message size limit for nodes with many
+    // images. The number of items per list may vary depending on the container
+    // runtime. Each item must appear in exactly one response and must not be
+    // duplicated across responses in the same stream. The server must close the
+    // stream with EOF after all items have been sent. The kubelet collects all
+    // items from the stream and processes them all at once after the stream
+    // completes. The kubelet enforces a timeout on the entire stream and will
+    // discard partial results if the stream is not completed in time.
+    // Feature gate: CRIListStreaming
+    // See https://kep.k8s.io/5825 for more details.
+    rpc StreamImages(StreamImagesRequest) returns (stream StreamImagesResponse) {}
+    // ImageStatus returns the status of the image. If the image is not
+    // present, returns a response with ImageStatusResponse.Image set to
+    // nil.
+    rpc ImageStatus(ImageStatusRequest) returns (ImageStatusResponse) {}
+    // PullImage pulls an image with authentication config.
+    rpc PullImage(PullImageRequest) returns (PullImageResponse) {}
+    // RemoveImage removes the image.
+    // This call is idempotent, and must not return an error if the image has
+    // already been removed.
+    // Note that if the image is referenced by multiple tags (even across different repositories
+    // if they resolve to the same image digest), removing the image by a single tag
+    // will remove all of its tags. For example, if `repo/image:v1` and `another_repo/image:latest`
+    // point to the same image, removing `repo/image:v1` will also remove `another_repo/image:latest`.
+    // The next call to ListImages, ImageStatus, ImageFsInfo will not return this image.
+    // The resources (e.g. disk space) may be cleaned asynchronously
+    // and not guaranteed to be cleaned up by the time this method returns.
+    rpc RemoveImage(RemoveImageRequest) returns (RemoveImageResponse) {}
+    // ImageFSInfo returns information of the filesystem that is used to store images.
+    // Usage information may include images that were removed, but are still being cleaned up.
+    rpc ImageFsInfo(ImageFsInfoRequest) returns (ImageFsInfoResponse) {}
+}
+
+message VersionRequest {
+    // Version of the kubelet runtime API.
+    string version = 1;
+}
+
+message VersionResponse {
+    // Version of the kubelet runtime API.
+    string version = 1;
+    // Name of the container runtime.
+    string runtime_name = 2;
+    // Version of the container runtime. The string must be
+    // semver-compatible.
+    string runtime_version = 3;
+    // API version of the container runtime. The string must be
+    // semver-compatible.
+    string runtime_api_version = 4;
+}
+
+// DNSConfig specifies the DNS servers and search domains of a sandbox.
+message DNSConfig {
+    // List of DNS servers of the cluster.
+    repeated string servers = 1;
+    // List of DNS search domains of the cluster.
+    repeated string searches = 2;
+    // List of DNS options. See https://linux.die.net/man/5/resolv.conf
+    // for all available options.
+    repeated string options = 3;
+}
+
+enum Protocol {
+    TCP = 0;
+    UDP = 1;
+    SCTP = 2;
+}
+
+// PortMapping specifies the port mapping configurations of a sandbox.
+message PortMapping {
+    // Protocol of the port mapping.
+    Protocol protocol = 1;
+    // Port number within the container. Default: 0 (not specified).
+    int32 container_port = 2;
+    // Port number on the host to map the container port to.
+    //
+    // * Valid host port range is 1-65535.
+    // * The value 0 has explicit semantic meaning: it indicates NO host port should be allocated.
+    // * The value 0 does NOT indicate dynamic port allocation. Future implementations
+    //   of dynamic allocation will use different values/semantics.
+    // * Implementations MUST handle the case where this field is explicitly set to 0,
+    //   This field SHOULD be omitted when no port is required.
+    //
+    // Default: If omitted, container port will not be exposed on the host.
+    int32 host_port = 3;
+    // Host IP.
+    string host_ip = 4;
+}
+
+enum MountPropagation {
+    // No mount propagation ("rprivate" in Linux terminology).
+    PROPAGATION_PRIVATE = 0;
+    // Mounts get propagated from the host to the container ("rslave" in Linux).
+    PROPAGATION_HOST_TO_CONTAINER = 1;
+    // Mounts get propagated from the host to the container and from the
+    // container to the host ("rshared" in Linux).
+    PROPAGATION_BIDIRECTIONAL = 2;
+}
+
+// Mount specifies a host volume to mount into a container.
+message Mount {
+    // Path of the mount within the container.
+    string container_path = 1;
+    // Path of the mount on the host. Has to be empty if the image field below
+    // is provided, because those fields are mutually exclusive. If the image
+    // field below is nil and the host path doesn't exist, then runtimes should
+    // report an error. If the hostpath is a symbolic link, runtimes should
+    // follow the symlink and mount the real destination to container.
+    string host_path = 2;
+    // If set, the mount is read-only.
+    bool readonly = 3;
+    // If set, the mount needs SELinux relabeling.
+    bool selinux_relabel = 4;
+    // Requested propagation mode.
+    MountPropagation propagation = 5;
+    // UidMappings specifies the runtime UID mappings for the mount.
+    repeated IDMapping uidMappings = 6;
+    // GidMappings specifies the runtime GID mappings for the mount.
+    repeated IDMapping gidMappings = 7;
+    // If set to true, the mount is made recursive read-only.
+    // In this CRI API, recursive_read_only is a plain true/false boolean, although its equivalent
+    // in the Kubernetes core API is a quaternary that can be nil, "Enabled", "IfPossible", or "Disabled".
+    // kubelet translates that quaternary value in the core API into a boolean in this CRI API.
+    // Remarks:
+    // - nil is just treated as false
+    // - when set to true, readonly must be explicitly set to true, and propagation must be PRIVATE (0).
+    // - (readonly == false && recursive_read_only == false) does not make the mount read-only.
+    bool recursive_read_only = 8;
+    // Mount an image reference (image ID, with or without digest), which is a
+    // special use case for image volume mounts. If this field is set, then
+    // host_path should be unset. All image mounts are per feature definition
+    // readonly. The kubelet does an PullImage RPC and evaluates the returned
+    // PullImageResponse.image_ref value, which is then set to the
+    // ImageSpec.image field. Runtimes are expected to mount the image as
+    // required.
+    // Introduced in the Image Volume Source KEP: https://kep.k8s.io/4639
+    ImageSpec image = 9;
+    // Specific image sub path to be used from inside the image instead of its
+    // root, only necessary if the above image field is set. If the sub path is
+    // not empty and does not exist in the image, then runtimes should fail and
+    // return an error.
+    // Introduced in the Image Volume Source KEP beta graduation: https://kep.k8s.io/4639
+    string image_sub_path = 10;
+}
+
+// IDMapping describes host to container ID mappings for a pod sandbox.
+message IDMapping {
+    // HostId is the id on the host.
+    uint32 host_id = 1;
+    // ContainerId is the id in the container.
+    uint32 container_id = 2;
+    // Length is the size of the range to map.
+    uint32 length = 3;
+}
+
+// A NamespaceMode describes the intended namespace configuration for each
+// of the namespaces (Network, PID, IPC) in NamespaceOption. Runtimes should
+// map these modes as appropriate for the technology underlying the runtime.
+enum NamespaceMode {
+    // A POD namespace is common to all containers in a pod.
+    // For example, a container with a PID namespace of POD expects to view
+    // all of the processes in all of the containers in the pod.
+    POD       = 0;
+    // A CONTAINER namespace is restricted to a single container.
+    // For example, a container with a PID namespace of CONTAINER expects to
+    // view only the processes in that container.
+    CONTAINER = 1;
+    // A NODE namespace is the namespace of the Kubernetes node.
+    // For example, a container with a PID namespace of NODE expects to view
+    // all of the processes on the host running the kubelet.
+    NODE      = 2;
+    // TARGET targets the namespace of another container. When this is specified,
+    // a target_id must be specified in NamespaceOption and refer to a container
+    // previously created with NamespaceMode CONTAINER. This containers namespace
+    // will be made to match that of container target_id.
+    // For example, a container with a PID namespace of TARGET expects to view
+    // all of the processes that container target_id can view.
+    TARGET    = 3;
+}
+
+// UserNamespace describes the intended user namespace configuration for a pod sandbox.
+message UserNamespace {
+    // Mode is the NamespaceMode for this UserNamespace.
+    // Note: NamespaceMode for UserNamespace currently supports only POD and NODE, not CONTAINER OR TARGET.
+    NamespaceMode mode = 1;
+
+    // Uids specifies the UID mappings for the user namespace.
+    repeated IDMapping uids = 2;
+
+    // Gids specifies the GID mappings for the user namespace.
+    repeated IDMapping gids = 3;
+}
+
+// NamespaceOption provides options for Linux namespaces.
+message NamespaceOption {
+    // Network namespace for this container/sandbox.
+    // Note: There is currently no way to set CONTAINER scoped network in the Kubernetes API.
+    // Namespaces currently set by the kubelet: POD, NODE
+    NamespaceMode network = 1;
+    // PID namespace for this container/sandbox.
+    // Note: The CRI default is POD, but the v1.PodSpec default is CONTAINER.
+    // The kubelet's runtime manager will set this to CONTAINER explicitly for v1 pods.
+    // Namespaces currently set by the kubelet: POD, CONTAINER, NODE, TARGET
+    NamespaceMode pid = 2;
+    // IPC namespace for this container/sandbox.
+    // Note: There is currently no way to set CONTAINER scoped IPC in the Kubernetes API.
+    // Namespaces currently set by the kubelet: POD, NODE
+    NamespaceMode ipc = 3;
+    // Target Container ID for NamespaceMode of TARGET. This container must have been
+    // previously created in the same pod. It is not possible to specify different targets
+    // for each namespace.
+    string target_id = 4;
+    // UsernsOptions for this pod sandbox.
+    // The Kubelet picks the user namespace configuration to use for the pod sandbox.  The mappings
+    // are specified as part of the UserNamespace struct.  If the struct is nil, then the POD mode
+    // must be assumed.  This is done for backward compatibility with older Kubelet versions that
+    // do not set a user namespace.
+    UserNamespace userns_options = 5;
+}
+
+// SupplementalGroupsPolicy defines how supplemental groups 
+// of the first container processes are calculated.
+enum SupplementalGroupsPolicy {
+    // Merge means that the container's provided SupplementalGroups 
+    // and FsGroup (specified in SecurityContext) will be merged with 
+    // the primary user's groups as defined in the container image
+    // (in /etc/group).
+    Merge = 0;
+    // Strict means that the container's provided SupplementalGroups
+    // and FsGroup (specified in SecurityContext) will be used instead of 
+    // any groups defined in the container image.
+    Strict = 1;
+}
+
+// Int64Value is the wrapper of int64.
+message Int64Value {
+    // The value.
+    int64 value = 1;
+}
+
+// LinuxSandboxSecurityContext holds linux security configuration that will be
+// applied to a sandbox. Note that:
+// 1) It does not apply to containers in the pods.
+// 2) It may not be applicable to a PodSandbox which does not contain any running
+//    process.
+message LinuxSandboxSecurityContext {
+    // Configurations for the sandbox's namespaces.
+    // This will be used only if the PodSandbox uses namespace for isolation.
+    NamespaceOption namespace_options = 1;
+    // Optional SELinux context to be applied.
+    SELinuxOption selinux_options = 2;
+    // UID to run sandbox processes as, when applicable.
+    Int64Value run_as_user = 3;
+    // GID to run sandbox processes as, when applicable. run_as_group should only
+    // be specified when run_as_user is specified; otherwise, the runtime MUST error.
+    Int64Value run_as_group = 8;
+    // If set, the root filesystem of the sandbox is read-only.
+    bool readonly_rootfs = 4;
+    // List of groups applied to the first process run in each container.
+    // supplemental_groups_policy can control how groups will be calculated.
+    repeated int64 supplemental_groups = 5;
+    // supplemental_groups_policy defines how supplemental groups of the first 
+    // container processes are calculated.
+    // Valid values are "Merge" and "Strict".
+    // If not specified, "Merge" is used.
+    SupplementalGroupsPolicy supplemental_groups_policy = 11;
+    // Indicates whether the sandbox will be asked to run a privileged
+    // container. If a privileged container is to be executed within it, this
+    // MUST be true.
+    // This allows a sandbox to take additional security precautions if no
+    // privileged containers are expected to be run.
+    bool privileged = 6;
+    // Seccomp profile for the sandbox.
+    SecurityProfile seccomp = 9;
+    // AppArmor profile for the sandbox.
+    SecurityProfile apparmor = 10;
+    // Seccomp profile for the sandbox, candidate values are:
+    // * runtime/default: the default profile for the container runtime
+    // * unconfined: unconfined profile, ie, no seccomp sandboxing
+    // * localhost/<full-path-to-profile>: the profile installed on the node.
+    //   <full-path-to-profile> is the full path of the profile.
+    // Default: "", which is identical with unconfined.
+    string seccomp_profile_path = 7 [deprecated=true];
+}
+
+// A security profile which can be used for sandboxes and containers.
+message SecurityProfile {
+    // Available profile types.
+    enum ProfileType {
+        // The container runtime default profile should be used.
+        RuntimeDefault = 0;
+        // Disable the feature for the sandbox or the container.
+        Unconfined = 1;
+        // A pre-defined profile on the node should be used.
+        Localhost = 2;
+    }
+    // Indicator which `ProfileType` should be applied.
+    ProfileType profile_type = 1;
+    // Indicates that a pre-defined profile on the node should be used.
+    // Must only be set if `ProfileType` is `Localhost`.
+    // For seccomp, it must be an absolute path to the seccomp profile.
+    // For AppArmor, this field is the AppArmor `<profile name>/`
+    string localhost_ref = 2;
+}
+
+// LinuxPodSandboxConfig holds platform-specific configurations for Linux
+// host platforms and Linux-based containers.
+message LinuxPodSandboxConfig {
+    // Parent cgroup of the PodSandbox.
+    // The cgroupfs style syntax will be used, but the container runtime can
+    // convert it to systemd semantics if needed.
+    string cgroup_parent = 1;
+    // LinuxSandboxSecurityContext holds sandbox security attributes.
+    LinuxSandboxSecurityContext security_context = 2;
+    // Sysctls holds linux sysctls config for the sandbox.
+    map<string, string> sysctls = 3;
+    // Optional overhead represents the overheads associated with this sandbox
+    LinuxContainerResources overhead = 4;
+    // Optional resources represents the sum of container resources for this sandbox
+    LinuxContainerResources resources = 5;
+}
+
+// PodSandboxMetadata holds all necessary information for building the sandbox name.
+// The container runtime is encouraged to expose the metadata associated with the
+// PodSandbox in its user interface for better user experience. For example,
+// the runtime can construct a unique PodSandboxName based on the metadata.
+message PodSandboxMetadata {
+    // Pod name of the sandbox. Same as the pod name in the Pod ObjectMeta.
+    string name = 1;
+    // Pod UID of the sandbox. Same as the pod UID in the Pod ObjectMeta.
+    string uid = 2;
+    // Pod namespace of the sandbox. Same as the pod namespace in the Pod ObjectMeta.
+    string namespace = 3;
+    // Attempt number of creating the sandbox. Default: 0.
+    uint32 attempt = 4;
+}
+
+// PodSandboxConfig holds all the required and optional fields for creating a
+// sandbox.
+message PodSandboxConfig {
+    // Metadata of the sandbox. This information will uniquely identify the
+    // sandbox, and the runtime should leverage this to ensure correct
+    // operation. The runtime may also use this information to improve UX, such
+    // as by constructing a readable name.
+    PodSandboxMetadata metadata = 1;
+    // Hostname of the sandbox. Hostname could only be empty when the pod
+    // network namespace is NODE.
+    string hostname = 2;
+    // Path to the directory on the host in which container log files are
+    // stored.
+    // By default the log of a container going into the LogDirectory will be
+    // hooked up to STDOUT and STDERR. However, the LogDirectory may contain
+    // binary log files with structured logging data from the individual
+    // containers. For example, the files might be newline separated JSON
+    // structured logs, systemd-journald journal files, gRPC trace files, etc.
+    // E.g.,
+    //     PodSandboxConfig.LogDirectory = `/var/log/pods/<NAMESPACE>_<NAME>_<UID>/`
+    //     ContainerConfig.LogPath = `containerName/Instance#.log`
+    string log_directory = 3;
+    // DNS config for the sandbox.
+    DNSConfig dns_config = 4;
+    // Port mappings for the sandbox.
+    repeated PortMapping port_mappings = 5;
+    // Key-value pairs that may be used to scope and select individual resources.
+    map<string, string> labels = 6;
+    // Unstructured key-value map that may be set by the kubelet to store and
+    // retrieve arbitrary metadata. This will include any annotations set on a
+    // pod through the Kubernetes API.
+    //
+    // Annotations MUST NOT be altered by the runtime; the annotations stored
+    // here MUST be returned in the PodSandboxStatus associated with the pod
+    // this PodSandboxConfig creates.
+    //
+    // In general, in order to preserve a well-defined interface between the
+    // kubelet and the container runtime, annotations SHOULD NOT influence
+    // runtime behaviour.
+    //
+    // Annotations can also be useful for runtime authors to experiment with
+    // new features that are opaque to the Kubernetes APIs (both user-facing
+    // and the CRI). Whenever possible, however, runtime authors SHOULD
+    // consider proposing new typed fields for any new features instead.
+    map<string, string> annotations = 7;
+    // Optional configurations specific to Linux hosts.
+    LinuxPodSandboxConfig linux = 8;
+    // Optional configurations specific to Windows hosts.
+    WindowsPodSandboxConfig windows = 9;
+}
+
+message RunPodSandboxRequest {
+    // Configuration for creating a PodSandbox.
+    PodSandboxConfig config = 1;
+    // Named runtime configuration to use for this PodSandbox.
+    // If the runtime handler is unknown, this request should be rejected.  An
+    // empty string should select the default handler, equivalent to the
+    // behavior before this feature was added.
+    // See https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
+    string runtime_handler = 2;
+}
+
+message RunPodSandboxResponse {
+    // ID of the PodSandbox to run.
+    string pod_sandbox_id = 1;
+}
+
+message StopPodSandboxRequest {
+    // ID of the PodSandbox to stop.
+    string pod_sandbox_id = 1;
+}
+
+message StopPodSandboxResponse {}
+
+message RemovePodSandboxRequest {
+    // ID of the PodSandbox to remove.
+    string pod_sandbox_id = 1;
+}
+
+message RemovePodSandboxResponse {}
+
+message PodSandboxStatusRequest {
+    // ID of the PodSandbox for which to retrieve status.
+    string pod_sandbox_id = 1;
+    // Verbose indicates whether to return extra information about the pod sandbox.
+    bool verbose = 2;
+}
+
+// PodIP represents an ip of a Pod
+message PodIP{
+    // an ip is a string representation of an IPv4 or an IPv6
+    string ip = 1;
+}
+// PodSandboxNetworkStatus is the status of the network for a PodSandbox.
+// Currently ignored for pods sharing the host networking namespace.
+message PodSandboxNetworkStatus {
+    // IP address of the PodSandbox.
+    string ip = 1;
+    // list of additional ips (not inclusive of PodSandboxNetworkStatus.Ip) of the PodSandBoxNetworkStatus
+    repeated PodIP additional_ips  = 2;
+}
+
+// Namespace contains paths to the namespaces.
+message Namespace {
+    // Namespace options for Linux namespaces.
+    NamespaceOption options = 2;
+}
+
+// LinuxSandboxStatus contains status specific to Linux sandboxes.
+message LinuxPodSandboxStatus {
+    // Paths to the sandbox's namespaces.
+    Namespace namespaces = 1;
+}
+
+enum PodSandboxState {
+    SANDBOX_READY    = 0;
+    SANDBOX_NOTREADY = 1;
+}
+
+// PodSandboxStatus contains the status of the PodSandbox.
+message PodSandboxStatus {
+    // ID of the sandbox.
+    string id = 1;
+    // Metadata of the sandbox.
+    PodSandboxMetadata metadata = 2;
+    // State of the sandbox.
+    PodSandboxState state = 3;
+    // Creation timestamp of the sandbox in nanoseconds. Must be > 0.
+    int64 created_at = 4;
+    // Network contains network status if network is handled by the runtime.
+    PodSandboxNetworkStatus network = 5;
+    // Linux-specific status to a pod sandbox.
+    LinuxPodSandboxStatus linux = 6;
+    // Labels are key-value pairs that may be used to scope and select individual resources.
+    map<string, string> labels = 7;
+    // Unstructured key-value map holding arbitrary metadata.
+    // Annotations MUST NOT be altered by the runtime; the value of this field
+    // MUST be identical to that of the corresponding PodSandboxConfig used to
+    // instantiate the pod sandbox this status represents.
+    map<string, string> annotations = 8;
+    // runtime configuration used for this PodSandbox.
+    string runtime_handler = 9;
+}
+
+message PodSandboxStatusResponse {
+    // Status of the PodSandbox.
+    PodSandboxStatus status = 1;
+    // Info is extra information of the PodSandbox. The key could be arbitrary string, and
+    // value should be in json format. The information could include anything useful for
+    // debug, e.g. network namespace for linux container based container runtime.
+    // It should only be returned non-empty when Verbose is true.
+    map<string, string> info = 2;
+    // Container statuses
+    repeated ContainerStatus containers_statuses = 3;
+    // Timestamp in nanoseconds at which container and pod statuses were recorded
+    int64 timestamp = 4;
+}
+
+// PodSandboxStateValue is the wrapper of PodSandboxState.
+message PodSandboxStateValue {
+    // State of the sandbox.
+    PodSandboxState state = 1;
+}
+
+// PodSandboxFilter is used to filter a list of PodSandboxes.
+// All those fields are combined with 'AND'
+message PodSandboxFilter {
+    // ID of the sandbox.
+    string id = 1;
+    // State of the sandbox.
+    PodSandboxStateValue state = 2;
+    // LabelSelector to select matches.
+    // Only api.MatchLabels is supported for now and the requirements
+    // are ANDed. MatchExpressions is not supported yet.
+    map<string, string> label_selector = 3;
+}
+
+message ListPodSandboxRequest {
+    // PodSandboxFilter to filter a list of PodSandboxes.
+    PodSandboxFilter filter = 1;
+}
+
+
+// PodSandbox contains minimal information about a sandbox.
+message PodSandbox {
+    // ID of the PodSandbox.
+    string id = 1;
+    // Metadata of the PodSandbox.
+    PodSandboxMetadata metadata = 2;
+    // State of the PodSandbox.
+    PodSandboxState state = 3;
+    // Creation timestamps of the PodSandbox in nanoseconds. Must be > 0.
+    int64 created_at = 4;
+    // Labels of the PodSandbox.
+    map<string, string> labels = 5;
+    // Unstructured key-value map holding arbitrary metadata.
+    // Annotations MUST NOT be altered by the runtime; the value of this field
+    // MUST be identical to that of the corresponding PodSandboxConfig used to
+    // instantiate this PodSandbox.
+    map<string, string> annotations = 6;
+    // runtime configuration used for this PodSandbox.
+    string runtime_handler = 7;
+}
+
+message ListPodSandboxResponse {
+    // List of PodSandboxes.
+    repeated PodSandbox items = 1;
+}
+
+message StreamPodSandboxesRequest {
+    // Filter for the list request.
+    PodSandboxFilter filter = 1;
+}
+
+message StreamPodSandboxesResponse {
+    // List of PodSandboxes.
+    repeated PodSandbox pod_sandboxes = 1;
+}
+
+message PodSandboxStatsRequest {
+    // ID of the pod sandbox for which to retrieve stats.
+    string pod_sandbox_id = 1;
+}
+
+message PodSandboxStatsResponse {
+    PodSandboxStats stats = 1;
+}
+
+// PodSandboxStatsFilter is used to filter the list of pod sandboxes to retrieve stats for.
+// All those fields are combined with 'AND'.
+message PodSandboxStatsFilter {
+    // ID of the pod sandbox.
+    string id = 1;
+    // LabelSelector to select matches.
+    // Only api.MatchLabels is supported for now and the requirements
+    // are ANDed. MatchExpressions is not supported yet.
+    map<string, string> label_selector = 2;
+}
+
+message ListPodSandboxStatsRequest {
+    // Filter for the list request.
+    PodSandboxStatsFilter filter = 1;
+}
+
+message ListPodSandboxStatsResponse {
+    // Stats of the pod sandbox.
+    repeated PodSandboxStats stats = 1;
+}
+
+message StreamPodSandboxStatsRequest {
+    // Filter for the list request.
+    PodSandboxStatsFilter filter = 1;
+}
+
+message StreamPodSandboxStatsResponse {
+    // List of pod sandbox stats.
+    repeated PodSandboxStats pod_sandbox_stats = 1;
+}
+
+// PodSandboxAttributes provides basic information of the pod sandbox.
+message PodSandboxAttributes {
+    // ID of the pod sandbox.
+    string id = 1;
+    // Metadata of the pod sandbox.
+    PodSandboxMetadata metadata = 2;
+    // Key-value pairs that may be used to scope and select individual resources.
+    map<string,string> labels = 3;
+    // Unstructured key-value map holding arbitrary metadata.
+    // Annotations MUST NOT be altered by the runtime; the value of this field
+    // MUST be identical to that of the corresponding PodSandboxStatus used to
+    // instantiate the PodSandbox this status represents.
+    map<string,string> annotations = 4;
+}
+
+// PodSandboxStats provides the resource usage statistics for a pod.
+// The linux or windows field will be populated depending on the platform.
+message PodSandboxStats {
+    // Information of the pod.
+    PodSandboxAttributes attributes = 1;
+    // Stats from linux.
+    LinuxPodSandboxStats linux = 2;
+    // Stats from windows.
+    WindowsPodSandboxStats windows = 3;
+}
+
+// LinuxPodSandboxStats provides the resource usage statistics for a pod sandbox on linux.
+message LinuxPodSandboxStats {
+    // CPU usage gathered for the pod sandbox.
+    CpuUsage cpu = 1;
+    // Memory usage gathered for the pod sandbox.
+    MemoryUsage memory = 2;
+    // Network usage gathered for the pod sandbox
+    NetworkUsage network = 3;
+    // Stats pertaining to processes in the pod sandbox.
+    ProcessUsage process = 4;
+    // Stats of containers in the measured pod sandbox.
+    repeated ContainerStats containers = 5;
+    // IO usage gathered for the pod sandbox.
+    IoUsage io = 6;
+}
+
+// WindowsPodSandboxStats provides the resource usage statistics for a pod sandbox on windows
+message WindowsPodSandboxStats {
+    // CPU usage gathered for the pod sandbox.
+    WindowsCpuUsage cpu = 1;
+    // Memory usage gathered for the pod sandbox.
+    WindowsMemoryUsage memory = 2;
+    // Network usage gathered for the pod sandbox
+    WindowsNetworkUsage network = 3;
+    // Stats pertaining to processes in the pod sandbox.
+    WindowsProcessUsage process = 4;
+    // Stats of containers in the measured pod sandbox.
+    repeated WindowsContainerStats containers = 5;
+}
+
+// NetworkUsage contains data about network resources.
+message NetworkUsage {
+    // Timestamp in nanoseconds at which the information were collected. Must be > 0.
+    int64 timestamp = 1;
+    // Stats for the default network interface.
+    NetworkInterfaceUsage default_interface = 2;
+    // Stats for all found network interfaces, excluding the default.
+    repeated NetworkInterfaceUsage interfaces = 3;
+}
+
+// WindowsNetworkUsage contains data about network resources specific to Windows.
+message WindowsNetworkUsage {
+    // Timestamp in nanoseconds at which the information were collected. Must be > 0.
+    int64 timestamp = 1;
+    // Stats for the default network interface.
+    WindowsNetworkInterfaceUsage default_interface = 2;
+    // Stats for all found network interfaces, excluding the default.
+    repeated WindowsNetworkInterfaceUsage interfaces = 3;
+}
+
+// NetworkInterfaceUsage contains resource value data about a network interface.
+message NetworkInterfaceUsage {
+    // The name of the network interface.
+    string name = 1;
+    // Cumulative count of bytes received.
+    UInt64Value rx_bytes = 2;
+    // Cumulative count of receive errors encountered.
+    UInt64Value rx_errors = 3;
+    // Cumulative count of bytes transmitted.
+    UInt64Value tx_bytes = 4;
+    // Cumulative count of transmit errors encountered.
+    UInt64Value tx_errors = 5;
+}
+
+// WindowsNetworkInterfaceUsage contains resource value data about a network interface specific for Windows.
+message WindowsNetworkInterfaceUsage {
+    // The name of the network interface.
+    string name = 1;
+    // Cumulative count of bytes received.
+    UInt64Value rx_bytes = 2;
+    // Cumulative count of receive errors encountered.
+    UInt64Value rx_packets_dropped = 3;
+    // Cumulative count of bytes transmitted.
+    UInt64Value tx_bytes = 4;
+    // Cumulative count of transmit errors encountered.
+    UInt64Value tx_packets_dropped = 5;
+}
+
+// ProcessUsage are stats pertaining to processes.
+message ProcessUsage {
+    // Timestamp in nanoseconds at which the information were collected. Must be > 0.
+    int64 timestamp = 1;
+    // Number of processes.
+    UInt64Value process_count = 2;
+}
+
+// WindowsProcessUsage are stats pertaining to processes specific to Windows.
+message WindowsProcessUsage {
+    // Timestamp in nanoseconds at which the information were collected. Must be > 0.
+    int64 timestamp = 1;
+    // Number of processes.
+    UInt64Value process_count = 2;
+}
+
+// ImageSpec is an internal representation of an image.
+message ImageSpec {
+    // Container's Image field (e.g. imageID or imageDigest).
+    string image = 1;
+    // Unstructured key-value map holding arbitrary metadata.
+    // ImageSpec Annotations can be used to help the runtime target specific
+    // images in multi-arch images.
+    map<string, string> annotations = 2;
+    // The container image reference specified by the user (e.g. image[:tag] or digest).
+    // Only set if available within the RPC context.
+    string user_specified_image = 18;
+    // Runtime handler to use for pulling the image.
+    // If the runtime handler is unknown, the request should be rejected.
+    // An empty string would select the default runtime handler.
+    string runtime_handler = 19;
+    // The digest of the image used for this volume.
+    // It should have a value that's similar to the pod's status.containerStatuses[i].imageID.
+    string image_ref = 20;
+}
+
+message KeyValue {
+    string key = 1;
+    bytes value = 2;
+}
+
+// LinuxContainerResources specifies Linux specific configuration for
+// resources.
+message LinuxContainerResources {
+    // CPU CFS (Completely Fair Scheduler) period. Default: 0 (not specified).
+    int64 cpu_period = 1;
+    // CPU CFS (Completely Fair Scheduler) quota. Default: 0 (not specified).
+    int64 cpu_quota = 2;
+    // CPU shares (relative weight vs. other containers). Default: 0 (not specified).
+    int64 cpu_shares = 3;
+    // Memory limit in bytes. Default: 0 (not specified).
+    int64 memory_limit_in_bytes = 4;
+    // OOMScoreAdj adjusts the oom-killer score. Default: 0 (not specified).
+    int64 oom_score_adj = 5;
+    // CpusetCpus constrains the allowed set of logical CPUs. Default: "" (not specified).
+    string cpuset_cpus = 6;
+    // CpusetMems constrains the allowed set of memory nodes. Default: "" (not specified).
+    string cpuset_mems = 7;
+    // List of HugepageLimits to limit the HugeTLB usage of container per page size. Default: nil (not specified).
+    repeated HugepageLimit hugepage_limits = 8;
+    // Unified resources for cgroup v2. Default: nil (not specified).
+    // Each key/value in the map refers to the cgroup v2.
+    // e.g. "memory.max": "6937202688" or "io.weight": "default 100".
+    map<string, string> unified = 9;
+    // Memory swap limit in bytes. Default 0 (not specified).
+    int64 memory_swap_limit_in_bytes = 10;
+}
+
+// HugepageLimit corresponds to the file`hugetlb.<hugepagesize>.limit_in_byte` in container level cgroup.
+// For example, `PageSize=1GB`, `Limit=1073741824` means setting `1073741824` bytes to hugetlb.1GB.limit_in_bytes.
+message HugepageLimit {
+    // The value of PageSize has the format <size><unit-prefix>B (2MB, 1GB),
+    // and must match the <hugepagesize> of the corresponding control file found in `hugetlb.<hugepagesize>.limit_in_bytes`.
+    // The values of <unit-prefix> are intended to be parsed using base 1024("1KB" = 1024, "1MB" = 1048576, etc).
+    string page_size = 1;
+    // limit in bytes of hugepagesize HugeTLB usage.
+    uint64 limit = 2;
+}
+
+// SELinuxOption are the labels to be applied to the container.
+message SELinuxOption {
+    string user = 1;
+    string role = 2;
+    string type = 3;
+    string level = 4;
+}
+
+// Capability contains the container capabilities to add or drop
+// Dropping a capability will drop it from all sets.
+// If a capability is added to only the add_capabilities list then it gets added to permitted,
+// inheritable, effective and bounding sets, i.e. all sets except the ambient set.
+// If a capability is added to only the add_ambient_capabilities list then it gets added to all sets, i.e permitted
+// inheritable, effective, bounding and ambient sets.
+// If a capability is added to add_capabilities and add_ambient_capabilities lists then it gets added to all sets, i.e.
+// permitted, inheritable, effective, bounding and ambient sets.
+message Capability {
+    // List of capabilities to add.
+    repeated string add_capabilities = 1;
+    // List of capabilities to drop.
+    repeated string drop_capabilities = 2;
+    // List of ambient capabilities to add.
+    repeated string add_ambient_capabilities = 3;
+}
+
+// LinuxContainerSecurityContext holds linux security configuration that will be applied to a container.
+message LinuxContainerSecurityContext {
+    // Capabilities to add or drop.
+    Capability capabilities = 1;
+    // If set, run container in privileged mode.
+    // Privileged mode is incompatible with the following options. If
+    // privileged is set, the following features MAY have no effect:
+    // 1. capabilities
+    // 2. selinux_options
+    // 4. seccomp
+    // 5. apparmor
+    //
+    // Privileged mode implies the following specific options are applied:
+    // 1. All capabilities are added.
+    // 2. Sensitive paths, such as kernel module paths within sysfs, are not masked.
+    // 3. Any sysfs and procfs mounts are mounted RW.
+    // 4. AppArmor confinement is not applied.
+    // 5. Seccomp restrictions are not applied.
+    // 6. The device cgroup does not restrict access to any devices.
+    // 7. All devices from the host's /dev are available within the container.
+    // 8. SELinux restrictions are not applied (e.g. label=disabled).
+    bool privileged = 2;
+    // Configurations for the container's namespaces.
+    // Only used if the container uses namespace for isolation.
+    NamespaceOption namespace_options = 3;
+    // SELinux context to be optionally applied.
+    SELinuxOption selinux_options = 4;
+    // UID to run the container process as. Only one of run_as_user and
+    // run_as_username can be specified at a time.
+    Int64Value run_as_user = 5;
+    // GID to run the container process as. run_as_group should only be specified
+    // when run_as_user or run_as_username is specified; otherwise, the runtime
+    // MUST error.
+    Int64Value run_as_group = 12;
+    // User name to run the container process as. If specified, the user MUST
+    // exist in the container image (i.e. in the /etc/passwd inside the image),
+    // and be resolved there by the runtime; otherwise, the runtime MUST error.
+    string run_as_username = 6;
+    // If set, the root filesystem of the container is read-only.
+    bool readonly_rootfs = 7;
+    // List of groups applied to the first process run in each container.
+    // supplemental_groups_policy can control how groups will be calculated.
+    repeated int64 supplemental_groups = 8;
+    // supplemental_groups_policy defines how supplemental groups of the first 
+    // container processes are calculated.
+    // Valid values are "Merge" and "Strict".
+    // If not specified, "Merge" is used.
+    SupplementalGroupsPolicy supplemental_groups_policy = 17;
+    // no_new_privs defines if the flag for no_new_privs should be set on the
+    // container.
+    bool no_new_privs = 11;
+    // masked_paths is a slice of paths that should be masked by the container
+    // runtime, this can be passed directly to the OCI spec.
+    repeated string masked_paths = 13;
+    // readonly_paths is a slice of paths that should be set as readonly by the
+    // container runtime, this can be passed directly to the OCI spec.
+    repeated string readonly_paths = 14;
+    // Seccomp profile for the container.
+    SecurityProfile seccomp = 15;
+    // AppArmor profile for the container.
+    SecurityProfile apparmor = 16;
+    // AppArmor profile for the container, candidate values are:
+    // * runtime/default: equivalent to not specifying a profile.
+    // * unconfined: no profiles are loaded
+    // * localhost/<profile_name>: profile loaded on the node
+    //    (localhost) by name. The possible profile names are detailed at
+    //    https://gitlab.com/apparmor/apparmor/-/wikis/AppArmor_Core_Policy_Reference
+    string apparmor_profile = 9 [deprecated=true];
+    // Seccomp profile for the container, candidate values are:
+    // * runtime/default: the default profile for the container runtime
+    // * unconfined: unconfined profile, ie, no seccomp sandboxing
+    // * localhost/<full-path-to-profile>: the profile installed on the node.
+    //   <full-path-to-profile> is the full path of the profile.
+    // Default: "", which is identical with unconfined.
+    string seccomp_profile_path = 10 [deprecated=true];
+}
+
+// LinuxContainerConfig contains platform-specific configuration for
+// Linux-based containers.
+message LinuxContainerConfig {
+    // Resources specification for the container.
+    LinuxContainerResources resources = 1;
+    // LinuxContainerSecurityContext configuration for the container.
+    LinuxContainerSecurityContext security_context = 2;
+}
+
+message LinuxContainerUser {
+    // uid is the primary uid initially attached to the first process in the container
+    int64 uid = 1;
+    // gid is the primary gid initially attached to the first process in the container
+    int64 gid = 2;
+    // supplemental_groups are the supplemental groups initially attached to the first process in the container
+    repeated int64 supplemental_groups = 3;
+}
+
+// WindowsNamespaceOption provides options for Windows namespaces.
+message WindowsNamespaceOption {
+    // Network namespace for this container/sandbox.
+    // This is currently never set by the kubelet
+    NamespaceMode network = 1;
+}
+
+// WindowsSandboxSecurityContext holds platform-specific configurations that will be
+// applied to a sandbox.
+// These settings will only apply to the sandbox container.
+message WindowsSandboxSecurityContext {
+    // User name to run the container process as. If specified, the user MUST
+    // exist in the container image and be resolved there by the runtime;
+    // otherwise, the runtime MUST return error.
+    string run_as_username = 1;
+
+    // The contents of the GMSA credential spec to use to run this container.
+    string credential_spec = 2;
+
+    // Indicates whether the container requested to run as a HostProcess container.
+    bool host_process = 3;
+
+    // Configuration for the sandbox's namespaces
+    WindowsNamespaceOption namespace_options = 4;
+}
+
+// WindowsPodSandboxConfig holds platform-specific configurations for Windows
+// host platforms and Windows-based containers.
+message WindowsPodSandboxConfig {
+    // WindowsSandboxSecurityContext holds sandbox security attributes.
+    WindowsSandboxSecurityContext security_context = 1;
+}
+
+// WindowsContainerSecurityContext holds windows security configuration that will be applied to a container.
+message WindowsContainerSecurityContext {
+    // User name to run the container process as. If specified, the user MUST
+    // exist in the container image and be resolved there by the runtime;
+    // otherwise, the runtime MUST return error.
+    string run_as_username = 1;
+
+    // The contents of the GMSA credential spec to use to run this container.
+    string credential_spec = 2;
+
+    // Indicates whether a container is to be run as a HostProcess container.
+    bool host_process = 3;
+}
+
+// WindowsContainerConfig contains platform-specific configuration for
+// Windows-based containers.
+message WindowsContainerConfig {
+    // Resources specification for the container.
+    WindowsContainerResources resources = 1;
+    // WindowsContainerSecurityContext configuration for the container.
+    WindowsContainerSecurityContext security_context = 2;
+}
+
+// WindowsContainerResources specifies Windows specific configuration for
+// resources.
+message WindowsContainerResources {
+    // CPU shares (relative weight vs. other containers). Default: 0 (not specified).
+    int64 cpu_shares = 1;
+    // Number of CPUs available to the container. Default: 0 (not specified).
+    int64 cpu_count = 2;
+    // Specifies the portion of processor cycles that this container can use as a percentage times 100.
+    int64 cpu_maximum = 3;
+    // Memory limit in bytes. Default: 0 (not specified).
+    int64 memory_limit_in_bytes = 4;
+    // Specifies the size of the rootfs / scratch space in bytes to be configured for this container. Default: 0 (not specified).
+    int64 rootfs_size_in_bytes = 5;
+    // Optionally specifies the set of CPUs to affinitize for this container.
+    repeated WindowsCpuGroupAffinity affinity_cpus = 6;
+}
+
+// WindowsCpuGroupAffinity specifies the CPU mask and group to affinitize.
+// This is similar to the following _GROUP_AFFINITY structure:
+// https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/miniport/ns-miniport-_group_affinity
+message WindowsCpuGroupAffinity {
+    // CPU mask relative to this CPU group.
+    uint64 cpu_mask = 1;
+    // Processor group the mask refers to, as returned by
+    // GetLogicalProcessorInformationEx.
+    uint32 cpu_group = 2;
+}
+
+// ContainerMetadata holds all necessary information for building the container
+// name. The container runtime is encouraged to expose the metadata in its user
+// interface for better user experience. E.g., runtime can construct a unique
+// container name based on the metadata. Note that (name, attempt) is unique
+// within a sandbox for the entire lifetime of the sandbox.
+message ContainerMetadata {
+    // Name of the container. Same as the container name in the PodSpec.
+    string name = 1;
+    // Attempt number of creating the container. Default: 0.
+    uint32 attempt = 2;
+}
+
+// Device specifies a host device to mount into a container.
+message Device {
+    // Path of the device within the container.
+    string container_path = 1;
+    // Path of the device on the host.
+    string host_path = 2;
+    // Cgroups permissions of the device, candidates are one or more of
+    // * r - allows container to read from the specified device.
+    // * w - allows container to write to the specified device.
+    // * m - allows container to create device files that do not yet exist.
+    string permissions = 3;
+}
+
+// CDIDevice specifies a CDI device information.
+message CDIDevice {
+    // Fully qualified CDI device name
+    // for example: vendor.com/gpu=gpudevice1
+    // see more details in the CDI specification:
+    // https://github.com/container-orchestrated-devices/container-device-interface/blob/main/SPEC.md
+    string name = 1;
+}
+
+// ContainerConfig holds all the required and optional fields for creating a
+// container.
+message ContainerConfig {
+    // Metadata of the container. This information will uniquely identify the
+    // container, and the runtime should leverage this to ensure correct
+    // operation. The runtime may also use this information to improve UX, such
+    // as by constructing a readable name.
+    ContainerMetadata metadata = 1 ;
+    // Image to use.
+    ImageSpec image = 2;
+    // Command to execute (i.e., entrypoint for docker)
+    repeated string command = 3;
+    // Args for the Command (i.e., command for docker)
+    repeated string args = 4;
+    // Current working directory of the command.
+    string working_dir = 5;
+    // List of environment variable to set in the container.
+    repeated KeyValue envs = 6;
+    // Mounts for the container.
+    repeated Mount mounts = 7;
+    // Devices for the container.
+    repeated Device devices = 8;
+    // Key-value pairs that may be used to scope and select individual resources.
+    // Label keys are of the form:
+    //     label-key ::= prefixed-name | name
+    //     prefixed-name ::= prefix '/' name
+    //     prefix ::= DNS_SUBDOMAIN
+    //     name ::= DNS_LABEL
+    map<string, string> labels = 9;
+    // Unstructured key-value map that may be used by the kubelet to store and
+    // retrieve arbitrary metadata.
+    //
+    // Annotations MUST NOT be altered by the runtime; the annotations stored
+    // here MUST be returned in the ContainerStatus associated with the container
+    // this ContainerConfig creates.
+    //
+    // In general, in order to preserve a well-defined interface between the
+    // kubelet and the container runtime, annotations SHOULD NOT influence
+    // runtime behaviour.
+    map<string, string> annotations = 10;
+    // Path relative to PodSandboxConfig.LogDirectory for container to store
+    // the log (STDOUT and STDERR) on the host.
+    // E.g.,
+    //     PodSandboxConfig.LogDirectory = `/var/log/pods/<NAMESPACE>_<NAME>_<UID>/`
+    //     ContainerConfig.LogPath = `containerName/Instance#.log`
+    string log_path = 11;
+
+    // Variables for interactive containers, these have very specialized
+    // use-cases (e.g. debugging).
+    bool stdin = 12;
+    bool stdin_once = 13;
+    bool tty = 14;
+
+    // Configuration specific to Linux containers.
+    LinuxContainerConfig linux = 15;
+    // Configuration specific to Windows containers.
+    WindowsContainerConfig windows = 16;
+
+    // CDI devices for the container.
+    repeated CDIDevice CDI_devices = 17;
+
+    // The custom stop signal for the container
+    Signal stop_signal = 18;
+}
+
+enum Signal {
+    RUNTIME_DEFAULT   = 0;
+    SIGABRT           = 1;
+    SIGALRM           = 2;
+    SIGBUS            = 3;
+    SIGCHLD           = 4;
+    SIGCLD            = 5;
+    SIGCONT           = 6;
+    SIGFPE            = 7;
+    SIGHUP            = 8;
+    SIGILL            = 9;
+    SIGINT            = 10;
+    SIGIO             = 11;
+    SIGIOT            = 12;
+    SIGKILL           = 13;
+    SIGPIPE           = 14;
+    SIGPOLL           = 15;
+    SIGPROF           = 16;
+    SIGPWR            = 17;
+    SIGQUIT           = 18;
+    SIGSEGV           = 19;
+    SIGSTKFLT         = 20;
+    SIGSTOP           = 21;
+    SIGSYS            = 22;
+    SIGTERM           = 23;
+    SIGTRAP           = 24;
+    SIGTSTP           = 25;
+    SIGTTIN           = 26;
+    SIGTTOU           = 27;
+    SIGURG            = 28;
+    SIGUSR1           = 29;
+    SIGUSR2           = 30;
+    SIGVTALRM         = 31;
+    SIGWINCH          = 32;
+    SIGXCPU           = 33;
+    SIGXFSZ           = 34;
+    SIGRTMIN          = 35;
+    SIGRTMINPLUS1     = 36;
+    SIGRTMINPLUS2     = 37;
+    SIGRTMINPLUS3     = 38;
+    SIGRTMINPLUS4     = 39;
+    SIGRTMINPLUS5     = 40;
+    SIGRTMINPLUS6     = 41;
+    SIGRTMINPLUS7     = 42;
+    SIGRTMINPLUS8     = 43;
+    SIGRTMINPLUS9     = 44;
+    SIGRTMINPLUS10    = 45;
+    SIGRTMINPLUS11    = 46;
+    SIGRTMINPLUS12    = 47;
+    SIGRTMINPLUS13    = 48;
+    SIGRTMINPLUS14    = 49;
+    SIGRTMINPLUS15    = 50;
+    SIGRTMAXMINUS14   = 51;
+    SIGRTMAXMINUS13   = 52;
+    SIGRTMAXMINUS12   = 53;
+    SIGRTMAXMINUS11   = 54;
+    SIGRTMAXMINUS10   = 55;
+    SIGRTMAXMINUS9    = 56;
+    SIGRTMAXMINUS8    = 57;
+    SIGRTMAXMINUS7    = 58;
+    SIGRTMAXMINUS6    = 59;
+    SIGRTMAXMINUS5    = 60;
+    SIGRTMAXMINUS4    = 61;
+    SIGRTMAXMINUS3    = 62;
+    SIGRTMAXMINUS2    = 63;
+    SIGRTMAXMINUS1    = 64;
+    SIGRTMAX          = 65;
+}
+
+message CreateContainerRequest {
+    // ID of the PodSandbox in which the container should be created.
+    string pod_sandbox_id = 1;
+    // Config of the container.
+    ContainerConfig config = 2;
+    // Config of the PodSandbox. This is the same config that was passed
+    // to RunPodSandboxRequest to create the PodSandbox. It is passed again
+    // here just for easy reference. The PodSandboxConfig is immutable and
+    // remains the same throughout the lifetime of the pod.
+    PodSandboxConfig sandbox_config = 3;
+}
+
+message CreateContainerResponse {
+    // ID of the created container.
+    string container_id = 1;
+}
+
+message StartContainerRequest {
+    // ID of the container to start.
+    string container_id = 1;
+}
+
+message StartContainerResponse {}
+
+message StopContainerRequest {
+    // ID of the container to stop.
+    string container_id = 1;
+    // Timeout in seconds to wait for the container to stop before forcibly
+    // terminating it. Default: 0 (forcibly terminate the container immediately)
+    int64 timeout = 2;
+}
+
+message StopContainerResponse {}
+
+message RemoveContainerRequest {
+    // ID of the container to remove.
+    string container_id = 1;
+}
+
+message RemoveContainerResponse {}
+
+enum ContainerState {
+    CONTAINER_CREATED = 0;
+    CONTAINER_RUNNING = 1;
+    CONTAINER_EXITED  = 2;
+    CONTAINER_UNKNOWN = 3;
+}
+
+// ContainerStateValue is the wrapper of ContainerState.
+message ContainerStateValue {
+    // State of the container.
+    ContainerState state = 1;
+}
+
+// ContainerFilter is used to filter containers.
+// All those fields are combined with 'AND'
+message ContainerFilter {
+    // ID of the container.
+    string id = 1;
+    // State of the container.
+    ContainerStateValue state = 2;
+    // ID of the PodSandbox.
+    string pod_sandbox_id = 3;
+    // LabelSelector to select matches.
+    // Only api.MatchLabels is supported for now and the requirements
+    // are ANDed. MatchExpressions is not supported yet.
+    map<string, string> label_selector = 4;
+}
+
+message ListContainersRequest {
+    ContainerFilter filter = 1;
+}
+
+// Container provides the runtime information for a container, such as ID, hash,
+// state of the container.
+message Container {
+    // ID of the container, used by the container runtime to identify
+    // a container.
+    string id = 1;
+    // ID of the sandbox to which this container belongs.
+    string pod_sandbox_id = 2;
+    // Metadata of the container.
+    ContainerMetadata metadata = 3;
+    // Spec of the image.
+    ImageSpec image = 4;
+    // Digested reference to the image in use.
+    string image_ref = 5;
+    // State of the container.
+    ContainerState state = 6;
+    // Creation time of the container in nanoseconds.
+    int64 created_at = 7;
+    // Key-value pairs that may be used to scope and select individual resources.
+    map<string, string> labels = 8;
+    // Unstructured key-value map holding arbitrary metadata.
+    // Annotations MUST NOT be altered by the runtime; the value of this field
+    // MUST be identical to that of the corresponding ContainerConfig used to
+    // instantiate this Container.
+    map<string, string> annotations = 9;
+    // Reference to the unique identifier of the image on the node, as
+    // returned in the image and runtime service apis.
+    //
+    // This value MUST always match `PullImageResponse.image_ref` when referring
+    // to the same image.
+    string image_id = 10;
+}
+
+message ListContainersResponse {
+    // List of containers.
+    repeated Container containers = 1;
+}
+
+message StreamContainersRequest {
+    // Filter for the list request.
+    ContainerFilter filter = 1;
+}
+
+message StreamContainersResponse {
+    // List of containers.
+    repeated Container containers = 1;
+}
+
+message ContainerStatusRequest {
+    // ID of the container for which to retrieve status.
+    string container_id = 1;
+    // Verbose indicates whether to return extra information about the container.
+    bool verbose = 2;
+}
+
+// ContainerStatus represents the status of a container.
+message ContainerStatus {
+    // ID of the container.
+    string id = 1;
+    // Metadata of the container.
+    ContainerMetadata metadata = 2;
+    // Status of the container.
+    ContainerState state = 3;
+    // Creation time of the container in nanoseconds.
+    int64 created_at = 4;
+    // Start time of the container in nanoseconds. Default: 0 (not specified).
+    int64 started_at = 5;
+    // Finish time of the container in nanoseconds. Default: 0 (not specified).
+    int64 finished_at = 6;
+    // Exit code of the container. Only required when finished_at != 0. Default: 0.
+    int32 exit_code = 7;
+    // Spec of the image.
+    ImageSpec image = 8;
+    // Digested reference to the image in use.
+    string image_ref = 9;
+    // Brief CamelCase string explaining why container is in its current state.
+    // Must be set to "OOMKilled" for containers terminated by cgroup-based Out-of-Memory killer.
+    string reason = 10;
+    // Human-readable message indicating details about why container is in its
+    // current state.
+    string message = 11;
+    // Key-value pairs that may be used to scope and select individual resources.
+    map<string,string> labels = 12;
+    // Unstructured key-value map holding arbitrary metadata.
+    // Annotations MUST NOT be altered by the runtime; the value of this field
+    // MUST be identical to that of the corresponding ContainerConfig used to
+    // instantiate the Container this status represents.
+    map<string,string> annotations = 13;
+    // Mounts for the container.
+    repeated Mount mounts = 14;
+    // Log path of container.
+    string log_path = 15;
+    // Resource limits configuration of the container.
+    ContainerResources resources = 16;
+    // Reference to the unique identifier of the image on the node, as
+    // returned in the image and runtime service apis.
+    //
+    // This value MUST always match `PullImageResponse.image_ref` when referring
+    // to the same image.
+    string image_id = 17;
+    // User identities initially attached to the container
+    ContainerUser user = 18;
+
+    // Returns the stop signal used by the container runtime to terminate the container 
+    Signal stop_signal = 19;
+}
+
+message ContainerStatusResponse {
+    // Status of the container.
+    ContainerStatus status = 1;
+    // Info is extra information of the Container. The key could be arbitrary string, and
+    // value should be in json format. The information could include anything useful for
+    // debug, e.g. pid for linux container based container runtime.
+    // It should only be returned non-empty when Verbose is true.
+    map<string, string> info = 2;
+}
+
+// ContainerResources holds resource limits configuration for a container.
+message ContainerResources {
+    // Resource limits configuration specific to Linux container.
+    LinuxContainerResources linux = 1;
+    // Resource limits configuration specific to Windows container.
+    WindowsContainerResources windows = 2;
+}
+
+message ContainerUser {
+    // User identities initially attached to first process in the Linux container.
+    // Note that the actual running identity can be changed if the process has enough privilege to do so.
+    LinuxContainerUser linux = 1;
+
+    // User identities initially attached to first process in the Windows container
+    // This is just reserved for future use.
+    // WindowsContainerUser windows = 2;
+}
+
+
+message UpdateContainerResourcesRequest {
+    // ID of the container to update.
+    string container_id = 1;
+    // Resource configuration specific to Linux containers.
+    LinuxContainerResources linux = 2;
+    // Resource configuration specific to Windows containers.
+    WindowsContainerResources windows = 3;
+    // Unstructured key-value map holding arbitrary additional information for
+    // container resources updating. This can be used for specifying experimental
+    // resources to update or other options to use when updating the container.
+    map<string, string> annotations = 4;
+}
+
+message UpdateContainerResourcesResponse {}
+
+message ExecSyncRequest {
+    // ID of the container.
+    string container_id = 1;
+    // Command to execute.
+    repeated string cmd = 2;
+    // Timeout in seconds to stop the command. Default: 0 (run forever).
+    int64 timeout = 3;
+}
+
+message ExecSyncResponse {
+    // Captured command stdout output.
+	// The runtime should cap the output of this response to 16MB.
+	// If the stdout of the command produces more than 16MB, the remaining output
+	// should be discarded, and the command should proceed with no error.
+	// See CVE-2022-1708 and CVE-2022-31030 for more information.
+    bytes stdout = 1;
+    // Captured command stderr output.
+	// The runtime should cap the output of this response to 16MB.
+	// If the stderr of the command produces more than 16MB, the remaining output
+	// should be discarded, and the command should proceed with no error.
+	// See CVE-2022-1708 and CVE-2022-31030 for more information.
+    bytes stderr = 2;
+    // Exit code the command finished with. Default: 0 (success).
+    int32 exit_code = 3;
+}
+
+message ExecRequest {
+    // ID of the container in which to execute the command.
+    string container_id = 1;
+    // Command to execute.
+    repeated string cmd = 2;
+    // Whether to exec the command in a TTY.
+    bool tty = 3;
+    // Whether to stream stdin.
+    // One of `stdin`, `stdout`, and `stderr` MUST be true.
+    bool stdin = 4;
+    // Whether to stream stdout.
+    // One of `stdin`, `stdout`, and `stderr` MUST be true.
+    bool stdout = 5;
+    // Whether to stream stderr.
+    // One of `stdin`, `stdout`, and `stderr` MUST be true.
+    // If `tty` is true, `stderr` MUST be false. Multiplexing is not supported
+    // in this case. The output of stdout and stderr will be combined to a
+    // single stream.
+    bool stderr = 6;
+}
+
+message ExecResponse {
+    // Fully qualified URL of the exec streaming server.
+    string url = 1;
+}
+
+message AttachRequest {
+    // ID of the container to which to attach.
+    string container_id = 1;
+    // Whether to stream stdin.
+    // One of `stdin`, `stdout`, and `stderr` MUST be true.
+    bool stdin = 2;
+    // Whether the process being attached is running in a TTY.
+    // This must match the TTY setting in the ContainerConfig.
+    bool tty = 3;
+    // Whether to stream stdout.
+    // One of `stdin`, `stdout`, and `stderr` MUST be true.
+    bool stdout = 4;
+    // Whether to stream stderr.
+    // One of `stdin`, `stdout`, and `stderr` MUST be true.
+    // If `tty` is true, `stderr` MUST be false. Multiplexing is not supported
+    // in this case. The output of stdout and stderr will be combined to a
+    // single stream.
+    bool stderr = 5;
+}
+
+message AttachResponse {
+    // Fully qualified URL of the attach streaming server.
+    string url = 1;
+}
+
+message PortForwardRequest {
+    // ID of the container to which to forward the port.
+    string pod_sandbox_id = 1;
+    // Port to forward.
+    repeated int32 port = 2;
+}
+
+message PortForwardResponse {
+    // Fully qualified URL of the port-forward streaming server.
+    string url = 1;
+}
+
+message ImageFilter {
+    // Spec of the image.
+    ImageSpec image = 1;
+}
+
+message ListImagesRequest {
+    // Filter to list images.
+    ImageFilter filter = 1;
+}
+
+// Basic information about a container image.
+message Image {
+    // Reference to the unique identifier of the image on the node, as
+    // returned in the image and runtime service apis.
+    //
+    // This value MUST always match `PullImageResponse.image_ref` when referring
+    // to the same image.
+    string id = 1;
+    // Other names by which this image is known.
+    repeated string repo_tags = 2;
+    // Digests by which this image is known.
+    repeated string repo_digests = 3;
+    // Size of the image in bytes. Must be > 0.
+    uint64 size = 4;
+    // UID that will run the command(s). This is used as a default if no user is
+    // specified when creating the container. UID and the following user name
+    // are mutually exclusive.
+    Int64Value uid = 5;
+    // User name that will run the command(s). This is used if UID is not set
+    // and no user is specified when creating container.
+    string username = 6;
+    // ImageSpec for image which includes annotations
+    ImageSpec spec = 7;
+    // Recommendation on whether this image should be exempt from garbage collection.
+    // It must only be treated as a recommendation -- the client can still request that the image be deleted,
+    // and the runtime must oblige.
+    bool pinned = 8;
+}
+
+message ListImagesResponse {
+    // List of images.
+    repeated Image images = 1;
+}
+
+message StreamImagesRequest {
+    // Filter to list images.
+    ImageFilter filter = 1;
+}
+
+message StreamImagesResponse {
+    // List of images.
+    repeated Image images = 1;
+}
+
+message ImageStatusRequest {
+    // Spec of the image.
+    ImageSpec image = 1;
+    // Verbose indicates whether to return extra information about the image.
+    bool verbose = 2;
+}
+
+message ImageStatusResponse {
+    // Status of the image.
+    Image image = 1;
+    // Info is extra information of the Image. The key could be arbitrary string, and
+    // value should be in json format. The information could include anything useful
+    // for debug, e.g. image config for oci image based container runtime.
+    // It should only be returned non-empty when Verbose is true.
+    map<string, string> info = 2;
+}
+
+// AuthConfig contains authorization information for connecting to a registry.
+message AuthConfig {
+    string username = 1;
+    string password = 2 [debug_redact = true];
+    string auth = 3 [debug_redact = true];
+    string server_address = 4;
+    // IdentityToken is used to authenticate the user and get
+    // an access token for the registry.
+    string identity_token = 5 [debug_redact = true];
+    // RegistryToken is a bearer token to be sent to a registry
+    string registry_token = 6 [debug_redact = true];
+}
+
+message PullImageRequest {
+    // Spec of the image.
+    ImageSpec image = 1;
+    // Authentication configuration for pulling the image.
+    AuthConfig auth = 2;
+    // Config of the PodSandbox, which is used to pull image in PodSandbox context.
+    PodSandboxConfig sandbox_config = 3;
+}
+
+message PullImageResponse {
+    // Reference to the unique identifier of the image on the node, as
+    // returned in the image and runtime service apis.
+    //
+    // When referring to the same image, the container runtime MUST always return
+    // the same value for:
+    //     - Image.id
+    //     - Container.image_id
+    //     - ContainerStatus.image_id
+    //     - PullImageResponse.image_ref
+    // Note: this field has a stricter meaning starting with v1.36.
+    // It used to be image ID OR digest, which are different values,
+    // and would not necessarily match other ID fields in the Container,
+    // ContainerStatus, and Image messages
+    string image_ref = 1;
+}
+
+message RemoveImageRequest {
+    // Spec of the image to remove.
+    ImageSpec image = 1;
+}
+
+message RemoveImageResponse {}
+
+message NetworkConfig {
+    // CIDR to use for pod IP addresses. If the CIDR is empty, runtimes
+    // should omit it.
+    string pod_cidr = 1;
+}
+
+message RuntimeConfig {
+    NetworkConfig network_config = 1;
+}
+
+message UpdateRuntimeConfigRequest {
+    RuntimeConfig runtime_config = 1;
+}
+
+message UpdateRuntimeConfigResponse {}
+
+// RuntimeCondition contains condition information for the runtime.
+// There are 2 kinds of runtime conditions:
+// 1. Required conditions: Conditions are required for kubelet to work
+// properly. If any required condition is unmet, the node will be not ready.
+// The required conditions include:
+//   * RuntimeReady: RuntimeReady means the runtime is up and ready to accept
+//   basic containers e.g. container only needs host network.
+//   * NetworkReady: NetworkReady means the runtime network is up and ready to
+//   accept containers which require container network.
+// 2. Optional conditions: Conditions are informative to the user, but kubelet
+// will not rely on. Since condition type is an arbitrary string, all conditions
+// not required are optional. These conditions will be exposed to users to help
+// them understand the status of the system.
+message RuntimeCondition {
+    // Type of runtime condition.
+    string type = 1;
+    // Status of the condition, one of true/false. Default: false.
+    bool status = 2;
+    // Brief CamelCase string containing reason for the condition's last transition.
+    string reason = 3;
+    // Human-readable message indicating details about last transition.
+    string message = 4;
+}
+
+// RuntimeStatus is information about the current status of the runtime.
+message RuntimeStatus {
+    // List of current observed runtime conditions.
+    repeated RuntimeCondition conditions = 1;
+}
+
+message StatusRequest {
+    // Verbose indicates whether to return extra information about the runtime.
+    bool verbose = 1;
+}
+
+// RuntimeHandlerFeatures is a set of features implemented by the runtime handler.
+message RuntimeHandlerFeatures {
+    // recursive_read_only_mounts is set to true if the runtime handler supports
+    // recursive read-only mounts.
+    // For runc-compatible runtimes, availability of this feature can be detected by checking whether
+    // the Linux kernel version is >= 5.12, and,  `runc features | jq .mountOptions` contains "rro".
+    bool recursive_read_only_mounts = 1;
+
+    // user_namespaces is set to true if the runtime handler supports user namespaces as implemented
+    // in Kubernetes. This means support for both, user namespaces and idmap mounts.
+    bool user_namespaces = 2;
+}
+
+message RuntimeHandler {
+    // Name must be unique in StatusResponse.
+    // An empty string denotes the default handler.
+    string name = 1;
+    // Supported features.
+    RuntimeHandlerFeatures features = 2;
+}
+
+// RuntimeFeatures describes the set of features implemented by the CRI implementation.
+// The features contained in the RuntimeFeatures should depend only on the cri implementation
+// independent of runtime handlers.
+message RuntimeFeatures {
+    // supplemental_groups_policy is set to true if the runtime supports SupplementalGroupsPolicy and ContainerUser.
+    bool supplemental_groups_policy = 1;
+    // user_namespaces_host_network is set to true if the runtime supports containers using both
+    // host network and user namespace simultaneously.
+    bool user_namespaces_host_network = 2;
+}
+
+message StatusResponse {
+    // Status of the Runtime.
+    RuntimeStatus status = 1;
+    // Info is extra information of the Runtime. The key could be arbitrary string, and
+    // value should be in json format. The information could include anything useful for
+    // debug, e.g. plugins used by the container runtime.
+    // It should only be returned non-empty when Verbose is true.
+    map<string, string> info = 2;
+    // Runtime handlers.
+    repeated RuntimeHandler runtime_handlers = 3;
+    // features describes the set of features implemented by the CRI implementation.
+    // This field is supposed to propagate to NodeFeatures in Kubernetes API.
+    RuntimeFeatures features = 4;
+}
+
+message ImageFsInfoRequest {}
+
+// UInt64Value is the wrapper of uint64.
+message UInt64Value {
+    // The value.
+    uint64 value = 1;
+}
+
+// FilesystemIdentifier uniquely identify the filesystem.
+message FilesystemIdentifier{
+    // Mountpoint of a filesystem.
+    string mountpoint = 1;
+}
+
+// FilesystemUsage provides the filesystem usage information.
+message FilesystemUsage {
+    // Timestamp in nanoseconds at which the information were collected. Must be > 0.
+    int64 timestamp = 1;
+    // The unique identifier of the filesystem.
+    FilesystemIdentifier fs_id = 2;
+    // UsedBytes represents the bytes used for images on the filesystem.
+    // This may differ from the total bytes used on the filesystem and may not
+    // equal CapacityBytes - AvailableBytes.
+    UInt64Value used_bytes = 3;
+    // InodesUsed represents the inodes used by the images.
+    // This may not equal InodesCapacity - InodesAvailable because the underlying
+    // filesystem may also be used for purposes other than storing images.
+    UInt64Value inodes_used = 4;
+}
+
+// WindowsFilesystemUsage provides the filesystem usage information specific to Windows.
+message WindowsFilesystemUsage {
+    // Timestamp in nanoseconds at which the information were collected. Must be > 0.
+    int64 timestamp = 1;
+    // The unique identifier of the filesystem.
+    FilesystemIdentifier fs_id = 2;
+    // UsedBytes represents the bytes used for images on the filesystem.
+    // This may differ from the total bytes used on the filesystem and may not
+    // equal CapacityBytes - AvailableBytes.
+    UInt64Value used_bytes = 3;
+}
+
+message ImageFsInfoResponse {
+    // Information of image filesystem(s).
+    repeated FilesystemUsage image_filesystems = 1;
+    // Information of container filesystem(s).
+    // This is an optional field, may be used for example if container and image
+    // storage are separated.
+    // Default will be to return this as empty.
+    repeated FilesystemUsage container_filesystems = 2;
+}
+
+message ContainerStatsRequest{
+    // ID of the container for which to retrieve stats.
+    string container_id = 1;
+}
+
+message ContainerStatsResponse {
+    // Stats of the container.
+    ContainerStats stats = 1;
+}
+
+message ListContainerStatsRequest{
+    // Filter for the list request.
+    ContainerStatsFilter filter = 1;
+}
+
+// ContainerStatsFilter is used to filter containers.
+// All those fields are combined with 'AND'
+message ContainerStatsFilter {
+    // ID of the container.
+    string id = 1;
+    // ID of the PodSandbox.
+    string pod_sandbox_id = 2;
+    // LabelSelector to select matches.
+    // Only api.MatchLabels is supported for now and the requirements
+    // are ANDed. MatchExpressions is not supported yet.
+    map<string, string> label_selector = 3;
+}
+
+message ListContainerStatsResponse {
+    // Stats of the container.
+    repeated ContainerStats stats = 1;
+}
+
+message StreamContainerStatsRequest {
+    // Filter for the list request.
+    ContainerStatsFilter filter = 1;
+}
+
+message StreamContainerStatsResponse {
+    // List of container stats.
+    repeated ContainerStats container_stats = 1;
+}
+
+// ContainerAttributes provides basic information of the container.
+message ContainerAttributes {
+    // ID of the container.
+    string id = 1;
+    // Metadata of the container.
+    ContainerMetadata metadata = 2;
+    // Key-value pairs that may be used to scope and select individual resources.
+    map<string,string> labels = 3;
+    // Unstructured key-value map holding arbitrary metadata.
+    // Annotations MUST NOT be altered by the runtime; the value of this field
+    // MUST be identical to that of the corresponding ContainerConfig used to
+    // instantiate the Container this status represents.
+    map<string,string> annotations = 4;
+}
+
+// ContainerStats provides the resource usage statistics for a container.
+message ContainerStats {
+    // Information of the container.
+    ContainerAttributes attributes = 1;
+    // CPU usage gathered from the container.
+    CpuUsage cpu = 2;
+    // Memory usage gathered from the container.
+    MemoryUsage memory = 3;
+    // Usage of the writable layer.
+    FilesystemUsage writable_layer = 4;
+    // Swap usage gathered from the container.
+    SwapUsage swap = 5;
+    // IO usage gathered from the container.
+    IoUsage io = 6;
+}
+
+// WindowsContainerStats provides the resource usage statistics for a container specific for Windows
+message WindowsContainerStats {
+    // Information of the container.
+    ContainerAttributes attributes = 1;
+    // CPU usage gathered from the container.
+    WindowsCpuUsage cpu = 2;
+    // Memory usage gathered from the container.
+    WindowsMemoryUsage memory = 3;
+    // Usage of the writable layer.
+    WindowsFilesystemUsage writable_layer = 4;
+}
+
+// PSI statistics for an individual resource.
+message PsiStats {
+	// PSI data for all tasks in the cgroup.
+	PsiData Full = 1;
+	// PSI data for some tasks in the cgroup.
+	PsiData Some = 2;
+}
+
+// PSI data for an individual resource.
+message PsiData {
+	// Total time duration for tasks in the cgroup have waited due to congestion.
+	// Unit: nanoseconds.
+	uint64 Total = 1;
+	// The average (in %) tasks have waited due to congestion over a 10 second window.
+	double Avg10 = 2;
+	// The average (in %) tasks have waited due to congestion over a 60 second window.
+	double Avg60 = 3;
+	// The average (in %) tasks have waited due to congestion over a 300 second window.
+	double Avg300 = 4;
+}
+
+// CpuUsage provides the CPU usage information.
+message CpuUsage {
+    // Timestamp in nanoseconds at which the information were collected. Must be > 0.
+    int64 timestamp = 1;
+    // Cumulative CPU usage (sum across all cores) since object creation.
+    UInt64Value usage_core_nano_seconds = 2;
+    // Total CPU usage (sum of all cores) averaged over the sample window.
+    // The "core" unit can be interpreted as CPU core-nanoseconds per second.
+    UInt64Value usage_nano_cores = 3;
+    // CPU PSI statistics.
+    PsiStats psi = 4;
+}
+
+// WindowsCpuUsage provides the CPU usage information specific to Windows
+message WindowsCpuUsage {
+    // Timestamp in nanoseconds at which the information were collected. Must be > 0.
+    int64 timestamp = 1;
+    // Cumulative CPU usage (sum across all cores) since object creation.
+    UInt64Value usage_core_nano_seconds = 2;
+    // Total CPU usage (sum of all cores) averaged over the sample window.
+    // The "core" unit can be interpreted as CPU core-nanoseconds per second.
+    UInt64Value usage_nano_cores = 3;
+}
+
+// MemoryUsage provides the memory usage information.
+message MemoryUsage {
+    // Timestamp in nanoseconds at which the information were collected. Must be > 0.
+    int64 timestamp = 1;
+    // The amount of working set memory in bytes.
+    UInt64Value working_set_bytes = 2;
+    // Available memory for use. This is defined as the memory limit - workingSetBytes.
+    UInt64Value available_bytes = 3;
+    // Total memory in use. This includes all memory regardless of when it was accessed.
+    UInt64Value usage_bytes = 4;
+    // The amount of anonymous and swap cache memory (includes transparent hugepages).
+    UInt64Value rss_bytes = 5;
+    // Cumulative number of minor page faults.
+    UInt64Value page_faults = 6;
+    // Cumulative number of major page faults.
+    UInt64Value major_page_faults = 7;
+    // Memory PSI statistics.
+    PsiStats psi = 8;
+}
+
+message IoUsage {
+    // Timestamp in nanoseconds at which the information were collected. Must be > 0.
+    int64 timestamp = 1;
+    // IO PSI statistics.
+    PsiStats psi = 2;
+}
+
+message SwapUsage {
+    // Timestamp in nanoseconds at which the information were collected. Must be > 0.
+    int64 timestamp = 1;
+    // Available swap for use. This is defined as the swap limit - swapUsageBytes.
+    UInt64Value swap_available_bytes = 2;
+    // Total memory in use. This includes all memory regardless of when it was accessed.
+    UInt64Value swap_usage_bytes = 3;
+}
+
+// WindowsMemoryUsage provides the memory usage information specific to Windows
+message WindowsMemoryUsage {
+    // Timestamp in nanoseconds at which the information were collected. Must be > 0.
+    int64 timestamp = 1;
+    // The amount of working set memory in bytes.
+    UInt64Value working_set_bytes = 2;
+    // Available memory for use. This is defined as the memory limit - commit_memory_bytes.
+    UInt64Value available_bytes = 3;
+    // Cumulative number of page faults.
+    UInt64Value page_faults = 4;
+    // Total commit memory in use. Commit memory is total of physical and virtual memory in use.
+    UInt64Value commit_memory_bytes = 5;
+}
+
+message ReopenContainerLogRequest {
+    // ID of the container for which to reopen the log.
+    string container_id = 1;
+}
+
+message ReopenContainerLogResponse{
+}
+
+message CheckpointContainerRequest {
+    // ID of the container to be checkpointed.
+    string container_id = 1;
+    // Location of the checkpoint archive used for export
+    string location = 2;
+    // Timeout in seconds for the checkpoint to complete.
+    // Timeout of zero means to use the CRI default.
+    // Timeout > 0 means to use the user specified timeout.
+    int64 timeout = 3;
+}
+
+message CheckpointContainerResponse {}
+
+message GetEventsRequest {}
+
+message ContainerEventResponse {
+    // ID of the container
+    string container_id = 1;
+
+    // Type of the container event
+    ContainerEventType container_event_type = 2;
+
+    // Creation timestamp in nanoseconds of this event
+    int64 created_at = 3;
+
+    // Sandbox status
+    PodSandboxStatus pod_sandbox_status = 4;
+
+    // Container statuses
+    repeated ContainerStatus containers_statuses = 5;
+}
+
+enum ContainerEventType {
+    // Container created
+    CONTAINER_CREATED_EVENT = 0;
+
+    // Container started
+    CONTAINER_STARTED_EVENT = 1;
+
+    // Container stopped
+    CONTAINER_STOPPED_EVENT = 2;
+
+    // Container deleted
+    CONTAINER_DELETED_EVENT = 3;
+}
+
+message ListMetricDescriptorsRequest {}
+
+message ListMetricDescriptorsResponse {
+    repeated MetricDescriptor descriptors = 1;
+}
+
+message MetricDescriptor {
+    // The name field will be used as a unique identifier of this MetricDescriptor,
+    // and be used in conjunction with the Metric structure to populate the full Metric.
+    string name = 1;
+    string help = 2;
+    // When a metric uses this metric descriptor, it should only define
+    // labels that have previously been declared in label_keys.
+    // It is the responsibility of the runtime to correctly keep sorted the keys and values.
+    // If the two slices have different length, the behavior is undefined.
+    repeated string label_keys = 3;
+}
+
+message ListPodSandboxMetricsRequest {}
+
+message ListPodSandboxMetricsResponse {
+    repeated PodSandboxMetrics pod_metrics = 1;
+}
+
+message StreamPodSandboxMetricsRequest {}
+
+message StreamPodSandboxMetricsResponse {
+    // List of pod sandbox metrics.
+    repeated PodSandboxMetrics pod_sandbox_metrics = 1;
+}
+
+message PodSandboxMetrics {
+    string pod_sandbox_id = 1;
+    repeated Metric metrics = 2;
+    repeated ContainerMetrics container_metrics = 3;
+}
+
+message ContainerMetrics {
+    string container_id = 1;
+    repeated Metric metrics = 2;
+}
+
+message Metric {
+    // Name must match a name previously returned in a MetricDescriptors call,
+    // otherwise, it will be ignored.
+    string name = 1;
+    // Timestamp should be 0 if the metric was gathered live.
+    // If it was cached, the Timestamp should reflect the time in nanoseconds it was collected.
+    int64 timestamp = 2;
+    MetricType metric_type = 3;
+    // The corresponding LabelValues to the LabelKeys defined in the MetricDescriptor.
+    // It is the responsibility of the runtime to correctly keep sorted the keys and values.
+    // If the two slices have different length, the behavior is undefined.
+    repeated string label_values = 4;
+    UInt64Value value = 5;
+}
+
+enum MetricType {
+    COUNTER = 0;
+    GAUGE = 1;
+}
+
+message RuntimeConfigRequest {}
+
+message RuntimeConfigResponse {
+    // Configuration information for Linux-based runtimes. This field contains
+    // global runtime configuration options that are not specific to runtime
+    // handlers.
+    LinuxRuntimeConfiguration linux = 1;
+}
+
+message LinuxRuntimeConfiguration {
+    // Cgroup driver to use
+    // Note: this field should not change for the lifecycle of the Kubelet,
+    // or while there are running containers.
+    // The Kubelet will not re-request this after startup, and will construct the cgroup
+    // hierarchy assuming it is static.
+    // If the runtime wishes to change this value, it must be accompanied by removal of
+    // all pods, and a restart of the Kubelet. The easiest way to do this is with a full node reboot.
+    CgroupDriver cgroup_driver = 1;
+}
+
+enum CgroupDriver {
+    SYSTEMD = 0;
+    CGROUPFS = 1;
+}
+
+message UpdatePodSandboxResourcesRequest {
+    // ID of the PodSandbox to update.
+    string pod_sandbox_id = 1;
+
+    // Optional overhead represents the overheads associated with this sandbox
+    LinuxContainerResources overhead = 2;
+    // Optional resources represents the sum of container resources for this sandbox
+    LinuxContainerResources resources = 3;
+}
+
+message UpdatePodSandboxResourcesResponse {}

--- a/pelagos-cri/src/image.rs
+++ b/pelagos-cri/src/image.rs
@@ -1,0 +1,222 @@
+//! CRI ImageService implementation.
+
+use crate::cri::image_service_server::ImageService;
+use crate::cri::{
+    Image, ImageFsInfoRequest, ImageFsInfoResponse, ImageSpec, ImageStatusRequest,
+    ImageStatusResponse, ListImagesRequest, ListImagesResponse, PullImageRequest,
+    PullImageResponse, RemoveImageRequest, RemoveImageResponse, StreamImagesRequest,
+    StreamImagesResponse,
+};
+use crate::invoke::run_pelagos;
+use crate::state::AppState;
+use serde::Deserialize;
+use std::collections::HashMap;
+use tonic::{Request, Response, Status};
+
+const IMAGES_DIR: &str = "/var/lib/pelagos/images";
+const LAYERS_DIR: &str = "/var/lib/pelagos/layers";
+
+#[derive(Deserialize)]
+struct ImageManifest {
+    reference: String,
+    digest: String,
+    #[allow(dead_code)]
+    layers: Vec<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    layer_types: Vec<String>,
+    #[allow(dead_code)]
+    config: ImageConfig,
+}
+
+#[derive(Deserialize)]
+struct ImageConfig {
+    #[serde(default)]
+    #[allow(dead_code)]
+    env: Vec<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    cmd: Vec<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    entrypoint: Vec<String>,
+}
+
+pub struct ImageSvc {
+    pub state: AppState,
+}
+
+impl ImageSvc {
+    async fn read_manifests(&self) -> Vec<ImageManifest> {
+        let Ok(mut rd) = tokio::fs::read_dir(IMAGES_DIR).await else {
+            return Vec::new();
+        };
+        let mut manifests = Vec::new();
+        while let Ok(Some(entry)) = rd.next_entry().await {
+            if !entry.path().is_dir() {
+                continue;
+            }
+            let manifest_path = entry.path().join("manifest.json");
+            if let Ok(data) = tokio::fs::read_to_string(&manifest_path).await {
+                if let Ok(m) = serde_json::from_str::<ImageManifest>(&data) {
+                    manifests.push(m);
+                }
+            }
+        }
+        manifests
+    }
+
+    async fn compute_image_size(manifest: &ImageManifest) -> u64 {
+        let mut total: u64 = 0;
+        for layer in &manifest.layers {
+            let layer_file = format!("{}/{}/layer.tar.gz", LAYERS_DIR, layer);
+            if let Ok(meta) = tokio::fs::metadata(&layer_file).await {
+                total += meta.len();
+            }
+        }
+        total
+    }
+
+    fn manifest_to_image(manifest: &ImageManifest, size: u64) -> Image {
+        Image {
+            id: manifest.digest.clone(),
+            repo_tags: vec![manifest.reference.clone()],
+            repo_digests: vec![manifest.digest.clone()],
+            size,
+            uid: None,
+            username: String::new(),
+            spec: Some(ImageSpec {
+                image: manifest.reference.clone(),
+                annotations: HashMap::new(),
+                ..Default::default()
+            }),
+            pinned: false,
+        }
+    }
+
+    async fn get_bin(&self) -> String {
+        self.state.inner.lock().await.pelagos_bin.clone()
+    }
+}
+
+#[tonic::async_trait]
+impl ImageService for ImageSvc {
+    async fn list_images(
+        &self,
+        _request: Request<ListImagesRequest>,
+    ) -> Result<Response<ListImagesResponse>, Status> {
+        let manifests = self.read_manifests().await;
+        let mut images = Vec::new();
+        for m in &manifests {
+            let size = Self::compute_image_size(m).await;
+            images.push(Self::manifest_to_image(m, size));
+        }
+        Ok(Response::new(ListImagesResponse { images }))
+    }
+
+    async fn image_status(
+        &self,
+        request: Request<ImageStatusRequest>,
+    ) -> Result<Response<ImageStatusResponse>, Status> {
+        let image_ref = request
+            .into_inner()
+            .image
+            .map(|s| s.image)
+            .unwrap_or_default();
+        if image_ref.is_empty() {
+            return Ok(Response::new(ImageStatusResponse {
+                image: None,
+                info: HashMap::new(),
+            }));
+        }
+
+        let manifests = self.read_manifests().await;
+        let found = manifests
+            .iter()
+            .find(|m| m.reference == image_ref || m.digest == image_ref);
+
+        let image = if let Some(m) = found {
+            let size = Self::compute_image_size(m).await;
+            Some(Self::manifest_to_image(m, size))
+        } else {
+            None
+        };
+
+        Ok(Response::new(ImageStatusResponse {
+            image,
+            info: HashMap::new(),
+        }))
+    }
+
+    async fn pull_image(
+        &self,
+        request: Request<PullImageRequest>,
+    ) -> Result<Response<PullImageResponse>, Status> {
+        let inner = request.into_inner();
+        let image_ref = inner.image.map(|s| s.image).unwrap_or_default();
+        if image_ref.is_empty() {
+            return Err(Status::invalid_argument("image reference is required"));
+        }
+
+        let bin = self.get_bin().await;
+        let result = run_pelagos(&bin, &["image", "pull", &image_ref]).await;
+        match result {
+            Ok(out) if out.success => Ok(Response::new(PullImageResponse {
+                image_ref: image_ref.clone(),
+            })),
+            Ok(out) => Err(Status::internal(format!(
+                "pelagos image pull failed: {}",
+                out.stderr
+            ))),
+            Err(e) => Err(Status::internal(format!("exec error: {}", e))),
+        }
+    }
+
+    async fn remove_image(
+        &self,
+        request: Request<RemoveImageRequest>,
+    ) -> Result<Response<RemoveImageResponse>, Status> {
+        let image_ref = request
+            .into_inner()
+            .image
+            .map(|s| s.image)
+            .unwrap_or_default();
+        if image_ref.is_empty() {
+            return Ok(Response::new(RemoveImageResponse {}));
+        }
+
+        let bin = self.get_bin().await;
+        let _ = run_pelagos(&bin, &["image", "rm", &image_ref]).await;
+        Ok(Response::new(RemoveImageResponse {}))
+    }
+
+    async fn image_fs_info(
+        &self,
+        _request: Request<ImageFsInfoRequest>,
+    ) -> Result<Response<ImageFsInfoResponse>, Status> {
+        use crate::cri::{FilesystemIdentifier, FilesystemUsage, UInt64Value};
+        let usage = FilesystemUsage {
+            timestamp: 0,
+            fs_id: Some(FilesystemIdentifier {
+                mountpoint: LAYERS_DIR.to_string(),
+            }),
+            used_bytes: Some(UInt64Value { value: 0 }),
+            inodes_used: Some(UInt64Value { value: 0 }),
+        };
+        Ok(Response::new(ImageFsInfoResponse {
+            image_filesystems: vec![usage],
+            container_filesystems: vec![],
+        }))
+    }
+
+    type StreamImagesStream = std::pin::Pin<
+        Box<dyn futures_core::Stream<Item = Result<StreamImagesResponse, Status>> + Send>,
+    >;
+
+    async fn stream_images(
+        &self,
+        _request: Request<StreamImagesRequest>,
+    ) -> Result<Response<Self::StreamImagesStream>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+}

--- a/pelagos-cri/src/invoke.rs
+++ b/pelagos-cri/src/invoke.rs
@@ -1,0 +1,30 @@
+//! Async subprocess helpers for invoking the pelagos CLI.
+
+use tokio::process::Command;
+
+pub struct CmdOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub success: bool,
+}
+
+pub async fn run_pelagos(bin: &str, args: &[&str]) -> std::io::Result<CmdOutput> {
+    let out = Command::new(bin).args(args).output().await?;
+    Ok(CmdOutput {
+        stdout: String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        stderr: String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        success: out.status.success(),
+    })
+}
+
+/// Run a pelagos command and return stdout on success, Err on non-zero exit.
+#[allow(dead_code)]
+pub async fn run_pelagos_capture(bin: &str, args: &[&str]) -> std::io::Result<String> {
+    let out = Command::new(bin).args(args).output().await?;
+    if out.status.success() {
+        Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+    } else {
+        let msg = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        Err(std::io::Error::other(msg))
+    }
+}

--- a/pelagos-cri/src/main.rs
+++ b/pelagos-cri/src/main.rs
@@ -1,0 +1,87 @@
+//! Kubernetes CRI gRPC server that delegates to the pelagos container runtime.
+
+pub mod cri {
+    #![allow(clippy::all)]
+    tonic::include_proto!("runtime.v1");
+}
+
+mod image;
+mod invoke;
+mod runtime;
+mod state;
+
+use clap::Parser;
+use image::ImageSvc;
+use runtime::RuntimeSvc;
+use state::AppState;
+use tokio::signal::unix::{signal, SignalKind};
+use tokio_stream::wrappers::UnixListenerStream;
+
+#[derive(Parser)]
+#[clap(name = "pelagos-cri", about = "CRI gRPC server for pelagos")]
+struct Args {
+    /// Unix socket path to listen on.
+    #[clap(long, default_value = "/run/pelagos/cri.sock")]
+    socket: String,
+    /// Path to the pelagos binary.
+    #[clap(long, default_value = "pelagos")]
+    pelagos_bin: String,
+}
+
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let args = Args::parse();
+
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    if let Err(e) = rt.block_on(async_run(args)) {
+        log::error!("{}", e);
+        std::process::exit(1);
+    }
+}
+
+async fn async_run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    use std::os::unix::fs::PermissionsExt;
+
+    // Create socket directory
+    if let Some(parent) = std::path::Path::new(&args.socket).parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+
+    // Remove stale socket
+    if std::path::Path::new(&args.socket).exists() {
+        std::fs::remove_file(&args.socket)?;
+    }
+
+    let app_state = AppState::new(args.pelagos_bin.clone());
+
+    let runtime_svc = RuntimeSvc {
+        state: app_state.clone(),
+    };
+    let image_svc = ImageSvc {
+        state: app_state.clone(),
+    };
+
+    let uds = tokio::net::UnixListener::bind(&args.socket)?;
+    std::fs::set_permissions(&args.socket, std::fs::Permissions::from_mode(0o660))?;
+    log::info!("pelagos-cri listening on {}", args.socket);
+
+    let incoming = UnixListenerStream::new(uds);
+
+    let mut sigterm = signal(SignalKind::terminate())?;
+
+    tonic::transport::Server::builder()
+        .add_service(cri::runtime_service_server::RuntimeServiceServer::new(
+            runtime_svc,
+        ))
+        .add_service(cri::image_service_server::ImageServiceServer::new(
+            image_svc,
+        ))
+        .serve_with_incoming_shutdown(incoming, async move {
+            sigterm.recv().await;
+            log::info!("received SIGTERM, shutting down");
+        })
+        .await?;
+
+    Ok(())
+}

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -1,0 +1,970 @@
+//! CRI RuntimeService implementation.
+
+use crate::cri::runtime_service_server::RuntimeService;
+use crate::cri::{
+    AttachRequest, AttachResponse, CheckpointContainerRequest, CheckpointContainerResponse,
+    ContainerEventResponse, ContainerMetadata, ContainerState as CriContainerStateEnum,
+    ContainerStatsRequest, ContainerStatsResponse, ContainerStatus as CriContainerStatus,
+    ContainerStatusRequest, ContainerStatusResponse, CreateContainerRequest,
+    CreateContainerResponse, ExecRequest, ExecResponse, ExecSyncRequest, ExecSyncResponse,
+    GetEventsRequest, ImageSpec, LinuxPodSandboxStatus, ListContainerStatsRequest,
+    ListContainerStatsResponse, ListContainersRequest, ListContainersResponse,
+    ListMetricDescriptorsRequest, ListMetricDescriptorsResponse, ListPodSandboxMetricsRequest,
+    ListPodSandboxMetricsResponse, ListPodSandboxRequest, ListPodSandboxResponse,
+    ListPodSandboxStatsRequest, ListPodSandboxStatsResponse, Namespace, NamespaceOption,
+    PodSandbox, PodSandboxMetadata, PodSandboxNetworkStatus, PodSandboxState,
+    PodSandboxStatsRequest, PodSandboxStatsResponse, PodSandboxStatus as CriPodSandboxStatus,
+    PodSandboxStatusRequest, PodSandboxStatusResponse, PortForwardRequest, PortForwardResponse,
+    RemoveContainerRequest, RemoveContainerResponse, RemovePodSandboxRequest,
+    RemovePodSandboxResponse, ReopenContainerLogRequest, ReopenContainerLogResponse,
+    RuntimeCondition, RuntimeConfigRequest, RuntimeConfigResponse, RuntimeStatus,
+    StartContainerRequest, StartContainerResponse, StatusRequest, StatusResponse,
+    StopContainerRequest, StopContainerResponse, StopPodSandboxRequest, StopPodSandboxResponse,
+    StreamContainerStatsRequest, StreamContainerStatsResponse, StreamContainersRequest,
+    StreamContainersResponse, StreamPodSandboxMetricsRequest, StreamPodSandboxMetricsResponse,
+    StreamPodSandboxStatsRequest, StreamPodSandboxStatsResponse, StreamPodSandboxesRequest,
+    StreamPodSandboxesResponse, UpdateContainerResourcesRequest, UpdateContainerResourcesResponse,
+    UpdatePodSandboxResourcesRequest, UpdatePodSandboxResourcesResponse,
+    UpdateRuntimeConfigRequest, UpdateRuntimeConfigResponse, VersionRequest, VersionResponse,
+};
+use crate::invoke::run_pelagos;
+use crate::state::{
+    self, AppState, ContainerState as MyContainerState, CriContainer, CriMount, CriSandbox,
+    SandboxState,
+};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tonic::{Request, Response, Status};
+
+const PELAGOS_SANDBOXES_DIR: &str = "/run/pelagos/sandboxes";
+const PELAGOS_CONTAINERS_DIR: &str = "/run/pelagos/containers";
+
+// ── Pelagos on-disk state structs ────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct PelagosSandboxState {
+    #[allow(dead_code)]
+    id: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    name: Option<String>,
+    #[allow(dead_code)]
+    pause_pid: i32,
+    #[allow(dead_code)]
+    ns_name: String,
+    #[allow(dead_code)]
+    veth_host: String,
+    container_ip: String,
+}
+
+#[derive(Deserialize)]
+struct PelagosContainerState {
+    #[allow(dead_code)]
+    name: String,
+    status: String,
+    #[allow(dead_code)]
+    pid: i32,
+    #[allow(dead_code)]
+    started_at: String,
+    #[serde(default)]
+    exit_code: Option<i32>,
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn now_ns() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as i64
+}
+
+fn read_pelagos_sandbox_ip(sandbox_id: &str) -> Option<String> {
+    let path = format!("{}/{}/state.json", PELAGOS_SANDBOXES_DIR, sandbox_id);
+    let data = std::fs::read_to_string(&path).ok()?;
+    let st: PelagosSandboxState = serde_json::from_str(&data).ok()?;
+    Some(st.container_ip)
+}
+
+fn read_pelagos_container_state(pelagos_name: &str) -> Option<PelagosContainerState> {
+    let path = format!("{}/{}/state.json", PELAGOS_CONTAINERS_DIR, pelagos_name);
+    let data = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+fn cri_sandbox_state_val(s: &SandboxState) -> i32 {
+    match s {
+        SandboxState::Running => PodSandboxState::SandboxReady as i32,
+        SandboxState::NotReady => PodSandboxState::SandboxNotready as i32,
+    }
+}
+
+fn cri_container_state_val(s: &MyContainerState) -> i32 {
+    match s {
+        MyContainerState::Created => CriContainerStateEnum::ContainerCreated as i32,
+        MyContainerState::Running => CriContainerStateEnum::ContainerRunning as i32,
+        MyContainerState::Exited => CriContainerStateEnum::ContainerExited as i32,
+        MyContainerState::Unknown => CriContainerStateEnum::ContainerUnknown as i32,
+    }
+}
+
+fn labels_match(
+    container_labels: &HashMap<String, String>,
+    selector: &HashMap<String, String>,
+) -> bool {
+    selector
+        .iter()
+        .all(|(k, v)| container_labels.get(k).map(|val| val == v).unwrap_or(false))
+}
+
+fn sandbox_to_proto(s: &CriSandbox) -> PodSandbox {
+    PodSandbox {
+        id: s.id.clone(),
+        metadata: Some(PodSandboxMetadata {
+            name: s.name.clone(),
+            uid: s.uid.clone(),
+            namespace: s.namespace.clone(),
+            attempt: s.attempt,
+        }),
+        state: cri_sandbox_state_val(&s.state),
+        created_at: s.created_at_ns,
+        labels: s.labels.clone(),
+        annotations: s.annotations.clone(),
+        runtime_handler: String::new(),
+    }
+}
+
+fn container_to_proto(c: &CriContainer) -> crate::cri::Container {
+    crate::cri::Container {
+        id: c.id.clone(),
+        pod_sandbox_id: c.sandbox_id.clone(),
+        metadata: Some(ContainerMetadata {
+            name: c.name.clone(),
+            attempt: 0,
+        }),
+        image: Some(ImageSpec {
+            image: c.image.clone(),
+            annotations: HashMap::new(),
+            ..Default::default()
+        }),
+        image_ref: c.image.clone(),
+        state: cri_container_state_val(&c.state),
+        created_at: c.created_at_ns,
+        labels: c.labels.clone(),
+        annotations: c.annotations.clone(),
+        image_id: c.image.clone(),
+    }
+}
+
+// ── RuntimeSvc ───────────────────────────────────────────────────────────────
+
+pub struct RuntimeSvc {
+    pub state: AppState,
+}
+
+impl RuntimeSvc {
+    async fn bin(&self) -> String {
+        self.state.inner.lock().await.pelagos_bin.clone()
+    }
+}
+
+// ── Trait impl ───────────────────────────────────────────────────────────────
+
+#[tonic::async_trait]
+impl RuntimeService for RuntimeSvc {
+    async fn version(
+        &self,
+        _request: Request<VersionRequest>,
+    ) -> Result<Response<VersionResponse>, Status> {
+        Ok(Response::new(VersionResponse {
+            version: "0.1.0".into(),
+            runtime_name: "pelagos".into(),
+            runtime_version: env!("CARGO_PKG_VERSION").to_string(),
+            runtime_api_version: "v1".into(),
+        }))
+    }
+
+    async fn status(
+        &self,
+        _request: Request<StatusRequest>,
+    ) -> Result<Response<StatusResponse>, Status> {
+        Ok(Response::new(StatusResponse {
+            status: Some(RuntimeStatus {
+                conditions: vec![
+                    RuntimeCondition {
+                        r#type: "RuntimeReady".into(),
+                        status: true,
+                        reason: String::new(),
+                        message: String::new(),
+                    },
+                    RuntimeCondition {
+                        r#type: "NetworkReady".into(),
+                        status: true,
+                        reason: String::new(),
+                        message: String::new(),
+                    },
+                ],
+            }),
+            info: HashMap::new(),
+            runtime_handlers: vec![],
+            features: None,
+        }))
+    }
+
+    async fn run_pod_sandbox(
+        &self,
+        request: Request<crate::cri::RunPodSandboxRequest>,
+    ) -> Result<Response<crate::cri::RunPodSandboxResponse>, Status> {
+        let req = request.into_inner();
+        let config = req
+            .config
+            .ok_or_else(|| Status::invalid_argument("missing config"))?;
+        let meta = config
+            .metadata
+            .ok_or_else(|| Status::invalid_argument("missing metadata"))?;
+
+        let uid = meta.uid.clone();
+        let bin = self.bin().await;
+
+        let raw = run_pelagos(&bin, &["sandbox", "create", "--name", &uid])
+            .await
+            .map_err(|e| Status::internal(format!("exec error: {}", e)))?;
+        if !raw.success {
+            return Err(Status::internal(format!(
+                "sandbox create failed: {}",
+                raw.stderr
+            )));
+        }
+        let sandbox_id = raw.stdout.trim().to_string();
+
+        let sandbox = CriSandbox {
+            id: sandbox_id.clone(),
+            name: meta.name.clone(),
+            namespace: meta.namespace.clone(),
+            uid,
+            attempt: meta.attempt,
+            labels: config.labels.clone(),
+            annotations: config.annotations.clone(),
+            created_at_ns: now_ns(),
+            state: SandboxState::Running,
+        };
+
+        {
+            let mut st = self.state.inner.lock().await;
+            state::save_sandbox(&sandbox)
+                .map_err(|e| Status::internal(format!("save sandbox: {}", e)))?;
+            st.sandboxes.insert(sandbox_id.clone(), sandbox);
+        }
+
+        Ok(Response::new(crate::cri::RunPodSandboxResponse {
+            pod_sandbox_id: sandbox_id,
+        }))
+    }
+
+    async fn stop_pod_sandbox(
+        &self,
+        request: Request<StopPodSandboxRequest>,
+    ) -> Result<Response<StopPodSandboxResponse>, Status> {
+        let sandbox_id = request.into_inner().pod_sandbox_id;
+        let bin = self.bin().await;
+
+        let containers_to_stop: Vec<(String, MyContainerState)> = {
+            let st = self.state.inner.lock().await;
+            st.containers
+                .values()
+                .filter(|c| c.sandbox_id == sandbox_id)
+                .map(|c| (c.pelagos_name.clone(), c.state.clone()))
+                .collect()
+        };
+
+        for (pelagos_name, cstate) in &containers_to_stop {
+            if *cstate == MyContainerState::Running {
+                let _ = run_pelagos(&bin, &["stop", pelagos_name]).await;
+            }
+        }
+
+        let _ = run_pelagos(&bin, &["sandbox", "rm", &sandbox_id]).await;
+
+        let mut st = self.state.inner.lock().await;
+        if let Some(s) = st.sandboxes.get_mut(&sandbox_id) {
+            s.state = SandboxState::NotReady;
+            let _ = state::save_sandbox(s);
+        }
+
+        Ok(Response::new(StopPodSandboxResponse {}))
+    }
+
+    async fn remove_pod_sandbox(
+        &self,
+        request: Request<RemovePodSandboxRequest>,
+    ) -> Result<Response<RemovePodSandboxResponse>, Status> {
+        let sandbox_id = request.into_inner().pod_sandbox_id;
+
+        let mut st = self.state.inner.lock().await;
+        let container_ids: Vec<String> = st
+            .containers
+            .values()
+            .filter(|c| c.sandbox_id == sandbox_id)
+            .map(|c| c.id.clone())
+            .collect();
+
+        for cid in container_ids {
+            st.containers.remove(&cid);
+            state::remove_container_file(&cid);
+        }
+
+        st.sandboxes.remove(&sandbox_id);
+        state::remove_sandbox_file(&sandbox_id);
+
+        Ok(Response::new(RemovePodSandboxResponse {}))
+    }
+
+    async fn pod_sandbox_status(
+        &self,
+        request: Request<PodSandboxStatusRequest>,
+    ) -> Result<Response<PodSandboxStatusResponse>, Status> {
+        let sandbox_id = request.into_inner().pod_sandbox_id;
+
+        let st = self.state.inner.lock().await;
+        let sandbox = st
+            .sandboxes
+            .get(&sandbox_id)
+            .ok_or_else(|| Status::not_found("sandbox not found"))?
+            .clone();
+        drop(st);
+
+        let ip = read_pelagos_sandbox_ip(&sandbox_id).unwrap_or_default();
+
+        let status = CriPodSandboxStatus {
+            id: sandbox.id.clone(),
+            metadata: Some(PodSandboxMetadata {
+                name: sandbox.name.clone(),
+                uid: sandbox.uid.clone(),
+                namespace: sandbox.namespace.clone(),
+                attempt: sandbox.attempt,
+            }),
+            state: cri_sandbox_state_val(&sandbox.state),
+            created_at: sandbox.created_at_ns,
+            network: Some(PodSandboxNetworkStatus {
+                ip: ip.clone(),
+                additional_ips: vec![],
+            }),
+            linux: Some(LinuxPodSandboxStatus {
+                namespaces: Some(Namespace {
+                    options: Some(NamespaceOption {
+                        network: 0,
+                        pid: 0,
+                        ipc: 0,
+                        target_id: String::new(),
+                        userns_options: None,
+                    }),
+                }),
+            }),
+            labels: sandbox.labels.clone(),
+            annotations: sandbox.annotations.clone(),
+            runtime_handler: String::new(),
+        };
+
+        Ok(Response::new(PodSandboxStatusResponse {
+            status: Some(status),
+            info: HashMap::new(),
+            containers_statuses: vec![],
+            timestamp: now_ns(),
+        }))
+    }
+
+    async fn list_pod_sandbox(
+        &self,
+        request: Request<ListPodSandboxRequest>,
+    ) -> Result<Response<ListPodSandboxResponse>, Status> {
+        let filter = request.into_inner().filter;
+        let st = self.state.inner.lock().await;
+
+        let items: Vec<PodSandbox> = st
+            .sandboxes
+            .values()
+            .filter(|s| {
+                if let Some(ref f) = filter {
+                    if !f.id.is_empty() && s.id != f.id {
+                        return false;
+                    }
+                    if let Some(ref sv) = f.state {
+                        let want = sv.state;
+                        let have = cri_sandbox_state_val(&s.state);
+                        if want != have {
+                            return false;
+                        }
+                    }
+                    if !labels_match(&s.labels, &f.label_selector) {
+                        return false;
+                    }
+                }
+                true
+            })
+            .map(sandbox_to_proto)
+            .collect();
+
+        Ok(Response::new(ListPodSandboxResponse { items }))
+    }
+
+    async fn create_container(
+        &self,
+        request: Request<CreateContainerRequest>,
+    ) -> Result<Response<CreateContainerResponse>, Status> {
+        let req = request.into_inner();
+        let sandbox_id = req.pod_sandbox_id.clone();
+        let config = req
+            .config
+            .ok_or_else(|| Status::invalid_argument("missing container config"))?;
+
+        let meta = config
+            .metadata
+            .ok_or_else(|| Status::invalid_argument("missing container metadata"))?;
+
+        let image_ref = config.image.map(|s| s.image).unwrap_or_default();
+
+        let id = uuid::Uuid::new_v4().simple().to_string();
+        let pelagos_name = format!("pcri-{}", &id[..12]);
+
+        let envs: Vec<(String, String)> = config
+            .envs
+            .iter()
+            .map(|kv| {
+                (
+                    kv.key.clone(),
+                    String::from_utf8_lossy(&kv.value).into_owned(),
+                )
+            })
+            .collect();
+
+        let mounts: Vec<CriMount> = config
+            .mounts
+            .iter()
+            .map(|m| CriMount {
+                host_path: m.host_path.clone(),
+                container_path: m.container_path.clone(),
+                readonly: m.readonly,
+            })
+            .collect();
+
+        let container = CriContainer {
+            id: id.clone(),
+            sandbox_id,
+            pelagos_name,
+            name: meta.name.clone(),
+            image: image_ref,
+            entrypoint: config.command.clone(),
+            args: config.args.clone(),
+            envs,
+            working_dir: config.working_dir.clone(),
+            mounts,
+            labels: config.labels.clone(),
+            annotations: config.annotations.clone(),
+            created_at_ns: now_ns(),
+            started_at_ns: 0,
+            finished_at_ns: 0,
+            state: MyContainerState::Created,
+            exit_code: 0,
+        };
+
+        {
+            let mut st = self.state.inner.lock().await;
+            state::save_container(&container)
+                .map_err(|e| Status::internal(format!("save container: {}", e)))?;
+            st.containers.insert(id.clone(), container);
+        }
+
+        Ok(Response::new(CreateContainerResponse { container_id: id }))
+    }
+
+    async fn start_container(
+        &self,
+        request: Request<StartContainerRequest>,
+    ) -> Result<Response<StartContainerResponse>, Status> {
+        let container_id = request.into_inner().container_id;
+        let bin = self.bin().await;
+
+        let container = {
+            let st = self.state.inner.lock().await;
+            st.containers
+                .get(&container_id)
+                .cloned()
+                .ok_or_else(|| Status::not_found("container not found"))?
+        };
+
+        let mut args: Vec<String> = vec![
+            "run".into(),
+            "--name".into(),
+            container.pelagos_name.clone(),
+            "--detach".into(),
+            "--sandbox".into(),
+            container.sandbox_id.clone(),
+        ];
+
+        for (k, v) in &container.envs {
+            args.push("--env".into());
+            args.push(format!("{}={}", k, v));
+        }
+
+        if !container.working_dir.is_empty() {
+            args.push("--workdir".into());
+            args.push(container.working_dir.clone());
+        }
+
+        for m in &container.mounts {
+            args.push("-v".into());
+            if m.readonly {
+                args.push(format!("{}{}:ro", m.host_path, m.container_path));
+            } else {
+                args.push(format!("{}:{}", m.host_path, m.container_path));
+            }
+        }
+
+        args.push(container.image.clone());
+
+        // pelagos run treats all positional args after the image as the full
+        // command (replacing both ENTRYPOINT and CMD). Combine CRI command
+        // (entrypoint override) + args (cmd override) in order.
+        args.extend(container.entrypoint.iter().cloned());
+        args.extend(container.args.iter().cloned());
+
+        let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let out = run_pelagos(&bin, &args_ref)
+            .await
+            .map_err(|e| Status::internal(format!("exec error: {}", e)))?;
+
+        if !out.success {
+            return Err(Status::internal(format!(
+                "pelagos run failed: {}",
+                out.stderr
+            )));
+        }
+
+        let mut st = self.state.inner.lock().await;
+        if let Some(c) = st.containers.get_mut(&container_id) {
+            c.state = MyContainerState::Running;
+            c.started_at_ns = now_ns();
+            let _ = state::save_container(c);
+        }
+
+        Ok(Response::new(StartContainerResponse {}))
+    }
+
+    async fn stop_container(
+        &self,
+        request: Request<StopContainerRequest>,
+    ) -> Result<Response<StopContainerResponse>, Status> {
+        let container_id = request.into_inner().container_id;
+        let bin = self.bin().await;
+
+        let pelagos_name = {
+            let st = self.state.inner.lock().await;
+            st.containers
+                .get(&container_id)
+                .map(|c| c.pelagos_name.clone())
+                .ok_or_else(|| Status::not_found("container not found"))?
+        };
+
+        let _ = run_pelagos(&bin, &["stop", &pelagos_name]).await;
+
+        let mut st = self.state.inner.lock().await;
+        if let Some(c) = st.containers.get_mut(&container_id) {
+            c.state = MyContainerState::Exited;
+            c.finished_at_ns = now_ns();
+            let _ = state::save_container(c);
+        }
+
+        Ok(Response::new(StopContainerResponse {}))
+    }
+
+    async fn remove_container(
+        &self,
+        request: Request<RemoveContainerRequest>,
+    ) -> Result<Response<RemoveContainerResponse>, Status> {
+        let container_id = request.into_inner().container_id;
+        let bin = self.bin().await;
+
+        let pelagos_name = {
+            let st = self.state.inner.lock().await;
+            st.containers
+                .get(&container_id)
+                .map(|c| c.pelagos_name.clone())
+        };
+
+        if let Some(name) = pelagos_name {
+            let _ = run_pelagos(&bin, &["rm", &name]).await;
+        }
+
+        let mut st = self.state.inner.lock().await;
+        st.containers.remove(&container_id);
+        state::remove_container_file(&container_id);
+
+        Ok(Response::new(RemoveContainerResponse {}))
+    }
+
+    async fn list_containers(
+        &self,
+        request: Request<ListContainersRequest>,
+    ) -> Result<Response<ListContainersResponse>, Status> {
+        let filter = request.into_inner().filter;
+        let mut st = self.state.inner.lock().await;
+
+        // Refresh running containers from disk
+        let ids: Vec<String> = st.containers.keys().cloned().collect();
+        for id in ids {
+            if let Some(c) = st.containers.get(&id) {
+                if c.state == MyContainerState::Running {
+                    let pelagos_name = c.pelagos_name.clone();
+                    if let Some(live) = read_pelagos_container_state(&pelagos_name) {
+                        if live.status == "exited" {
+                            if let Some(c) = st.containers.get_mut(&id) {
+                                c.state = MyContainerState::Exited;
+                                c.exit_code = live.exit_code.unwrap_or(0);
+                                c.finished_at_ns = now_ns();
+                                let _ = state::save_container(c);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let containers: Vec<crate::cri::Container> = st
+            .containers
+            .values()
+            .filter(|c| {
+                if let Some(ref f) = filter {
+                    if !f.id.is_empty() && c.id != f.id {
+                        return false;
+                    }
+                    if !f.pod_sandbox_id.is_empty() && c.sandbox_id != f.pod_sandbox_id {
+                        return false;
+                    }
+                    if let Some(ref sv) = f.state {
+                        let want = sv.state;
+                        let have = cri_container_state_val(&c.state);
+                        if want != have {
+                            return false;
+                        }
+                    }
+                    if !labels_match(&c.labels, &f.label_selector) {
+                        return false;
+                    }
+                }
+                true
+            })
+            .map(container_to_proto)
+            .collect();
+
+        Ok(Response::new(ListContainersResponse { containers }))
+    }
+
+    async fn container_status(
+        &self,
+        request: Request<ContainerStatusRequest>,
+    ) -> Result<Response<ContainerStatusResponse>, Status> {
+        let container_id = request.into_inner().container_id;
+
+        let mut st = self.state.inner.lock().await;
+        let container = st
+            .containers
+            .get(&container_id)
+            .cloned()
+            .ok_or_else(|| Status::not_found("container not found"))?;
+
+        // Refresh from disk if running
+        let container = if container.state == MyContainerState::Running {
+            if let Some(live) = read_pelagos_container_state(&container.pelagos_name) {
+                if live.status == "exited" {
+                    if let Some(c) = st.containers.get_mut(&container_id) {
+                        c.state = MyContainerState::Exited;
+                        c.exit_code = live.exit_code.unwrap_or(0);
+                        c.finished_at_ns = now_ns();
+                        let _ = state::save_container(c);
+                    }
+                    st.containers.get(&container_id).cloned().unwrap()
+                } else {
+                    container
+                }
+            } else {
+                container
+            }
+        } else {
+            container
+        };
+
+        let cstate = cri_container_state_val(&container.state);
+
+        let status = CriContainerStatus {
+            id: container.id.clone(),
+            metadata: Some(ContainerMetadata {
+                name: container.name.clone(),
+                attempt: 0,
+            }),
+            state: cstate,
+            created_at: container.created_at_ns,
+            started_at: container.started_at_ns,
+            finished_at: container.finished_at_ns,
+            exit_code: container.exit_code,
+            image: Some(ImageSpec {
+                image: container.image.clone(),
+                annotations: HashMap::new(),
+                ..Default::default()
+            }),
+            image_ref: container.image.clone(),
+            reason: String::new(),
+            message: String::new(),
+            labels: container.labels.clone(),
+            annotations: container.annotations.clone(),
+            mounts: vec![],
+            log_path: String::new(),
+            resources: None,
+            image_id: container.image.clone(),
+            user: None,
+            stop_signal: 0,
+        };
+
+        Ok(Response::new(ContainerStatusResponse {
+            status: Some(status),
+            info: HashMap::new(),
+        }))
+    }
+
+    async fn exec_sync(
+        &self,
+        request: Request<ExecSyncRequest>,
+    ) -> Result<Response<ExecSyncResponse>, Status> {
+        let req = request.into_inner();
+        let container_id = req.container_id;
+        let cmd = req.cmd;
+        let timeout_secs = req.timeout;
+
+        let (pelagos_name, bin) = {
+            let st = self.state.inner.lock().await;
+            let name = st
+                .containers
+                .get(&container_id)
+                .map(|c| c.pelagos_name.clone())
+                .ok_or_else(|| Status::not_found("container not found"))?;
+            let bin = st.pelagos_bin.clone();
+            (name, bin)
+        };
+
+        use std::process::Stdio;
+        use tokio::process::Command;
+
+        let mut proc_cmd = Command::new(&bin);
+        proc_cmd.arg("exec");
+        proc_cmd.arg(&pelagos_name);
+        for c in &cmd {
+            proc_cmd.arg(c);
+        }
+        proc_cmd.stdout(Stdio::piped());
+        proc_cmd.stderr(Stdio::piped());
+
+        let child = proc_cmd
+            .spawn()
+            .map_err(|e| Status::internal(format!("spawn error: {}", e)))?;
+
+        let output = if timeout_secs > 0 {
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(timeout_secs as u64),
+                child.wait_with_output(),
+            )
+            .await
+            {
+                Ok(Ok(out)) => out,
+                Ok(Err(e)) => return Err(Status::internal(format!("wait error: {}", e))),
+                Err(_) => return Err(Status::deadline_exceeded("exec timed out")),
+            }
+        } else {
+            child
+                .wait_with_output()
+                .await
+                .map_err(|e| Status::internal(format!("wait error: {}", e)))?
+        };
+
+        let exit_code = output.status.code().unwrap_or(1);
+
+        Ok(Response::new(ExecSyncResponse {
+            stdout: output.stdout,
+            stderr: output.stderr,
+            exit_code,
+        }))
+    }
+
+    // ── Unimplemented RPCs ───────────────────────────────────────────────────
+
+    async fn update_container_resources(
+        &self,
+        _request: Request<UpdateContainerResourcesRequest>,
+    ) -> Result<Response<UpdateContainerResourcesResponse>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    async fn reopen_container_log(
+        &self,
+        _request: Request<ReopenContainerLogRequest>,
+    ) -> Result<Response<ReopenContainerLogResponse>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    async fn exec(&self, _request: Request<ExecRequest>) -> Result<Response<ExecResponse>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    async fn attach(
+        &self,
+        _request: Request<AttachRequest>,
+    ) -> Result<Response<AttachResponse>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    async fn port_forward(
+        &self,
+        _request: Request<PortForwardRequest>,
+    ) -> Result<Response<PortForwardResponse>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    async fn container_stats(
+        &self,
+        _request: Request<ContainerStatsRequest>,
+    ) -> Result<Response<ContainerStatsResponse>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    async fn list_container_stats(
+        &self,
+        _request: Request<ListContainerStatsRequest>,
+    ) -> Result<Response<ListContainerStatsResponse>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    async fn pod_sandbox_stats(
+        &self,
+        _request: Request<PodSandboxStatsRequest>,
+    ) -> Result<Response<PodSandboxStatsResponse>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    async fn list_pod_sandbox_stats(
+        &self,
+        _request: Request<ListPodSandboxStatsRequest>,
+    ) -> Result<Response<ListPodSandboxStatsResponse>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    async fn update_runtime_config(
+        &self,
+        _request: Request<UpdateRuntimeConfigRequest>,
+    ) -> Result<Response<UpdateRuntimeConfigResponse>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    async fn checkpoint_container(
+        &self,
+        _request: Request<CheckpointContainerRequest>,
+    ) -> Result<Response<CheckpointContainerResponse>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    async fn list_metric_descriptors(
+        &self,
+        _request: Request<ListMetricDescriptorsRequest>,
+    ) -> Result<Response<ListMetricDescriptorsResponse>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    async fn list_pod_sandbox_metrics(
+        &self,
+        _request: Request<ListPodSandboxMetricsRequest>,
+    ) -> Result<Response<ListPodSandboxMetricsResponse>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    async fn runtime_config(
+        &self,
+        _request: Request<RuntimeConfigRequest>,
+    ) -> Result<Response<RuntimeConfigResponse>, Status> {
+        Ok(Response::new(RuntimeConfigResponse { linux: None }))
+    }
+
+    async fn update_pod_sandbox_resources(
+        &self,
+        _request: Request<UpdatePodSandboxResourcesRequest>,
+    ) -> Result<Response<UpdatePodSandboxResourcesResponse>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    // ── Streaming RPCs ───────────────────────────────────────────────────────
+
+    type StreamPodSandboxesStream = std::pin::Pin<
+        Box<dyn futures_core::Stream<Item = Result<StreamPodSandboxesResponse, Status>> + Send>,
+    >;
+
+    async fn stream_pod_sandboxes(
+        &self,
+        _request: Request<StreamPodSandboxesRequest>,
+    ) -> Result<Response<Self::StreamPodSandboxesStream>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    type StreamContainersStream = std::pin::Pin<
+        Box<dyn futures_core::Stream<Item = Result<StreamContainersResponse, Status>> + Send>,
+    >;
+
+    async fn stream_containers(
+        &self,
+        _request: Request<StreamContainersRequest>,
+    ) -> Result<Response<Self::StreamContainersStream>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    type StreamContainerStatsStream = std::pin::Pin<
+        Box<dyn futures_core::Stream<Item = Result<StreamContainerStatsResponse, Status>> + Send>,
+    >;
+
+    async fn stream_container_stats(
+        &self,
+        _request: Request<StreamContainerStatsRequest>,
+    ) -> Result<Response<Self::StreamContainerStatsStream>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    type StreamPodSandboxStatsStream = std::pin::Pin<
+        Box<dyn futures_core::Stream<Item = Result<StreamPodSandboxStatsResponse, Status>> + Send>,
+    >;
+
+    async fn stream_pod_sandbox_stats(
+        &self,
+        _request: Request<StreamPodSandboxStatsRequest>,
+    ) -> Result<Response<Self::StreamPodSandboxStatsStream>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    type GetContainerEventsStream = std::pin::Pin<
+        Box<dyn futures_core::Stream<Item = Result<ContainerEventResponse, Status>> + Send>,
+    >;
+
+    async fn get_container_events(
+        &self,
+        _request: Request<GetEventsRequest>,
+    ) -> Result<Response<Self::GetContainerEventsStream>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    type StreamPodSandboxMetricsStream = std::pin::Pin<
+        Box<
+            dyn futures_core::Stream<Item = Result<StreamPodSandboxMetricsResponse, Status>> + Send,
+        >,
+    >;
+
+    async fn stream_pod_sandbox_metrics(
+        &self,
+        _request: Request<StreamPodSandboxMetricsRequest>,
+    ) -> Result<Response<Self::StreamPodSandboxMetricsStream>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
+}

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -1,0 +1,167 @@
+//! In-memory CRI state backed by disk at `/run/pelagos-cri/`.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+const SANDBOXES_DIR: &str = "/run/pelagos-cri/sandboxes";
+const CONTAINERS_DIR: &str = "/run/pelagos-cri/containers";
+
+// ── CRI sandbox metadata ─────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CriSandbox {
+    pub id: String,
+    pub name: String,
+    pub namespace: String,
+    pub uid: String,
+    pub attempt: u32,
+    pub labels: HashMap<String, String>,
+    pub annotations: HashMap<String, String>,
+    pub created_at_ns: i64,
+    pub state: SandboxState,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum SandboxState {
+    Running,
+    NotReady,
+}
+
+// ── CRI container metadata ───────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CriMount {
+    pub host_path: String,
+    pub container_path: String,
+    pub readonly: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CriContainer {
+    pub id: String,
+    pub sandbox_id: String,
+    pub pelagos_name: String,
+    pub name: String,
+    pub image: String,
+    /// CRI `command` field — overrides image ENTRYPOINT.
+    pub entrypoint: Vec<String>,
+    /// CRI `args` field — overrides image CMD.
+    pub args: Vec<String>,
+    pub envs: Vec<(String, String)>,
+    pub working_dir: String,
+    pub mounts: Vec<CriMount>,
+    pub labels: HashMap<String, String>,
+    pub annotations: HashMap<String, String>,
+    pub created_at_ns: i64,
+    pub started_at_ns: i64,
+    pub finished_at_ns: i64,
+    pub state: ContainerState,
+    pub exit_code: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum ContainerState {
+    Created,
+    Running,
+    Exited,
+    Unknown,
+}
+
+// ── StateInner ───────────────────────────────────────────────────────────────
+
+pub struct StateInner {
+    pub sandboxes: HashMap<String, CriSandbox>,
+    pub containers: HashMap<String, CriContainer>,
+    pub pelagos_bin: String,
+}
+
+impl StateInner {
+    fn load() -> Self {
+        let sandboxes = load_all_sandboxes();
+        let containers = load_all_containers();
+        StateInner {
+            sandboxes,
+            containers,
+            pelagos_bin: String::new(),
+        }
+    }
+}
+
+// ── AppState ─────────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+pub struct AppState {
+    pub inner: Arc<Mutex<StateInner>>,
+}
+
+impl AppState {
+    pub fn new(pelagos_bin: String) -> Self {
+        let _ = std::fs::create_dir_all(SANDBOXES_DIR);
+        let _ = std::fs::create_dir_all(CONTAINERS_DIR);
+        let mut inner = StateInner::load();
+        inner.pelagos_bin = pelagos_bin;
+        AppState {
+            inner: Arc::new(Mutex::new(inner)),
+        }
+    }
+}
+
+// ── Disk helpers ─────────────────────────────────────────────────────────────
+
+pub fn save_sandbox(s: &CriSandbox) -> std::io::Result<()> {
+    let _ = std::fs::create_dir_all(SANDBOXES_DIR);
+    let path = format!("{}/{}.json", SANDBOXES_DIR, s.id);
+    let json = serde_json::to_string(s)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    std::fs::write(path, json)
+}
+
+pub fn save_container(c: &CriContainer) -> std::io::Result<()> {
+    let _ = std::fs::create_dir_all(CONTAINERS_DIR);
+    let path = format!("{}/{}.json", CONTAINERS_DIR, c.id);
+    let json = serde_json::to_string(c)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    std::fs::write(path, json)
+}
+
+pub fn remove_sandbox_file(id: &str) {
+    let _ = std::fs::remove_file(format!("{}/{}.json", SANDBOXES_DIR, id));
+}
+
+pub fn remove_container_file(id: &str) {
+    let _ = std::fs::remove_file(format!("{}/{}.json", CONTAINERS_DIR, id));
+}
+
+fn load_all_sandboxes() -> HashMap<String, CriSandbox> {
+    let Ok(entries) = std::fs::read_dir(SANDBOXES_DIR) else {
+        return HashMap::new();
+    };
+    entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().map(|x| x == "json").unwrap_or(false))
+        .filter_map(|e| {
+            std::fs::read_to_string(e.path())
+                .ok()
+                .and_then(|d| serde_json::from_str::<CriSandbox>(&d).ok())
+        })
+        .map(|s| (s.id.clone(), s))
+        .collect()
+}
+
+fn load_all_containers() -> HashMap<String, CriContainer> {
+    let Ok(entries) = std::fs::read_dir(CONTAINERS_DIR) else {
+        return HashMap::new();
+    };
+    entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().map(|x| x == "json").unwrap_or(false))
+        .filter_map(|e| {
+            std::fs::read_to_string(e.path())
+                .ok()
+                .and_then(|d| serde_json::from_str::<CriContainer>(&d).ok())
+        })
+        .map(|c| (c.id.clone(), c))
+        .collect()
+}

--- a/scripts/test-cri.sh
+++ b/scripts/test-cri.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# End-to-end test script for the pelagos CRI gRPC server.
+#
+# Prerequisites:
+#   - Run as root (pelagos networking requires root)
+#   - pelagos and pelagos-cri built (cargo build)
+#   - crictl installed (https://github.com/kubernetes-sigs/cri-tools)
+#     Arch: sudo pacman -S cri-tools
+#     Ubuntu: sudo apt-get install cri-tools
+#   - alpine image pulled: pelagos image pull alpine
+#
+# Usage:
+#   sudo -E env "PATH=$PATH" bash scripts/test-cri.sh
+
+set -uo pipefail
+
+BINARY="./target/debug/pelagos"
+CRI_BINARY="./target/debug/pelagos-cri"
+CRI_SOCK="/run/pelagos/cri.sock"
+CRICTL="crictl --runtime-endpoint unix://${CRI_SOCK}"
+CRI_PID_FILE="/tmp/pelagos-cri-test.pid"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC}  $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC}  $1"; FAIL=$((FAIL + 1)); }
+step() { echo -e "\n${BOLD}${YELLOW}=== $1 ===${NC}"; }
+info() { echo "  $1"; }
+
+check_exit_ok() {
+    local desc="$1"; shift
+    if "$@" > /dev/null 2>&1; then
+        pass "$desc"
+    else
+        fail "$desc"
+    fi
+}
+
+check_contains() {
+    local desc="$1"
+    local output="$2"
+    local pattern="$3"
+    if echo "$output" | grep -q "$pattern"; then
+        pass "$desc"
+    else
+        fail "$desc (expected '$pattern' in output)"
+        info "  got: $(echo "$output" | head -3)"
+    fi
+}
+
+CRICTL_YAML_WRITTEN=0
+
+cleanup() {
+    if [ -f "$CRI_PID_FILE" ]; then
+        kill "$(cat $CRI_PID_FILE)" 2>/dev/null || true
+        rm -f "$CRI_PID_FILE"
+    fi
+    rm -f "$CRI_SOCK"
+    rm -rf /run/pelagos-cri
+    if [ "$CRICTL_YAML_WRITTEN" = "1" ]; then
+        rm -f /etc/crictl.yaml
+    fi
+}
+trap cleanup EXIT
+
+# Helper: run crictl and return only the last non-empty, non-warning line (for ID capture)
+crictl_id() {
+    $CRICTL "$@" 2>/dev/null | grep -v "^time=" | grep -v "^$" | tail -1
+}
+
+# ── Preflight ─────────────────────────────────────────────────────────────────
+
+step "Preflight checks"
+
+if [ "$(id -u)" != "0" ]; then
+    echo "Must run as root"
+    exit 1
+fi
+
+for bin in "$BINARY" "$CRI_BINARY"; do
+    if [ ! -x "$bin" ]; then
+        echo "Missing binary: $bin — run 'cargo build' first"
+        exit 1
+    fi
+done
+
+if ! command -v crictl > /dev/null 2>&1; then
+    echo "crictl not found — install cri-tools (pacman -S cri-tools or apt-get install cri-tools)"
+    exit 1
+fi
+
+pass "binaries present"
+pass "crictl found"
+
+# Write crictl config so it knows our socket and suppresses "config not found" warnings.
+if [ ! -f /etc/crictl.yaml ]; then
+    cat > /etc/crictl.yaml <<EOF
+runtime-endpoint: unix://${CRI_SOCK}
+image-endpoint: unix://${CRI_SOCK}
+timeout: 10
+debug: false
+EOF
+    CRICTL_YAML_WRITTEN=1
+fi
+pass "crictl config written"
+
+# ── Start pelagos-cri ─────────────────────────────────────────────────────────
+
+step "Start pelagos-cri"
+
+cleanup  # clean up any stale socket
+
+"$CRI_BINARY" --pelagos-bin "$BINARY" > /tmp/pelagos-cri.log 2>&1 &
+echo $! > "$CRI_PID_FILE"
+
+# Wait for socket to appear (up to 5 seconds)
+for i in $(seq 1 10); do
+    if [ -S "$CRI_SOCK" ]; then break; fi
+    sleep 0.5
+done
+
+if [ -S "$CRI_SOCK" ]; then
+    pass "pelagos-cri socket present"
+else
+    fail "pelagos-cri socket not present after 5s"
+    info "--- pelagos-cri log ---"
+    cat /tmp/pelagos-cri.log
+    exit 1
+fi
+
+# ── Version / Status ──────────────────────────────────────────────────────────
+
+step "C2: Version and Status"
+
+OUT=$($CRICTL version 2>&1)
+check_contains "crictl version: runtimeName=pelagos" "$OUT" "pelagos"
+
+OUT=$($CRICTL info 2>&1)
+check_contains "crictl info: RuntimeReady=true" "$OUT" "RuntimeReady"
+
+# ── Image operations ──────────────────────────────────────────────────────────
+
+step "C3: ImageService"
+
+# Pull alpine (may already be cached)
+if $CRICTL pull alpine > /tmp/crictl-pull.log 2>&1; then
+    pass "crictl pull alpine"
+else
+    fail "crictl pull alpine"
+    cat /tmp/crictl-pull.log
+fi
+
+OUT=$($CRICTL images 2>&1)
+check_contains "crictl images lists alpine" "$OUT" "alpine"
+
+# ImageStatus
+OUT=$($CRICTL img alpine 2>&1)
+check_contains "crictl img alpine: has tag" "$OUT" "alpine"
+
+# ── Pod sandbox ───────────────────────────────────────────────────────────────
+
+step "C4: Pod sandbox"
+
+cat > /tmp/test-pod.json <<'EOF'
+{
+  "metadata": {
+    "name": "test-pod",
+    "namespace": "default",
+    "uid": "test-uid-12345",
+    "attempt": 0
+  },
+  "hostname": "test-pod",
+  "log_directory": "/tmp/test-pod-logs",
+  "dns_config": {},
+  "port_mappings": [],
+  "labels": {"test": "cri"},
+  "annotations": {},
+  "linux": {}
+}
+EOF
+
+SANDBOX_ID=$(crictl_id runp /tmp/test-pod.json)
+if [ -n "$SANDBOX_ID" ]; then
+    pass "crictl runp created sandbox"
+    info "sandbox ID: $SANDBOX_ID"
+else
+    fail "crictl runp returned empty ID"
+    exit 1
+fi
+
+OUT=$($CRICTL pods 2>&1)
+check_contains "crictl pods lists sandbox" "$OUT" "test-pod"
+
+OUT=$($CRICTL inspectp "$SANDBOX_ID" 2>&1)
+check_contains "crictl inspectp: state=SANDBOX_READY" "$OUT" "SANDBOX_READY"
+
+# ── Container lifecycle ───────────────────────────────────────────────────────
+
+step "C6: Container lifecycle"
+
+cat > /tmp/test-container.json <<'EOF'
+{
+  "metadata": {
+    "name": "test-container",
+    "attempt": 0
+  },
+  "image": {"image": "alpine:latest"},
+  "command": ["/bin/sh"],
+  "args": ["-c", "echo hello-from-cri; sleep 30"],
+  "working_dir": "/",
+  "envs": [{"key": "TEST_VAR", "value": "hello"}],
+  "mounts": [],
+  "labels": {"test": "cri"},
+  "annotations": {},
+  "log_path": "test-container.log",
+  "linux": {}
+}
+EOF
+
+CONTAINER_ID=$(crictl_id create "$SANDBOX_ID" /tmp/test-container.json /tmp/test-pod.json)
+if [ -n "$CONTAINER_ID" ]; then
+    pass "crictl create returned container ID"
+    info "container ID: $CONTAINER_ID"
+else
+    fail "crictl create returned empty ID"
+    exit 1
+fi
+
+OUT=$($CRICTL ps -a 2>&1)
+check_contains "crictl ps -a shows created container" "$OUT" "test-container"
+
+check_exit_ok "crictl start container" $CRICTL start "$CONTAINER_ID"
+
+# Give the container a moment to be running
+sleep 1
+
+OUT=$($CRICTL ps 2>&1)
+check_contains "crictl ps shows running container" "$OUT" "test-container"
+
+# ── ExecSync ──────────────────────────────────────────────────────────────────
+
+step "C6: ExecSync"
+
+OUT=$($CRICTL exec --sync "$CONTAINER_ID" echo hello-exec 2>&1)
+check_contains "crictl exec --sync echo" "$OUT" "hello-exec"
+
+OUT=$($CRICTL exec --sync "$CONTAINER_ID" /bin/sh -c 'echo $TEST_VAR' 2>&1)
+check_contains "crictl exec: env var TEST_VAR is set" "$OUT" "hello"
+
+# ── Container status ──────────────────────────────────────────────────────────
+
+step "C6: Container status"
+
+OUT=$($CRICTL inspect "$CONTAINER_ID" 2>&1)
+check_contains "crictl inspect: state=CONTAINER_RUNNING" "$OUT" "CONTAINER_RUNNING"
+
+# ── Stop / remove ─────────────────────────────────────────────────────────────
+
+step "C6: Stop and remove"
+
+check_exit_ok "crictl stop container" $CRICTL stop "$CONTAINER_ID"
+
+OUT=$($CRICTL ps -a 2>&1)
+check_contains "crictl ps -a shows exited container" "$OUT" "Exited"
+
+check_exit_ok "crictl rm container" $CRICTL rm "$CONTAINER_ID"
+
+OUT=$($CRICTL ps -a 2>&1)
+if ! echo "$OUT" | grep -q "$CONTAINER_ID"; then
+    pass "container removed from crictl ps"
+else
+    fail "container still visible after rm"
+fi
+
+check_exit_ok "crictl stopp sandbox" $CRICTL stopp "$SANDBOX_ID"
+check_exit_ok "crictl rmp sandbox" $CRICTL rmp "$SANDBOX_ID"
+
+OUT=$($CRICTL pods 2>&1)
+if ! echo "$OUT" | grep -q "test-pod"; then
+    pass "sandbox removed from crictl pods"
+else
+    fail "sandbox still visible after rmp"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}Results: ${GREEN}${PASS} passed${NC}  ${RED}${FAIL} failed${NC}"
+
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #236

## Summary

- New `pelagos-cri` workspace member: a CRI gRPC server (tonic/prost) that delegates to the `pelagos` CLI as a subprocess
- Implements CRI phases C2–C6: Version/Status, ImageService (pull/list/rm/status), pod sandbox RPCs, and full container lifecycle (create/start/stop/rm/exec)
- Persistent state under `/run/pelagos-cri/` (JSON per sandbox/container) — survives daemon restarts
- End-to-end test script at `scripts/test-cri.sh`; **26/26 tests pass** against a live `pelagos-cri` instance using `crictl`

## Test plan

- [ ] `cargo build` — workspace builds cleanly
- [ ] `sudo -E env "PATH=$PATH" bash scripts/test-cri.sh` — all 26 tests pass
- [ ] Verify `crictl version` reports `runtimeName=pelagos`
- [ ] Verify sandbox create/inspect/stop/remove round-trip
- [ ] Verify container create/start/exec/stop/remove round-trip

## Deferred (follow-up issues)

- C5 CNI: pod network namespace + CNI plugin invocation (needed for k3s/Flannel)
- C7 streaming: `Exec`/`Attach` streaming, CRI log format, stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)