### PR TITLE
feat(cri): CNI plugin integration for k3s pod networking

### DIFF
--- a/pelagos-cri/src/cni.rs
+++ b/pelagos-cri/src/cni.rs
@@ -13,7 +13,10 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-const CNI_CONF_DIR: &str = "/etc/cni/net.d";
+/// CNI config directories searched in order; first file found wins.
+/// The k3s agent path is listed first so its managed configs (Flannel, etc.)
+/// take priority over stale files that may linger in /etc/cni/net.d/.
+const CNI_CONF_DIRS: &[&str] = &["/var/lib/rancher/k3s/agent/etc/cni/net.d", "/etc/cni/net.d"];
 const CNI_BIN_DIRS: &[&str] = &[
     "/opt/cni/bin",
     "/var/lib/rancher/k3s/data/current/bin",
@@ -39,21 +42,30 @@ struct Conf {
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
-/// Returns the path to the first CNI config file found in `/etc/cni/net.d/`,
-/// sorted lexicographically.  Returns `None` if the directory is absent or empty.
+/// Returns the first CNI config file found by searching `CNI_CONF_DIRS` in order.
+/// Within each directory files are sorted lexicographically; the first entry wins.
+/// Returns `None` if no config is found in any directory.
 pub fn find_cni_conf() -> Option<PathBuf> {
-    let mut entries: Vec<_> = std::fs::read_dir(CNI_CONF_DIR)
-        .ok()?
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            matches!(
-                e.path().extension().and_then(|x| x.to_str()),
-                Some("conf") | Some("conflist")
-            )
-        })
-        .collect();
-    entries.sort_by_key(|e| e.file_name());
-    entries.into_iter().next().map(|e| e.path())
+    for dir in CNI_CONF_DIRS {
+        let Ok(rd) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        let mut entries: Vec<_> = rd
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                matches!(
+                    e.path().extension().and_then(|x| x.to_str()),
+                    Some("conf") | Some("conflist")
+                )
+            })
+            .collect();
+        if entries.is_empty() {
+            continue;
+        }
+        entries.sort_by_key(|e| e.file_name());
+        return entries.into_iter().next().map(|e| e.path());
+    }
+    None
 }
 
 /// Create a named network namespace via `ip netns add`.

--- a/pelagos-cri/src/cni.rs
+++ b/pelagos-cri/src/cni.rs
@@ -1,0 +1,262 @@
+//! CNI plugin invocation for pod sandbox networking.
+//!
+//! Implements the standard CNI calling convention for both `.conf` and
+//! `.conflist` files.  For `.conflist`, plugins are called in order (ADD)
+//! or reverse order (DEL) with each plugin's result forwarded as `prevResult`
+//! to the next.
+//!
+//! When no CNI config is present (e.g. crictl standalone testing), callers
+//! should fall back to pelagos native bridge networking.
+
+use serde::Deserialize;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+const CNI_CONF_DIR: &str = "/etc/cni/net.d";
+const CNI_BIN_DIRS: &[&str] = &[
+    "/opt/cni/bin",
+    "/var/lib/rancher/k3s/data/current/bin",
+    "/usr/lib/cni",
+    "/usr/libexec/cni",
+];
+
+// ── Config file types ─────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct ConfList {
+    name: String,
+    #[serde(rename = "cniVersion")]
+    cni_version: String,
+    plugins: Vec<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct Conf {
+    #[serde(rename = "type")]
+    plugin_type: String,
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Returns the path to the first CNI config file found in `/etc/cni/net.d/`,
+/// sorted lexicographically.  Returns `None` if the directory is absent or empty.
+pub fn find_cni_conf() -> Option<PathBuf> {
+    let mut entries: Vec<_> = std::fs::read_dir(CNI_CONF_DIR)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            matches!(
+                e.path().extension().and_then(|x| x.to_str()),
+                Some("conf") | Some("conflist")
+            )
+        })
+        .collect();
+    entries.sort_by_key(|e| e.file_name());
+    entries.into_iter().next().map(|e| e.path())
+}
+
+/// Create a named network namespace via `ip netns add`.
+/// Returns the netns path (`/run/netns/<name>`) on success.
+pub fn create_netns(name: &str) -> Result<String, String> {
+    let out = Command::new("ip")
+        .args(["netns", "add", name])
+        .output()
+        .map_err(|e| format!("ip netns add: {}", e))?;
+    if !out.status.success() {
+        return Err(format!(
+            "ip netns add {} failed: {}",
+            name,
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    Ok(format!("/run/netns/{}", name))
+}
+
+/// Delete a named network namespace.  Best-effort; errors are ignored.
+pub fn delete_netns(name: &str) {
+    let _ = Command::new("ip").args(["netns", "del", name]).output();
+}
+
+/// Run CNI ADD for a sandbox.
+/// Returns the assigned IPv4 address (without prefix length) on success.
+pub fn cni_add(sandbox_id: &str, netns_path: &str, conf_path: &Path) -> Result<String, String> {
+    let result = invoke_cni("ADD", sandbox_id, netns_path, conf_path)?;
+    let ip = result
+        .get("ips")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|ip| ip.get("address"))
+        .and_then(|a| a.as_str())
+        .map(|s| s.split('/').next().unwrap_or(s).to_string())
+        .unwrap_or_default();
+    Ok(ip)
+}
+
+/// Run CNI DEL for a sandbox.  Best-effort; errors are logged but not returned.
+pub fn cni_del(sandbox_id: &str, netns_path: &str, conf_path: &Path) {
+    if let Err(e) = invoke_cni("DEL", sandbox_id, netns_path, conf_path) {
+        log::warn!("CNI DEL for {}: {}", sandbox_id, e);
+    }
+}
+
+// ── Internals ─────────────────────────────────────────────────────────────────
+
+fn cni_path_env() -> String {
+    CNI_BIN_DIRS.join(":")
+}
+
+fn find_plugin_bin(plugin_type: &str) -> Result<PathBuf, String> {
+    for dir in CNI_BIN_DIRS {
+        let p = Path::new(dir).join(plugin_type);
+        if p.is_file() {
+            return Ok(p);
+        }
+    }
+    Err(format!(
+        "CNI plugin '{}' not found in CNI_BIN_DIRS",
+        plugin_type
+    ))
+}
+
+/// Run a single CNI plugin binary.  Returns the parsed JSON result, or `None`
+/// for DEL responses (which may have empty stdout).
+fn run_plugin(
+    command: &str,
+    sandbox_id: &str,
+    netns_path: &str,
+    plugin_type: &str,
+    config_json: &str,
+) -> Result<Option<serde_json::Value>, String> {
+    let bin = find_plugin_bin(plugin_type)?;
+
+    let mut child = Command::new(&bin)
+        .env("CNI_COMMAND", command)
+        .env("CNI_CONTAINERID", sandbox_id)
+        .env("CNI_NETNS", netns_path)
+        .env("CNI_IFNAME", "eth0")
+        .env("CNI_PATH", cni_path_env())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("spawn '{}': {}", plugin_type, e))?;
+
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(config_json.as_bytes())
+        .map_err(|e| format!("write stdin to '{}': {}", plugin_type, e))?;
+
+    let out = child
+        .wait_with_output()
+        .map_err(|e| format!("wait '{}': {}", plugin_type, e))?;
+
+    if !out.status.success() {
+        return Err(format!(
+            "{} '{}' failed (exit {:?}): {}",
+            command,
+            plugin_type,
+            out.status.code(),
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+
+    if out.stdout.is_empty() {
+        return Ok(None);
+    }
+
+    serde_json::from_slice(&out.stdout).map(Some).map_err(|e| {
+        format!(
+            "parse {} result from '{}': {} (raw: {})",
+            command,
+            plugin_type,
+            e,
+            String::from_utf8_lossy(&out.stdout)
+        )
+    })
+}
+
+/// Dispatch to conflist or single-conf invoker based on file extension.
+fn invoke_cni(
+    command: &str,
+    sandbox_id: &str,
+    netns_path: &str,
+    conf_path: &Path,
+) -> Result<serde_json::Value, String> {
+    let raw = std::fs::read_to_string(conf_path)
+        .map_err(|e| format!("read {}: {}", conf_path.display(), e))?;
+
+    if conf_path.extension().and_then(|x| x.to_str()) == Some("conflist") {
+        invoke_conflist(command, sandbox_id, netns_path, &raw)
+    } else {
+        invoke_conf(command, sandbox_id, netns_path, &raw)
+    }
+}
+
+fn invoke_conf(
+    command: &str,
+    sandbox_id: &str,
+    netns_path: &str,
+    raw: &str,
+) -> Result<serde_json::Value, String> {
+    let conf: Conf = serde_json::from_str(raw).map_err(|e| format!("parse .conf: {}", e))?;
+    Ok(
+        run_plugin(command, sandbox_id, netns_path, &conf.plugin_type, raw)?
+            .unwrap_or_else(|| serde_json::json!({})),
+    )
+}
+
+/// For a conflist, call each plugin in order (ADD) or reverse (DEL), forwarding
+/// the result of each plugin as `prevResult` to the next.
+fn invoke_conflist(
+    command: &str,
+    sandbox_id: &str,
+    netns_path: &str,
+    raw: &str,
+) -> Result<serde_json::Value, String> {
+    let conflist: ConfList =
+        serde_json::from_str(raw).map_err(|e| format!("parse .conflist: {}", e))?;
+
+    let plugins: Vec<serde_json::Value> = if command == "DEL" {
+        conflist.plugins.iter().rev().cloned().collect()
+    } else {
+        conflist.plugins.clone()
+    };
+
+    let mut prev_result: Option<serde_json::Value> = None;
+    let mut last_result = serde_json::json!({});
+
+    for plugin_conf in &plugins {
+        let plugin_type = plugin_conf
+            .get("type")
+            .and_then(|t| t.as_str())
+            .ok_or_else(|| "conflist plugin missing 'type' field".to_string())?;
+
+        // Build the per-plugin config: conflist header + plugin stanza + prevResult.
+        let mut config = serde_json::json!({
+            "cniVersion": conflist.cni_version,
+            "name": conflist.name,
+        });
+        if let Some(obj) = plugin_conf.as_object() {
+            for (k, v) in obj {
+                config[k] = v.clone();
+            }
+        }
+        if let Some(ref pr) = prev_result {
+            config["prevResult"] = pr.clone();
+        }
+
+        let config_str = serde_json::to_string(&config)
+            .map_err(|e| format!("serialize config for '{}': {}", plugin_type, e))?;
+
+        if let Some(result) = run_plugin(command, sandbox_id, netns_path, plugin_type, &config_str)?
+        {
+            prev_result = Some(result.clone());
+            last_result = result;
+        }
+    }
+
+    Ok(last_result)
+}

--- a/pelagos-cri/src/main.rs
+++ b/pelagos-cri/src/main.rs
@@ -5,6 +5,7 @@ pub mod cri {
     tonic::include_proto!("runtime.v1");
 }
 
+mod cni;
 mod image;
 mod invoke;
 mod runtime;

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -1,5 +1,6 @@
 //! CRI RuntimeService implementation.
 
+use crate::cni;
 use crate::cri::runtime_service_server::RuntimeService;
 use crate::cri::{
     AttachRequest, AttachResponse, CheckpointContainerRequest, CheckpointContainerResponse,
@@ -313,16 +314,76 @@ impl RuntimeService for RuntimeSvc {
         let uid = meta.uid.clone();
         let bin = self.bin().await;
 
-        let raw = run_pelagos(&bin, &["sandbox", "create", "--name", &uid])
-            .await
-            .map_err(|e| Status::internal(format!("exec error: {}", e)))?;
-        if !raw.success {
-            return Err(Status::internal(format!(
-                "sandbox create failed: {}",
-                raw.stderr
-            )));
-        }
-        let sandbox_id = raw.stdout.trim().to_string();
+        // Try CNI networking first; fall back to pelagos native if no config is present.
+        let (sandbox_id, netns, ip, cni_conf, pause_pid) = if let Some(conf_path) =
+            cni::find_cni_conf()
+        {
+            // ── CNI path ───────────────────────────────────────────────────
+            let id = uuid::Uuid::new_v4().simple().to_string()[..16].to_string();
+            let ns_name = format!("pcri-{}", &id[..12]);
+
+            let netns_path = cni::create_netns(&ns_name)
+                .map_err(|e| Status::internal(format!("create netns for CNI sandbox: {}", e)))?;
+
+            let ip = match cni::cni_add(&id, &netns_path, &conf_path) {
+                Ok(ip) => ip,
+                Err(e) => {
+                    cni::delete_netns(&ns_name);
+                    return Err(Status::internal(format!("CNI ADD: {}", e)));
+                }
+            };
+
+            // Spawn pause process: joins the CNI-configured netns, unshares IPC+UTS.
+            // We re-use pelagos's own `sandbox __pause__ <ns_name>` subcommand.
+            let pause = std::process::Command::new(&bin)
+                .args(["sandbox", "__pause__", &ns_name])
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .map_err(|e| Status::internal(format!("spawn pause process: {}", e)))?;
+            let pause_pid = pause.id() as i32;
+            // Intentionally leaked — killed explicitly on StopPodSandbox.
+            std::mem::forget(pause);
+
+            // Brief pause for the process to enter namespaces before containers join.
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+            // Write pelagos-format sandbox state so `pelagos run --sandbox` works.
+            state::write_pelagos_sandbox_state(&id, Some(&meta.name), pause_pid, &ns_name, &ip)
+                .map_err(|e| Status::internal(format!("write sandbox state: {}", e)))?;
+
+            log::info!(
+                "CNI sandbox {} created: netns={} ip={} conf={}",
+                id,
+                ns_name,
+                ip,
+                conf_path.display()
+            );
+
+            (
+                id,
+                ns_name,
+                ip,
+                conf_path.to_string_lossy().to_string(),
+                pause_pid,
+            )
+        } else {
+            // ── Pelagos native path ────────────────────────────────────────
+            log::info!("no CNI config found — using pelagos native bridge networking");
+            let raw = run_pelagos(&bin, &["sandbox", "create", "--name", &uid])
+                .await
+                .map_err(|e| Status::internal(format!("exec error: {}", e)))?;
+            if !raw.success {
+                return Err(Status::internal(format!(
+                    "sandbox create failed: {}",
+                    raw.stderr
+                )));
+            }
+            let sandbox_id = raw.stdout.trim().to_string();
+            let ip = read_pelagos_sandbox_ip(&sandbox_id).unwrap_or_default();
+            (sandbox_id, String::new(), ip, String::new(), 0)
+        };
 
         let sandbox = CriSandbox {
             id: sandbox_id.clone(),
@@ -334,6 +395,10 @@ impl RuntimeService for RuntimeSvc {
             annotations: config.annotations.clone(),
             created_at_ns: now_ns(),
             state: SandboxState::Running,
+            netns,
+            ip,
+            cni_conf,
+            pause_pid,
         };
 
         {
@@ -370,7 +435,30 @@ impl RuntimeService for RuntimeSvc {
             }
         }
 
-        let _ = run_pelagos(&bin, &["sandbox", "rm", &sandbox_id]).await;
+        let sandbox = {
+            let st = self.state.inner.lock().await;
+            st.sandboxes.get(&sandbox_id).cloned()
+        };
+
+        if let Some(ref sb) = sandbox {
+            if !sb.netns.is_empty() {
+                // ── CNI teardown ───────────────────────────────────────────────
+                let netns_path = format!("/run/netns/{}", sb.netns);
+                if !sb.cni_conf.is_empty() {
+                    cni::cni_del(&sandbox_id, &netns_path, std::path::Path::new(&sb.cni_conf));
+                }
+                if sb.pause_pid > 0 {
+                    let _ = std::process::Command::new("kill")
+                        .args(["-TERM", &sb.pause_pid.to_string()])
+                        .output();
+                }
+                cni::delete_netns(&sb.netns);
+                state::remove_pelagos_sandbox_state(&sandbox_id);
+            } else {
+                // ── Pelagos native teardown ────────────────────────────────────
+                let _ = run_pelagos(&bin, &["sandbox", "rm", &sandbox_id]).await;
+            }
+        }
 
         let mut st = self.state.inner.lock().await;
         if let Some(s) = st.sandboxes.get_mut(&sandbox_id) {
@@ -420,7 +508,13 @@ impl RuntimeService for RuntimeSvc {
             .clone();
         drop(st);
 
-        let ip = read_pelagos_sandbox_ip(&sandbox_id).unwrap_or_default();
+        // For CNI sandboxes, ip is stored directly in CriSandbox.
+        // For native sandboxes, fall back to reading the pelagos state file.
+        let ip = if sandbox.ip.is_empty() {
+            read_pelagos_sandbox_ip(&sandbox_id).unwrap_or_default()
+        } else {
+            sandbox.ip.clone()
+        };
 
         let status = CriPodSandboxStatus {
             id: sandbox.id.clone(),

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -21,6 +21,19 @@ pub struct CriSandbox {
     pub annotations: HashMap<String, String>,
     pub created_at_ns: i64,
     pub state: SandboxState,
+    /// Named netns for CNI sandboxes (e.g. "pcri-a1b2c3d4").
+    /// Empty string means pelagos native networking was used.
+    #[serde(default)]
+    pub netns: String,
+    /// IP assigned to this sandbox (by CNI or pelagos native IPAM).
+    #[serde(default)]
+    pub ip: String,
+    /// Path to the CNI config file used for ADD; needed for DEL on teardown.
+    #[serde(default)]
+    pub cni_conf: String,
+    /// PID of the pause process holding IPC/UTS namespaces open (CNI path only).
+    #[serde(default)]
+    pub pause_pid: i32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -128,6 +141,48 @@ pub fn save_container(c: &CriContainer) -> std::io::Result<()> {
 
 pub fn remove_sandbox_file(id: &str) {
     let _ = std::fs::remove_file(format!("{}/{}.json", SANDBOXES_DIR, id));
+}
+
+// ── Pelagos runtime sandbox state (for `pelagos run --sandbox`) ──────────────
+
+const PELAGOS_SANDBOXES_DIR: &str = "/run/pelagos/sandboxes";
+
+/// Write the pelagos-format sandbox state so that `pelagos run --sandbox <id>`
+/// can join the CNI-configured network namespace.
+///
+/// The JSON schema mirrors `pelagos::sandbox::SandboxState`.
+pub fn write_pelagos_sandbox_state(
+    id: &str,
+    name: Option<&str>,
+    pause_pid: i32,
+    ns_name: &str,
+    container_ip: &str,
+) -> std::io::Result<()> {
+    let dir = format!("{}/{}", PELAGOS_SANDBOXES_DIR, id);
+    std::fs::create_dir_all(&dir)?;
+
+    let json = serde_json::json!({
+        "id": id,
+        "name": name,
+        "pause_pid": pause_pid,
+        "ns_name": ns_name,
+        "veth_host": "",        // CNI owns its own veth — pelagos must not delete it
+        "container_ip": container_ip,
+    });
+    std::fs::write(
+        format!("{}/state.json", dir),
+        serde_json::to_string(&json).unwrap(),
+    )?;
+    // pause.pid and ns_name files are read by some pelagos internals.
+    std::fs::write(format!("{}/pause.pid", dir), format!("{}", pause_pid))?;
+    std::fs::write(format!("{}/ns_name", dir), ns_name)?;
+    Ok(())
+}
+
+/// Remove the pelagos-format sandbox state directory.
+pub fn remove_pelagos_sandbox_state(id: &str) {
+    let dir = format!("{}/{}", PELAGOS_SANDBOXES_DIR, id);
+    let _ = std::fs::remove_dir_all(dir);
 }
 
 pub fn remove_container_file(id: &str) {

--- a/scripts/test-cri.sh
+++ b/scripts/test-cri.sh
@@ -11,11 +11,12 @@
 #
 # Usage:
 #   sudo -E env "PATH=$PATH" bash scripts/test-cri.sh
+#   BINARY=/usr/local/bin/pelagos CRI_BINARY=/usr/local/bin/pelagos-cri sudo bash scripts/test-cri.sh
 
 set -uo pipefail
 
-BINARY="./target/debug/pelagos"
-CRI_BINARY="./target/debug/pelagos-cri"
+BINARY="${BINARY:-./target/debug/pelagos}"
+CRI_BINARY="${CRI_BINARY:-./target/debug/pelagos-cri}"
 CRI_SOCK="/run/pelagos/cri.sock"
 CRICTL="crictl --runtime-endpoint unix://${CRI_SOCK}"
 CRI_PID_FILE="/tmp/pelagos-cri-test.pid"


### PR DESCRIPTION
## Summary

- Invokes CNI plugins (ADD/DEL) during `RunPodSandbox` / `StopPodSandbox` when a CNI config is present
- Supports both `.conf` (single plugin) and `.conflist` (chained plugins with `prevResult` forwarding)
- Spawns `pelagos sandbox __pause__` to hold the sandbox netns/IPC/UTS namespaces open
- Writes synthetic pelagos sandbox state so `pelagos run --sandbox` can join the CNI-configured netns
- Falls back to pelagos native bridge networking when no CNI config is found
- Searches k3s agent CNI conf dir (`/var/lib/rancher/k3s/agent/etc/cni/net.d`) before `/etc/cni/net.d` to avoid stale configs from previous CNI installations winning over the active one
- `test-cri.sh` accepts `BINARY`/`CRI_BINARY` env overrides for remote testing

## Validation

All 22/22 crictl tests pass on **ipc1** (Ubuntu 24.04, k3s v1.32.13+k3s1, Flannel CNI):
- `RunPodSandbox` via Flannel CNI → sandbox IP `10.42.0.x` in pod CIDR
- Container create/start/exec/stop/remove lifecycle
- `ListContainerStats` / `ContainerStats`
- `StopPodSandbox` + `RemovePodSandbox` with CNI DEL and netns cleanup

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --lib` passes  
- [x] Full crictl end-to-end on ipc1 with real Flannel CNI: 22/22 pass
- [x] `BINARY=/usr/local/bin/pelagos CRI_BINARY=/usr/local/bin/pelagos-cri sudo bash scripts/test-cri.sh` on ipc1

🤖 Generated with [Claude Code](https://claude.com/claude-code)