### PR TITLE
cri: verify and test ExecSync (#244)

### DIFF
--- a/scripts/test-cri.sh
+++ b/scripts/test-cri.sh
@@ -257,6 +257,20 @@ check_contains "crictl exec --sync echo" "$OUT" "hello-exec"
 OUT=$($CRICTL exec --sync "$CONTAINER_ID" /bin/sh -c 'echo $TEST_VAR' 2>&1)
 check_contains "crictl exec: env var TEST_VAR is set" "$OUT" "hello"
 
+# crictl itself exits 1 for any non-zero container exit; the actual exit code
+# appears in its stderr as "exited with N". Verify 42 is propagated correctly.
+OUT=$($CRICTL exec --sync "$CONTAINER_ID" /bin/sh -c 'exit 42' 2>&1 || true)
+check_contains "crictl exec --sync: non-zero exit code propagated" "$OUT" "exited with 42"
+
+START=$(date +%s)
+$CRICTL exec --sync --timeout 2 "$CONTAINER_ID" /bin/sh -c 'sleep 30' 2>&1 || true
+ELAPSED=$(( $(date +%s) - START ))
+if [ "$ELAPSED" -le 5 ]; then
+    pass "crictl exec --sync: timeout kills long-running command (${ELAPSED}s)"
+else
+    fail "crictl exec --sync: timeout did not fire (${ELAPSED}s elapsed)"
+fi
+
 # ── Container status ──────────────────────────────────────────────────────────
 
 step "C6: Container status"


### PR DESCRIPTION
## Summary

ExecSync (`RuntimeService.ExecSync`) was already implemented in commit 184f39b alongside the other multi-node CRI fixes, but had no dedicated test coverage.

This PR adds test coverage and live validation:

- **Exit code propagation**: verifies non-zero exit codes are returned correctly in `ExecSyncResponse`
- **Timeout enforcement**: verifies long-running commands are killed within the deadline (`DeadlineExceeded` returned to kubelet)
- **Live k3s validation**: deployed a pod with both `livenessProbe.exec` and `readinessProbe.exec` to ipc2 (k3s agent node); pod reached `1/1 Running` and held for 91s with 0 restarts across ~18 probe cycles

Closes #244.

## Test plan

- [x] `sudo -E env "PATH=$PATH" bash scripts/test-cri.sh` — 29/30 pass (1 fail = Docker Hub rate limit, pre-existing)
- [x] Live exec probe test on ipc2 k3s agent node — 0 restarts, probes continuously passing