### PR TITLE
fix(ci): check out spdystream-rs alongside pelagos so path dep resolves in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: pelagos-containers/spdystream-rs
+          path: ../spdystream-rs
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.94.0"
@@ -21,6 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: pelagos-containers/spdystream-rs
+          path: ../spdystream-rs
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.94.0"
@@ -32,6 +40,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: pelagos-containers/spdystream-rs
+          path: ../spdystream-rs
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.94.0"
@@ -53,6 +65,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: pelagos-containers/spdystream-rs
+          path: ../spdystream-rs
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.94.0"
@@ -72,6 +88,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: pelagos-containers/spdystream-rs
+          path: ../spdystream-rs
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.94.0"
@@ -90,6 +110,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: pelagos-containers/spdystream-rs
+          path: ../spdystream-rs
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.94.0"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: pelagos-containers/spdystream-rs
+          path: ../spdystream-rs
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -21,6 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: pelagos-containers/spdystream-rs
+          path: ../spdystream-rs
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --lib
@@ -29,6 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: pelagos-containers/spdystream-rs
+          path: ../spdystream-rs
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install system dependencies
@@ -60,6 +72,10 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: pelagos-containers/spdystream-rs
+          path: ../spdystream-rs
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -219,6 +235,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: pelagos-containers/spdystream-rs
+          path: ../spdystream-rs
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Publish to crates.io

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3594,7 +3594,6 @@ dependencies = [
 [[package]]
 name = "spdystream-rs"
 version = "0.1.0"
-source = "git+https://github.com/pelagos-containers/spdystream-rs.git?rev=68c020d#68c020d50fcb5f1b6a406048b0dff3525eac09d2"
 dependencies = [
  "bytes",
  "flate2",

--- a/pelagos-cri/Cargo.toml
+++ b/pelagos-cri/Cargo.toml
@@ -22,7 +22,7 @@ tonic = { version = "0.12", features = ["transport"] }
 prost = "0.13"
 uuid = { version = "1", features = ["v4"] }
 futures-core = "0.3"
-spdystream-rs = { git = "https://github.com/pelagos-containers/spdystream-rs.git", rev = "68c020d" }
+spdystream-rs = { path = "../../spdystream-rs" }
 bytes = "1"
 http = "1"
 


### PR DESCRIPTION
## Summary

- Reverts the brittle `rev = "68c020d"` git dep back to `path = "../../spdystream-rs"`
- Adds a `actions/checkout` step for `pelagos-containers/spdystream-rs` at `../spdystream-rs` to every Rust-building job in both `ci.yml` and `release.yml`
- This matches the local directory layout, so the path dep resolves identically in CI and locally

The previous approach (pinning to a commit SHA) would silently test against a stale version of spdystream-rs whenever fixes were pushed there.

## Test plan
- [ ] CI passes on this PR (all 6 jobs resolve spdystream-rs correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)