### PR TITLE
fix: fail-fast with clear error when host port is already in use (#253)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -1936,6 +1936,27 @@ Failure indicates the tokio accept loop exits prematurely after the first relay
 task completes, or that `copy_bidirectional` does not propagate server-side EOF
 cleanly (causing subsequent connections to hang or return empty data).
 
+### `test_bridge_duplicate_host_port_rejected`
+**Requires:** root, alpine-rootfs
+
+Starts a bridge-networked container with host port 19876 forwarded to container port 80.
+While that container is running, attempts to start a second container with the same host
+port. Asserts the second spawn returns an error whose message names the conflicting port.
+
+Failure indicates `enable_port_forwards` is not checking the existing port-forward registry
+for live conflicts, allowing two containers to race for the same nftables DNAT rule and TCP
+proxy binding (silent misbehaviour: only the first or last container gets traffic).
+
+### `test_pasta_duplicate_host_port_rejected`
+**Requires:** root, alpine-rootfs, pasta installed
+
+Pre-binds host port 19877 with a `TcpListener`, then attempts to spawn a pasta-networked
+container forwarding that port. Asserts spawn returns an error.
+
+Failure indicates `setup_pasta_network` is not checking port availability before spawning
+pasta, meaning pasta's port-bind failure ("Couldn't listen on requested ports", exit 1) is
+silently swallowed and the container starts with no working port forwarding.
+
 ---
 
 ## Multi-Network Tests

--- a/src/network.rs
+++ b/src/network.rs
@@ -1752,11 +1752,22 @@ fn enable_port_forwards(
 
     // Load existing entries and evict stale ones (crashed containers).
     let existing = read_port_forwards_locked(&mut file)?;
-    let mut live: Vec<PortForwardEntry> = existing
+    let live: Vec<PortForwardEntry> = existing
         .into_iter()
         .filter(|(n, _, _, _, _, _)| !n.is_empty() && netns_exists(n))
         .collect();
 
+    // Fail fast if any requested host port is already held by a live container.
+    for &(host_port, _, _) in forwards {
+        if live.iter().any(|(_, _, hp, _, _, _)| *hp == host_port) {
+            return Err(io::Error::other(format!(
+                "host port {} is already forwarded by another container",
+                host_port
+            )));
+        }
+    }
+
+    let mut live = live;
     for &(host_port, container_port, proto) in forwards {
         live.push((
             ns_name.to_string(),
@@ -2046,18 +2057,20 @@ fn start_tcp_proxies_async(
 /// Binds a `TcpListener` on `0.0.0.0:{host_port}` and spawns a `tcp_relay`
 /// task for each accepted connection.  Runs until the runtime is dropped.
 async fn tcp_accept_loop(host_port: u16, target: SocketAddr) {
-    let listener =
-        match tokio::net::TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], host_port))).await {
-            Ok(l) => l,
-            Err(e) => {
-                log::warn!(
-                    "tcp proxy: cannot bind 0.0.0.0:{}: {} (nftables DNAT still active)",
+    let listener = match tokio::net::TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], host_port)))
+        .await
+    {
+        Ok(l) => l,
+        Err(e) => {
+            log::error!(
+                    "tcp proxy: cannot bind 0.0.0.0:{}: {} \
+                     (localhost port forwarding broken; nftables DNAT still active for external traffic)",
                     host_port,
                     e
                 );
-                return;
-            }
-        };
+            return;
+        }
+    };
 
     log::debug!("tcp proxy: 0.0.0.0:{} -> {}", host_port, target);
 
@@ -2409,6 +2422,29 @@ pub fn setup_pasta_network(
     // SAFETY: geteuid() is always safe to call.
     let running_as_root = unsafe { libc::geteuid() } == 0;
 
+    // Fail fast if any requested host port is already bound.  pasta would start,
+    // create the TAP (so wait_for_pasta_network returns OK), and only then fail to
+    // bind the host relay socket — leaving an orphaned container process.  Checking
+    // here lets us return an error before the child is ever forked.
+    for &(host_port, _, proto) in port_forwards {
+        if matches!(proto, PortProto::Tcp | PortProto::Both)
+            && std::net::TcpListener::bind(("0.0.0.0", host_port)).is_err()
+        {
+            return Err(io::Error::other(format!(
+                "host port {} is already in use",
+                host_port
+            )));
+        }
+        if matches!(proto, PortProto::Udp | PortProto::Both)
+            && std::net::UdpSocket::bind(("0.0.0.0", host_port)).is_err()
+        {
+            return Err(io::Error::other(format!(
+                "host port {} (UDP) is already in use",
+                host_port
+            )));
+        }
+    }
+
     for &(host, container, proto) in port_forwards {
         if matches!(proto, PortProto::Tcp | PortProto::Both) {
             args.push("-t".to_string());
@@ -2605,7 +2641,30 @@ pub fn setup_pasta_network(
     //
     // We poll /proc/{pid}/net/dev until a non-loopback interface appears (success),
     // pasta exits before that happens (failure), or a 5-second timeout fires.
-    wait_for_pasta_network(child_pid, &mut process);
+    if let Err(e) = wait_for_pasta_network(child_pid, &mut process) {
+        // pasta failed (e.g. host port conflict).  Collect its output for a
+        // diagnostic message, then clean up before returning the error.
+        let _ = process.kill();
+        let _ = process.wait();
+        let pasta_output = output_thread
+            .and_then(|t| t.join().ok())
+            .unwrap_or_default();
+        if let Some(ref p) = ns_bind_mount {
+            unsafe {
+                libc::umount2(
+                    p.as_os_str().as_encoded_bytes().as_ptr() as *const libc::c_char,
+                    libc::MNT_DETACH,
+                )
+            };
+            let _ = std::fs::remove_file(p);
+        }
+        let detail = pasta_output.trim().lines().last().unwrap_or("").to_string();
+        return Err(io::Error::other(if detail.is_empty() {
+            e.to_string()
+        } else {
+            format!("{} (pasta: {})", e, detail)
+        }));
+    }
 
     Ok(PastaSetup {
         process,
@@ -2639,7 +2698,7 @@ fn host_has_ipv6() -> bool {
         .unwrap_or(false)
 }
 
-fn wait_for_pasta_network(child_pid: u32, process: &mut std::process::Child) {
+fn wait_for_pasta_network(child_pid: u32, process: &mut std::process::Child) -> io::Result<()> {
     let net_dev = format!("/proc/{}/net/dev", child_pid);
     let if_inet6 = format!("/proc/{}/net/if_inet6", child_pid);
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
@@ -2648,17 +2707,18 @@ fn wait_for_pasta_network(child_pid: u32, process: &mut std::process::Child) {
     loop {
         // Detect pasta exiting before the TAP interface appears — almost always
         // means pasta encountered an error (permission denied, missing /dev/net/tun,
-        // bad PID, etc.).  The exit status is the only clue available here; stderr
-        // output is collected by the reader thread and logged in teardown.
+        // bad PID, host port conflict, etc.).
         if let Ok(Some(status)) = process.try_wait() {
-            log::warn!(
-                "pasta exited (status: {}) before network setup completed in \
-                 /proc/{}/net/dev — network setup failed; stdout/stderr output \
-                 will be logged at teardown",
-                status,
-                child_pid
-            );
-            return;
+            if status.success() {
+                // pasta exited cleanly (unusual, but not fatal — continue).
+                return Ok(());
+            }
+            return Err(io::Error::other(format!(
+                "pasta exited with {} before network setup completed — \
+                 host port already in use or missing /dev/net/tun? \
+                 Run with RUST_LOG=warn to see pasta output.",
+                status
+            )));
         }
 
         if !tap_seen {
@@ -2705,7 +2765,7 @@ fn wait_for_pasta_network(child_pid: u32, process: &mut std::process::Child) {
                     "pasta: global IPv6 address configured in /proc/{}/net/if_inet6",
                     child_pid
                 );
-                return;
+                return Ok(());
             }
         }
 
@@ -2723,7 +2783,7 @@ fn wait_for_pasta_network(child_pid: u32, process: &mut std::process::Child) {
                     child_pid
                 );
             }
-            return;
+            return Ok(());
         }
         std::thread::sleep(std::time::Duration::from_millis(5));
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -9928,6 +9928,132 @@ mod port_proxy {
             failures.join("\n")
         );
     }
+
+    /// test_bridge_duplicate_host_port_rejected
+    ///
+    /// Requires: root, alpine-rootfs.
+    ///
+    /// Starts a bridge-networked container with host port 19876 forwarded to
+    /// container port 80.  While the first container is running, attempts to
+    /// start a second container with the same host port.  Asserts that the
+    /// second spawn returns an error mentioning the port, and that the first
+    /// container is unaffected.
+    ///
+    /// Failure indicates the fail-fast conflict check in `enable_port_forwards`
+    /// is missing or not working, meaning two containers would silently share a
+    /// host port with undefined nftables DNAT behaviour and a broken TCP proxy.
+    #[test]
+    #[serial(nat)]
+    fn test_bridge_duplicate_host_port_rejected() {
+        if !is_root() {
+            eprintln!("Skipping test_bridge_duplicate_host_port_rejected: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping test_bridge_duplicate_host_port_rejected: alpine-rootfs not found");
+            return;
+        };
+
+        let mut c1 = Command::new("/bin/sleep")
+            .args(["60"])
+            .with_chroot(&rootfs)
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS)
+            .with_network(NetworkMode::Bridge)
+            .with_nat()
+            .with_port_forward(19876, 80)
+            .env("PATH", ALPINE_PATH)
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Null)
+            .stderr(Stdio::Null)
+            .spawn()
+            .expect("first container should start");
+
+        let result = Command::new("/bin/sleep")
+            .args(["60"])
+            .with_chroot(&rootfs)
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS)
+            .with_network(NetworkMode::Bridge)
+            .with_nat()
+            .with_port_forward(19876, 80)
+            .env("PATH", ALPINE_PATH)
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Null)
+            .stderr(Stdio::Null)
+            .spawn();
+
+        unsafe { libc::kill(c1.pid(), libc::SIGKILL) };
+        let _ = c1.wait();
+
+        assert!(
+            result.is_err(),
+            "second container with duplicate host port 19876 should be rejected"
+        );
+        let err_msg = result.err().expect("expected Err").to_string();
+        assert!(
+            err_msg.contains("19876") || err_msg.contains("host port"),
+            "error should name the conflicting port; got: {}",
+            err_msg
+        );
+    }
+
+    /// test_pasta_duplicate_host_port_rejected
+    ///
+    /// Requires: root, alpine-rootfs, pasta installed.
+    ///
+    /// Pre-binds host port 19877 with a TCP listener, then attempts to start a
+    /// pasta-networked container forwarding that port.  Asserts that spawn
+    /// returns an error — pasta exits with code 1, `wait_for_pasta_network`
+    /// propagates that as `Err`, and the container is never fully started.
+    ///
+    /// Failure indicates `wait_for_pasta_network` is not propagating the pasta
+    /// exit status, meaning port-conflict errors from pasta are silently swallowed
+    /// and the container starts with no working port forwarding.
+    #[test]
+    #[serial(nat)]
+    fn test_pasta_duplicate_host_port_rejected() {
+        if !is_root() {
+            eprintln!("Skipping test_pasta_duplicate_host_port_rejected: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping test_pasta_duplicate_host_port_rejected: alpine-rootfs not found");
+            return;
+        };
+        if !pelagos::network::is_pasta_available() {
+            eprintln!("Skipping test_pasta_duplicate_host_port_rejected: pasta not installed");
+            return;
+        }
+
+        // Pre-bind the port so pasta cannot claim it.
+        let _listener = std::net::TcpListener::bind("0.0.0.0:19877")
+            .expect("pre-bind port 19877 for conflict test");
+
+        let result = Command::new("/bin/sleep")
+            .args(["1"])
+            .with_chroot(&rootfs)
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS)
+            .with_network(NetworkMode::Pasta)
+            .with_port_forward(19877, 80)
+            .env("PATH", ALPINE_PATH)
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Null)
+            .stderr(Stdio::Null)
+            .spawn();
+
+        // _listener is dropped here, releasing port 19877.
+        drop(_listener);
+
+        assert!(
+            result.is_err(),
+            "container with pasta port forward on pre-bound host port 19877 should be rejected"
+        );
+        let err_msg = result.err().expect("expected Err").to_string();
+        assert!(
+            err_msg.contains("pasta") || err_msg.contains("port") || err_msg.contains("19877"),
+            "error should indicate pasta/port failure; got: {}",
+            err_msg
+        );
+    }
 }
 
 // ==========================================================================


### PR DESCRIPTION
## Summary

- **Bridge mode**: `enable_port_forwards` now checks the live port-forward registry for conflicts before writing nftables rules — second container requesting the same host port gets an immediate `Err` naming the port, before any child is forked
- **Pasta mode**: `setup_pasta_network` proactively checks TCP/UDP port availability via `TcpListener::bind` / `UdpSocket::bind` before spawning pasta — avoids the race where pasta creates the TAP first (making `wait_for_pasta_network` return OK) and only then fails to bind the host relay port, which was previously swallowed silently
- `wait_for_pasta_network` now returns `io::Result<()>` and propagates non-zero pasta exit status as `Err` (covers other pasta failure modes: missing `/dev/net/tun`, permission errors, etc.)
- `tcp_accept_loop` bind failure promoted from `warn!` to `error!`

Closes #253. Child of #141.

## Known gap (not fixed here)

Cross-mode pasta→bridge conflict (pasta container holds a port, then a bridge container requests the same port) is not caught by the registry check — only the TCP proxy bind failure surfaces it, now as `error!` rather than `warn!`. Fixing this requires pasta containers to write into the port-forward registry, tracked separately.

## Test plan

- [x] `cargo fmt && cargo clippy -- -D warnings` — clean
- [x] `cargo test --lib` — 349/349 pass
- [x] `sudo -E cargo test --test integration_tests duplicate_host_port` — both new tests pass
  - `test_bridge_duplicate_host_port_rejected`
  - `test_pasta_duplicate_host_port_rejected`

🤖 Generated with [Claude Code](https://claude.com/claude-code)