### PR TITLE
fix: propagate spawn errors from watcher to CLI parent via sync pipe (#253)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -1957,6 +1957,17 @@ Failure indicates `setup_pasta_network` is not checking port availability before
 pasta, meaning pasta's port-bind failure ("Couldn't listen on requested ports", exit 1) is
 silently swallowed and the container starts with no working port forwarding.
 
+### `test_bridge_duplicate_host_port_rejected_cli`
+**Requires:** root, alpine-rootfs
+
+Same conflict scenario as `test_bridge_duplicate_host_port_rejected` but exercises the
+`pelagos run -d` CLI path (watcher process) rather than the library API. Verifies that the
+spawn error is propagated from the watcher back to the CLI parent via the sync pipe and
+appears in stderr — not the generic "watcher exited before writing state" message.
+
+Failure indicates the watcher exits silently on spawn failure without writing the error to
+the sync pipe, so the parent cannot surface the actual cause.
+
 ---
 
 ## Multi-Network Tests

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1392,8 +1392,20 @@ fn run_detached(a: DetachedArgs) -> Result<(), Box<dyn std::error::Error>> {
             let mut child = match cmd.spawn() {
                 Ok(c) => c,
                 Err(e) => {
-                    eprintln!("pelagos watcher: spawn failed: {}", e);
-                    unsafe { libc::_exit(1) };
+                    // Write the error message to the sync pipe so the parent can surface it,
+                    // then close the pipe and exit.  The parent distinguishes success (\x00)
+                    // from error (any other bytes) by reading more than 1 byte.
+                    let msg = e.to_string();
+                    let bytes = msg.as_bytes();
+                    unsafe {
+                        libc::write(
+                            sync_pipe[1],
+                            bytes.as_ptr() as *const libc::c_void,
+                            bytes.len(),
+                        );
+                        libc::close(sync_pipe[1]);
+                        libc::_exit(1);
+                    }
                 }
             };
             let pid = child.pid();
@@ -1516,13 +1528,20 @@ fn run_detached(a: DetachedArgs) -> Result<(), Box<dyn std::error::Error>> {
             // we also wait here to make the guarantee explicit and to avoid SIGPIPE
             // on the watcher's write end.
             unsafe { libc::close(sync_pipe[1]) };
-            let mut one = [0u8; 1];
-            let n = unsafe { libc::read(sync_pipe[0], one.as_mut_ptr() as *mut libc::c_void, 1) };
+            // Protocol: watcher writes \x00 (1 byte) on success, or an error string on
+            // failure.  Read up to 4096 bytes; n<=0 means unexpected watcher death.
+            let mut buf = [0u8; 4096];
+            let n =
+                unsafe { libc::read(sync_pipe[0], buf.as_mut_ptr() as *mut libc::c_void, 4096) };
             unsafe { libc::close(sync_pipe[0]) };
             if n <= 0 {
                 return Err(
                     "container failed to start (watcher exited before writing state)".into(),
                 );
+            }
+            if buf[0] != 0 {
+                let msg = String::from_utf8_lossy(&buf[..n as usize]).into_owned();
+                return Err(msg.into());
             }
 
             if attach_stdout || attach_stderr {

--- a/src/container.rs
+++ b/src/container.rs
@@ -7887,7 +7887,7 @@ pub enum Error {
     Seccomp(#[source] io::Error),
 
     /// Generic I/O error
-    #[error("I/O error: {0}")]
+    #[error("{0}")]
     Io(#[from] io::Error),
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -9996,6 +9996,103 @@ mod port_proxy {
         );
     }
 
+    /// test_bridge_duplicate_host_port_rejected_cli
+    ///
+    /// Requires: root, alpine-rootfs.
+    ///
+    /// Same scenario as `test_bridge_duplicate_host_port_rejected` but exercises
+    /// the `pelagos run -d` CLI path (watcher process) rather than the library
+    /// API directly.  Verifies that the spawn error is propagated from the watcher
+    /// back to the CLI parent via the sync pipe and printed to stderr.
+    ///
+    /// Failure indicates the watcher exits silently on spawn failure, causing the
+    /// CLI to emit the generic "watcher exited before writing state" message
+    /// instead of the actual port-conflict error.
+    #[test]
+    #[serial(nat)]
+    fn test_bridge_duplicate_host_port_rejected_cli() {
+        if !is_root() {
+            eprintln!("Skipping test_bridge_duplicate_host_port_rejected_cli: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!(
+                "Skipping test_bridge_duplicate_host_port_rejected_cli: alpine-rootfs not found"
+            );
+            return;
+        };
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+        let name1 = "pf-cli-conflict-c1";
+        let name2 = "pf-cli-conflict-c2";
+
+        // Ensure clean state.
+        let _ = std::process::Command::new(bin)
+            .args(["rm", "-f", name1])
+            .output();
+        let _ = std::process::Command::new(bin)
+            .args(["rm", "-f", name2])
+            .output();
+
+        // Start container 1 — should succeed.
+        let out1 = std::process::Command::new(bin)
+            .args([
+                "run",
+                "-d",
+                "--network",
+                "bridge",
+                "-p",
+                "19878:80",
+                "--name",
+                name1,
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "/bin/sleep",
+                "60",
+            ])
+            .output()
+            .expect("pelagos run c1");
+        assert!(out1.status.success(), "c1 failed: {:?}", out1);
+
+        // Start container 2 with same host port — should fail with a clear error.
+        let out2 = std::process::Command::new(bin)
+            .args([
+                "run",
+                "-d",
+                "--network",
+                "bridge",
+                "-p",
+                "19878:80",
+                "--name",
+                name2,
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "/bin/sleep",
+                "60",
+            ])
+            .output()
+            .expect("pelagos run c2");
+
+        let _ = std::process::Command::new(bin)
+            .args(["rm", "-f", name1])
+            .output();
+        let _ = std::process::Command::new(bin)
+            .args(["rm", "-f", name2])
+            .output();
+
+        assert!(!out2.status.success(), "c2 should have been rejected");
+        let stderr = String::from_utf8_lossy(&out2.stderr);
+        assert!(
+            stderr.contains("19878") || stderr.contains("host port"),
+            "stderr should name the conflicting port; got: {}",
+            stderr
+        );
+        assert!(
+            !stderr.contains("watcher exited before writing state"),
+            "generic watcher error should not appear; got: {}",
+            stderr
+        );
+    }
+
     /// test_pasta_duplicate_host_port_rejected
     ///
     /// Requires: root, alpine-rootfs, pasta installed.


### PR DESCRIPTION
## Summary

Follow-up to #254. The error detection worked at the library level but was invisible through the CLI because the watcher process silently died.

- Watcher now writes the error string to the sync pipe before exiting, instead of calling `_exit(1)` with no output
- Parent reads up to 4096 bytes from sync pipe: leading `\x00` = success (existing protocol), any other bytes = error message to surface
- `Error::Io` display prefix removed (`"I/O error: {0}"` → `"{0}"`) — it was redundant noise in CLI output
- New CLI integration test `test_bridge_duplicate_host_port_rejected_cli` verifies the error reaches the user and does **not** contain the generic "watcher exited before writing state" text

## Test plan

- [x] `cargo fmt && cargo clippy -- -D warnings` — clean
- [x] `cargo test --lib` — 349/349 pass
- [x] `sudo -E cargo test --test integration_tests duplicate_host_port` — all 3 tests pass
- [x] Manual: `sudo pelagos run -d --network bridge -p 9090:80 --name c1 alpine /bin/sleep 60 && sudo pelagos run -d --network bridge -p 9090:80 --name c2 alpine /bin/sleep 60` → `pelagos: error: host port 9090 is already forwarded by another container`

🤖 Generated with [Claude Code](https://claude.com/claude-code)