### PR TITLE
fix(cri): negotiate X-Stream-Protocol-Version for port-forward and exit-code propagation (issue #263)

### DIFF
--- a/ONGOING_TASKS.md
+++ b/ONGOING_TASKS.md
@@ -1,9 +1,95 @@
 # Ongoing Tasks
 
-## Session 2026-05-29 — Issue #261 COMPLETE; v0.64.0 RELEASED
+## Session 2026-05-29 — Issue #263 CRI cleanup (in progress)
+
+Branch: `fix/cri-cleanup-263`
+
+### Root cause analysis
+
+Three CRI issues found during v0.64.0 deployment to ipc cluster:
+
+1. **Port-forward broken** (`kubectl port-forward` → "unable to negotiate protocol: client
+   supports 'portforward.k8s.io', server returned ''")
+2. **Exit code propagation for non-1 values broken** (`exit 42` propagates as exit 1)
+3. **pasta not installed on ipc2/ipc3**
+
+Issues 1 and 2 share the same root cause: `send_upgrade_response` in
+`spdystream-rs/src/server.rs` always sends a fixed 101 response without echoing
+`X-Stream-Protocol-Version` back to the client.
+
+- For **exec/attach**: kubectl sends `X-Stream-Protocol-Version: v4.channel.k8s.io` (among
+  others for negotiation); server must echo the chosen version. Without v4 being confirmed,
+  kubectl falls back to v1/v2/v3 which don't use the error stream for exit codes → exit code
+  always appears as 1 (kubectl's own generic failure code).
+- For **port-forward**: kubectl sends `X-Stream-Protocol-Version: portforward.k8s.io/v1`;
+  server must echo it; without the echo kubectl rejects the upgrade entirely.
+
+### Fix plan
+
+#### spdystream-rs/src/server.rs
+
+Change `send_upgrade_response` signature to accept an optional protocol string to
+include as `X-Stream-Protocol-Version`:
+
+```rust
+pub async fn send_upgrade_response_with_protocol<S: AsyncWrite + Unpin>(
+    stream: &mut S,
+    protocol: Option<&str>,
+) -> Result<()>
+```
+
+Keep the original `send_upgrade_response` calling the new one with `None` (backward compat
+for tests). The response with a protocol:
+
+```
+HTTP/1.1 101 Switching Protocols\r\n
+Connection: Upgrade\r\n
+Upgrade: spdy/3.1\r\n
+X-Stream-Protocol-Version: <protocol>\r\n
+\r\n
+```
+
+#### spdystream-rs/src/server.rs — parse_upgrade_request
+
+Already captures all headers in `req.headers`. No change needed; caller reads
+`X-Stream-Protocol-Version` from `req.headers`.
+
+#### pelagos-cri/src/streaming.rs — handle_connection
+
+After `parse_upgrade_request`, select the protocol to confirm:
+
+```rust
+// For exec/attach: prefer v4 > v3 > v2 > v1
+// For port-forward: use portforward.k8s.io/v1
+let protocol = select_protocol(&req, kind);
+send_upgrade_response_with_protocol(&mut tcp, protocol.as_deref()).await?;
+```
+
+Where `select_protocol` inspects the path kind and `X-Stream-Protocol-Version` header(s):
+- `exec`/`attach` path → pick highest `*.channel.k8s.io` version the client offers
+- `portforward` path → `portforward.k8s.io/v1`
+
+Note: the `accept()` function in spdystream-rs (used elsewhere) can keep using the
+no-protocol variant — it's not in the hot path for CRI.
+
+#### pasta on ipc2/ipc3
+
+Simple install: `sudo apt-get install -y passt` on both agent nodes.
+No code change.
+
+### Test plan
+
+1. `cargo test -p spdystream-rs --lib` — new unit tests for `send_upgrade_response_with_protocol`
+2. Deploy to ipc cluster: `scripts/install.sh` + `sudo systemctl restart pelagos-cri`
+3. On ipc1:
+   - `kubectl exec pod -- /bin/sh -c 'exit 42'; echo $?` → must print 42
+   - `kubectl port-forward pod/test 9090:80 &; curl localhost:9090` → must succeed
+4. `scripts/test-cri.sh` on ipc1 — all assertions pass
+
+### Session 2026-05-29 — Issue #261 COMPLETE; v0.64.0 RELEASED
 
 Issue #261 (replace all `nft` shell-outs with native NETLINK_NETFILTER client) is complete.
-PR #262 merged to main. Tag v0.64.0 pushed, release workflow in progress.
+PR #262 merged to main. Tag v0.64.0 pushed and released.
 
 ### What was done
 
@@ -17,14 +103,7 @@ PR #262 merged to main. Tag v0.64.0 pushed, release workflow in progress.
 - Improved error visibility: non-ENOENT failures from `nft_delete_ip_table` and
   `nft_remove_filter_forward_compat` now emit `log::warn`
 
-### Test baseline (main, SHA 111d766, 2026-05-29)
-
-- 360/360 unit tests pass
-- Integration tests: ~337/349 pass (11 ignored, 2 pre-existing flaky tests:
-  - `test_port_forward_independent_teardown` — race in parallel NAT cleanup, pre-dates #261
-  - `auto_pull::test_run_auto_pulls_missing_image` — docker.io rate limiting)
-
-### Release fixes (same session)
+### Release fixes
 
 - `msghdr` struct literal init fails on aarch64-musl (private `__pad1`/`__pad2` fields);
   fixed with `zeroed() + field-assign` at 4 call sites in `src/nfnetlink.rs`
@@ -32,7 +111,3 @@ PR #262 merged to main. Tag v0.64.0 pushed, release workflow in progress.
   retry with 30s/60s backoff in both ECR-based `ensure_alpine` functions
 
 Final tag: `b93d473` — release at https://github.com/pelagos-containers/pelagos/releases/tag/v0.64.0
-
-### Next steps
-
-Nothing pending. v0.64.0 released successfully.

--- a/pelagos-cri/Cargo.toml
+++ b/pelagos-cri/Cargo.toml
@@ -22,7 +22,7 @@ tonic = { version = "0.12", features = ["transport"] }
 prost = "0.13"
 uuid = { version = "1", features = ["v4"] }
 futures-core = "0.3"
-spdystream-rs = "0.1"
+spdystream-rs = "0.1.2"
 bytes = "1"
 http = "1"
 

--- a/pelagos-cri/src/streaming.rs
+++ b/pelagos-cri/src/streaming.rs
@@ -93,12 +93,52 @@ pub async fn serve(listener: TcpListener, registry: Registry, pelagos_bin: Strin
     }
 }
 
+// Select the X-Stream-Protocol-Version to echo back in the 101 response.
+// exec/attach: confirm the highest channel version the client advertises (v4 preferred).
+// portforward: always confirm portforward.k8s.io/v1.
+fn negotiate_protocol(kind: &str, headers: &http::HeaderMap) -> Option<String> {
+    const EXEC_VERSIONS: &[&str] = &[
+        "v4.channel.k8s.io",
+        "v3.channel.k8s.io",
+        "v2.channel.k8s.io",
+        "v1.channel.k8s.io",
+    ];
+    const PF_VERSION: &str = "portforward.k8s.io/v1";
+
+    match kind {
+        "exec" | "attach" => {
+            let offered: Vec<&str> = headers
+                .get_all("x-stream-protocol-version")
+                .iter()
+                .filter_map(|v| v.to_str().ok())
+                .collect();
+            for &ver in EXEC_VERSIONS {
+                if offered.contains(&ver) {
+                    return Some(ver.to_string());
+                }
+            }
+            // Client didn't advertise a known version; echo none and fall back.
+            None
+        }
+        "portforward" => {
+            // Echo back whatever the client offered — kubectl sends "portforward.k8s.io"
+            // (not "/v1"), so don't hardcode; just reflect the first offered value.
+            headers
+                .get("x-stream-protocol-version")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string())
+                .or_else(|| Some(PF_VERSION.to_string()))
+        }
+        _ => None,
+    }
+}
+
 async fn handle_connection(
     mut tcp: TcpStream,
     registry: Registry,
     pelagos_bin: String,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    use spdystream_rs::server::{parse_upgrade_request, send_upgrade_response};
+    use spdystream_rs::server::{parse_upgrade_request, send_upgrade_response_with_protocol};
 
     let req = parse_upgrade_request(&mut tcp).await?;
     log::debug!("streaming request: {} {}", req.method, req.path);
@@ -121,7 +161,13 @@ async fn handle_connection(
         }
     };
 
-    send_upgrade_response(&mut tcp).await?;
+    // Negotiate the subprotocol by echoing X-Stream-Protocol-Version back to the client.
+    // kubectl rejects the upgrade if the server doesn't confirm the version it offered.
+    // For exec/attach we confirm v4 (supports exit-code propagation via the error stream).
+    // For port-forward we confirm portforward.k8s.io/v1.
+    let protocol = negotiate_protocol(kind, &req.headers);
+    log::debug!("streaming: negotiated protocol {:?}", protocol);
+    send_upgrade_response_with_protocol(&mut tcp, protocol.as_deref()).await?;
 
     match (kind, pending) {
         ("exec" | "attach", Pending::Exec(p)) => {


### PR DESCRIPTION
## Summary

- **Exit code propagation fixed**: `kubectl exec pod -- /bin/sh -c 'exit 42'` now returns `$? = 42` instead of always returning 1
- **Port-forward fixed**: `kubectl port-forward` now successfully negotiates the subprotocol and forwards traffic
- **pasta installed** on ipc2 and ipc3 agent nodes

## Root cause

Both bugs shared the same underlying cause: the HTTP 101 Switching Protocols response was not echoing `X-Stream-Protocol-Version` back to kubectl.

**Exit codes:** kubectl sends `X-Stream-Protocol-Version` as multiple separate HTTP headers (v4.channel.k8s.io, v3, v2, v1). `parse_upgrade_request` in spdystream-rs was using `headers.insert()` which kept only the last value (v1). With v1 selected, kubectl doesn't use the SPDY error stream for exit codes. Fixed in **spdystream-rs 0.1.2** by switching to `headers.append()`.

**Port-forward:** The server was echoing `portforward.k8s.io/v1` but kubectl advertises `portforward.k8s.io` (without version suffix). Fixed by reflecting the client's actual offered value.

## Changes

- `spdystream-rs` bumped to 0.1.2 (`headers.append`, `send_upgrade_response_with_protocol`)
- `pelagos-cri/src/streaming.rs`: new `negotiate_protocol()` selects the highest exec version (v4) and reflects the port-forward protocol
- `pelagos-cri/Cargo.toml`: spdystream-rs 0.1.2

## Test plan

Verified on live k3s cluster (ipc1/ipc2/ipc3):
- [x] `kubectl exec pod -- /bin/false` → exit 1
- [x] `kubectl exec pod -- /bin/sh -c 'exit 42'` → exit 42
- [x] `kubectl exec pod -- /bin/sh -c 'exit 0'` → exit 0
- [x] `echo hello | kubectl exec -i pod -- cat` → stdin relay works
- [x] `kubectl port-forward pod 9090:8080 + curl localhost:9090` → HTTP 200

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)