### PR TITLE
feat(seccomp): implement OCI linux.seccomp arg conditions (issue #265)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,16 @@ This is a hard requirement, not optional cleanup.
 5. Push both repos to remote
 6. Confirm both repos are clean and up to date with remote
 
+**"Once more into the breach!"** — Create issue, branch, plan, implement, test, report:
+1. Create a GitHub issue describing the work
+2. Create a feature branch named after the issue (e.g. `feat/description-NNN`)
+3. Move to that branch
+4. Write the full implementation plan to `ONGOING_TASKS.md`
+5. Present the plan to the user
+6. Quietly implement — no step-by-step narration
+7. Create integration tests and run them to success
+8. Report back with what was done and test results
+
 **"Engage!"** — Tag, release, and monitor:
 1. Create a git tag (ask user for version if unclear)
 2. Push the tag — this triggers the release workflow, which gates the build on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3616,9 +3616,9 @@ dependencies = [
 
 [[package]]
 name = "spdystream-rs"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2496b7335dc830aa6382d0eb3a5cf1419a3989ac29cdfe606f72fd148e7f03"
+checksum = "0a304ad360eb2215099094300f0eebe5d340f947011598b27e675b21c7424de0"
 dependencies = [
  "bytes",
  "flate2",

--- a/ONGOING_TASKS.md
+++ b/ONGOING_TASKS.md
@@ -1,113 +1,111 @@
 # Ongoing Tasks
 
-## Session 2026-05-29 — Issue #263 CRI cleanup (in progress)
+## Session 2026-05-29 — Issue #265: OCI seccomp arg conditions (feat/oci-seccomp-args-devices-265)
 
-Branch: `fix/cri-cleanup-263`
+### Scope adjustment
 
-### Root cause analysis
+After reading the code, `linux.devices` node creation is **already implemented** —
+`oci.rs` translates each `linux.devices[]` entry to a `DeviceNode` and calls
+`cmd.with_device()`, which does `mknod` in pre_exec (container.rs). No work needed there.
 
-Three CRI issues found during v0.64.0 deployment to ipc cluster:
+The sole remaining work is **`linux.seccomp` argument conditions** (`args` field per
+syscall rule). The comment in `src/seccomp.rs:454` explicitly says:
+> "Argument conditions (`args`) are ignored in this first-pass implementation."
 
-1. **Port-forward broken** (`kubectl port-forward` → "unable to negotiate protocol: client
-   supports 'portforward.k8s.io', server returned ''")
-2. **Exit code propagation for non-1 values broken** (`exit 42` propagates as exit 1)
-3. **pasta not installed on ipc2/ipc3**
+### Root cause
 
-Issues 1 and 2 share the same root cause: `send_upgrade_response` in
-`spdystream-rs/src/server.rs` always sends a fixed 101 response without echoing
-`X-Stream-Protocol-Version` back to the client.
+`filter_from_oci` in `src/seccomp.rs` builds `filtered_rules` by calling
+`filtered_rules.entry(num).or_default()` — this creates an empty `Vec<SeccompRule>`,
+meaning "match any call to this syscall → match_action". The `rule.args` field is
+parsed (already in `OciSyscallArg`) but never translated to `SeccompCondition`s.
 
-- For **exec/attach**: kubectl sends `X-Stream-Protocol-Version: v4.channel.k8s.io` (among
-  others for negotiation); server must echo the chosen version. Without v4 being confirmed,
-  kubectl falls back to v1/v2/v3 which don't use the error stream for exit codes → exit code
-  always appears as 1 (kubectl's own generic failure code).
-- For **port-forward**: kubectl sends `X-Stream-Protocol-Version: portforward.k8s.io/v1`;
-  server must echo it; without the echo kubectl rejects the upgrade entirely.
+### What needs to change
 
-### Fix plan
+#### 1. `src/oci.rs` — add `value_two` to `OciSyscallArg`
 
-#### spdystream-rs/src/server.rs
-
-Change `send_upgrade_response` signature to accept an optional protocol string to
-include as `X-Stream-Protocol-Version`:
+`SCMP_CMP_MASKED_EQ` requires two values: `value` is the mask, `valueTwo` is the
+expected masked result. The field is missing from our struct.
 
 ```rust
-pub async fn send_upgrade_response_with_protocol<S: AsyncWrite + Unpin>(
-    stream: &mut S,
-    protocol: Option<&str>,
-) -> Result<()>
+#[derive(Debug, Deserialize)]
+pub struct OciSyscallArg {
+    pub index: u32,
+    pub value: u64,
+    #[serde(default, rename = "valueTwo")]
+    pub value_two: u64,
+    pub op: String,
+}
 ```
 
-Keep the original `send_upgrade_response` calling the new one with `None` (backward compat
-for tests). The response with a protocol:
+#### 2. `src/seccomp.rs` — translate args to SeccompConditions
 
-```
-HTTP/1.1 101 Switching Protocols\r\n
-Connection: Upgrade\r\n
-Upgrade: spdy/3.1\r\n
-X-Stream-Protocol-Version: <protocol>\r\n
-\r\n
-```
-
-#### spdystream-rs/src/server.rs — parse_upgrade_request
-
-Already captures all headers in `req.headers`. No change needed; caller reads
-`X-Stream-Protocol-Version` from `req.headers`.
-
-#### pelagos-cri/src/streaming.rs — handle_connection
-
-After `parse_upgrade_request`, select the protocol to confirm:
-
+Update imports:
 ```rust
-// For exec/attach: prefer v4 > v3 > v2 > v1
-// For port-forward: use portforward.k8s.io/v1
-let protocol = select_protocol(&req, kind);
-send_upgrade_response_with_protocol(&mut tcp, protocol.as_deref()).await?;
+use seccompiler::{
+    BpfProgram, SeccompAction, SeccompCmpArgLen, SeccompCmpOp,
+    SeccompCondition, SeccompFilter, SeccompRule,
+};
 ```
 
-Where `select_protocol` inspects the path kind and `X-Stream-Protocol-Version` header(s):
-- `exec`/`attach` path → pick highest `*.channel.k8s.io` version the client offers
-- `portforward` path → `portforward.k8s.io/v1`
+Add helper `oci_arg_to_condition(arg: &OciSyscallArg) -> Option<SeccompCondition>`:
+- Maps OCI op strings to `SeccompCmpOp` variants
+- `SCMP_CMP_MASKED_EQ`: op = `MaskedEq(arg.value)`, comparison value = `arg.value_two`
+- All other ops: use `arg.value` as the comparison value
+- Uses `SeccompCmpArgLen::Qword` for all conditions (64-bit, safe for all syscall args)
 
-Note: the `accept()` function in spdystream-rs (used elsewhere) can keep using the
-no-protocol variant — it's not in the hot path for CRI.
+In the rule-building loop, replace `entry.or_default()` with:
+- If `rule.args` is empty → clear the entry (unconditional match wins over any
+  prior arg-conditional rules for the same syscall)
+- If `rule.args` is non-empty → build `SeccompCondition`s (ANDed), push a
+  `SeccompRule::new(conditions)` to the entry (ORed with other rules for same syscall)
 
-#### pasta on ipc2/ipc3
+OCI semantics map directly to seccompiler:
+- Multiple `args` within one rule → AND (all conditions in one `SeccompRule`)
+- Multiple `OciSyscallRule` entries for same syscall → OR (multiple `SeccompRule`s in Vec)
 
-Simple install: `sudo apt-get install -y passt` on both agent nodes.
-No code change.
+Also remove the dead first-pass loop (lines 478-499) that built `rules` but was
+never used. Update the doc comment to remove "args are ignored".
 
 ### Test plan
 
-1. `cargo test -p spdystream-rs --lib` — new unit tests for `send_upgrade_response_with_protocol`
-2. Deploy to ipc cluster: `scripts/install.sh` + `sudo systemctl restart pelagos-cri`
-3. On ipc1:
-   - `kubectl exec pod -- /bin/sh -c 'exit 42'; echo $?` → must print 42
-   - `kubectl port-forward pod/test 9090:80 &; curl localhost:9090` → must succeed
-4. `scripts/test-cri.sh` on ipc1 — all assertions pass
+#### Unit test in `src/seccomp.rs`
 
-### Session 2026-05-29 — Issue #261 COMPLETE; v0.64.0 RELEASED
+`test_filter_from_oci_with_args` — build an `OciSeccomp` directly in code with:
+- `defaultAction: SCMP_ACT_ALLOW`
+- One syscall rule: `socket`, action `SCMP_ACT_ERRNO`, args `[{index:0, op:SCMP_CMP_EQ, value:16}]`
 
-Issue #261 (replace all `nft` shell-outs with native NETLINK_NETFILTER client) is complete.
-PR #262 merged to main. Tag v0.64.0 pushed and released.
+Assert the BpfProgram compiles without error (no kernel required).
 
-### What was done
+#### Integration test `test_oci_seccomp_args`
 
-- New `src/nfnetlink.rs` (~1540 lines): raw nfnetlink socket client, no new dependencies
-- `src/network.rs`: all `run_nft`/`run_nft_quiet` call sites replaced with nfnetlink API
-- Fixed two protocol bugs found during implementation:
-  - `NFNL_SUBSYS_NFTABLES` constant was 12 (HOOK subsystem); correct value is 10
-  - Verdict immediates (accept/jump) must use `REG_VERDICT=0` as dreg, not REG1
-- 4 new `nfnetlink_native` integration tests (all `#[serial(nat)]`)
-- All 10 dockerd tests serialized with the `nat` group (`serial(nat, dockerd)`)
-- Improved error visibility: non-ENOENT failures from `nft_delete_ip_table` and
-  `nft_remove_filter_forward_compat` now emit `log::warn`
+OCI bundle with `defaultAction: SCMP_ACT_ALLOW` and one rule:
+- block `socket` when `arg[0] == 16` (AF_NETLINK = 16)
 
-### Release fixes
+Run a shell command inside the container that:
+1. Opens an AF_INET socket (must succeed → prints `INET_OK`)
+2. Opens an AF_NETLINK socket (must fail with EPERM → prints `NETLINK_FAIL`)
 
-- `msghdr` struct literal init fails on aarch64-musl (private `__pad1`/`__pad2` fields);
-  fixed with `zeroed() + field-assign` at 4 call sites in `src/nfnetlink.rs`
-- ECR rate limit caused transient test failure in `ensure_alpine()`; added 3-attempt
-  retry with 30s/60s backoff in both ECR-based `ensure_alpine` functions
+Use a small static C program compiled inside the test or a direct syscall via
+`busybox` approach. Simplest: compile a small C source via `cc` in the test tmpdir,
+copy into the bundle rootfs overlay, and run it via the OCI lifecycle.
 
-Final tag: `b93d473` — release at https://github.com/pelagos-containers/pelagos/releases/tag/v0.64.0
+Assert stdout contains `INET_OK` and `NETLINK_FAIL`.
+
+Document in `docs/INTEGRATION_TESTS.md`.
+
+### Files to change
+
+1. `src/oci.rs` — add `value_two` to `OciSyscallArg`
+2. `src/seccomp.rs` — implement arg conditions in `filter_from_oci`
+3. `tests/integration_tests.rs` — `test_oci_seccomp_args`
+4. `docs/INTEGRATION_TESTS.md` — document new test
+
+---
+
+## Previous: Session 2026-05-29 — Issue #263 CRI cleanup COMPLETE
+
+PR #264 merged. Issue #263 closed. pasta installed on ipc1/ipc2/ipc3.
+
+## Previous: Session 2026-05-29 — Issue #261 COMPLETE; v0.64.0 RELEASED
+
+Final tag: `b93d473` — https://github.com/pelagos-containers/pelagos/releases/tag/v0.64.0

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -1110,6 +1110,18 @@ Creates a `config.json` with `linux.seccomp` using a default-allow policy that d
 Failure indicates that `linux.seccomp` parsing from OCI config, the `filter_from_oci()`
 function in `src/seccomp.rs`, or the `with_seccomp_program()` wiring is broken.
 
+### `test_oci_seccomp_args`
+**Requires:** root (no rootfs required — compiles a static binary at test time)
+
+Builds a seccomp filter via `filter_from_oci` with an argument condition: `defaultAction=ALLOW`,
+but block `socket` when `arg[0] == 16` (AF_NETLINK). Compiles a tiny static C binary at test
+time that calls both `socket(AF_INET, ...)` and `socket(AF_NETLINK, ...)` and prints
+`INET_OK`/`NETLINK_OK` or `INET_FAIL`/`NETLINK_FAIL`. Runs the binary in two containers:
+one without any seccomp (both sockets must succeed), one with the arg-filtered filter
+(AF_INET must succeed, AF_NETLINK must be blocked). Failure indicates that `OciSyscallArg`
+→ `SeccompCondition` translation in `filter_from_oci` is broken or seccompiler arg
+conditions are mis-wired.
+
 ### `test_oci_cap_all_known_names_round_trip` (unit)
 **Requires:** nothing (unit test in `src/oci.rs`)
 

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -1122,6 +1122,29 @@ one without any seccomp (both sockets must succeed), one with the arg-filtered f
 → `SeccompCondition` translation in `filter_from_oci` is broken or seccompiler arg
 conditions are mis-wired.
 
+### `test_oci_seccomp_args_operators`
+**Requires:** root (no rootfs required — compiles a static binary at test time)
+
+Runtime-verifies the seccomp arg condition operators and combination semantics that
+`test_oci_seccomp_args` does not cover. Compiles one static C binary that calls
+`socket(AF_INET)`, `socket(AF_INET, SOCK_STREAM|SOCK_NONBLOCK)`, `socket(AF_INET6)`,
+and `socket(AF_NETLINK)`. Runs it four times with different seccomp policies:
+
+- **NE**: block `socket` when `arg[0] != AF_INET(2)` — verifies `SCMP_CMP_NE` BPF emission
+  allows AF_INET and blocks AF_INET6 and AF_NETLINK.
+- **MASKED_EQ**: block `socket` when `(arg[1] & 0x800) == 0x800` (SOCK_NONBLOCK bit) —
+  verifies `SCMP_CMP_MASKED_EQ` BPF emission allows plain SOCK_STREAM and blocks
+  SOCK_STREAM|SOCK_NONBLOCK.
+- **Multi-arg AND**: single rule with two conditions (`arg[0]==2 AND arg[1]==1`) — verifies
+  the kernel ANDs conditions: blocks exact `{AF_INET, SOCK_STREAM}`, allows
+  `{AF_INET, SOCK_STREAM|SOCK_NONBLOCK}` and `{AF_INET6, SOCK_STREAM}`.
+- **Multi-rule OR**: two `OciSyscallRule` entries for `socket` (`arg[0]==16` and `arg[0]==10`)
+  — verifies the kernel ORs rules: AF_INET allowed, AF_NETLINK blocked by rule 1,
+  AF_INET6 blocked by rule 2.
+
+Failure of any scenario indicates the corresponding seccompiler BPF emission path or
+OCI→SeccompCondition translation is wrong at the kernel level, not just at compile time.
+
 ### `test_oci_cap_all_known_names_round_trip` (unit)
 **Requires:** nothing (unit test in `src/oci.rs`)
 

--- a/src/oci.rs
+++ b/src/oci.rs
@@ -315,6 +315,10 @@ pub struct OciSyscallRule {
 pub struct OciSyscallArg {
     pub index: u32,
     pub value: u64,
+    /// Second value used only by `SCMP_CMP_MASKED_EQ`: `value` is the mask,
+    /// `value_two` is the expected result of `(arg & mask)`.
+    #[serde(default, rename = "valueTwo")]
+    pub value_two: u64,
     pub op: String,
 }
 

--- a/src/seccomp.rs
+++ b/src/seccomp.rs
@@ -49,7 +49,10 @@
 //! Seccomp filtering adds ~20-50ns overhead per syscall, which is negligible
 //! for most workloads (< 0.01% for typical applications).
 
-use seccompiler::{BpfProgram, SeccompAction, SeccompFilter, SeccompRule};
+use seccompiler::{
+    BpfProgram, SeccompAction, SeccompCmpArgLen, SeccompCmpOp, SeccompCondition, SeccompFilter,
+    SeccompRule,
+};
 use std::collections::BTreeMap;
 use std::io;
 
@@ -450,8 +453,9 @@ pub fn minimal_filter() -> Result<BpfProgram, io::Error> {
 /// Build a seccomp BPF program from an OCI `linux.seccomp` configuration.
 ///
 /// Handles `SCMP_ACT_ALLOW`, `SCMP_ACT_ERRNO`, `SCMP_ACT_KILL`, `SCMP_ACT_KILL_THREAD`,
-/// `SCMP_ACT_KILL_PROCESS`, `SCMP_ACT_LOG`, and `SCMP_ACT_TRAP`.
-/// Argument conditions (`args`) are ignored in this first-pass implementation.
+/// `SCMP_ACT_KILL_PROCESS`, `SCMP_ACT_LOG`, and `SCMP_ACT_TRAP`. Argument conditions
+/// (`args`) are fully translated: multiple `args` within one rule are ANDed; multiple
+/// rules for the same syscall are ORed.
 pub fn filter_from_oci(config: &crate::oci::OciSeccomp) -> Result<BpfProgram, io::Error> {
     use std::convert::TryInto;
 
@@ -467,6 +471,21 @@ pub fn filter_from_oci(config: &crate::oci::OciSeccomp) -> Result<BpfProgram, io
         }
     }
 
+    fn oci_arg_to_condition(arg: &crate::oci::OciSyscallArg) -> Option<SeccompCondition> {
+        let (op, value) = match arg.op.as_str() {
+            "SCMP_CMP_EQ" => (SeccompCmpOp::Eq, arg.value),
+            "SCMP_CMP_NE" => (SeccompCmpOp::Ne, arg.value),
+            "SCMP_CMP_LT" => (SeccompCmpOp::Lt, arg.value),
+            "SCMP_CMP_LE" => (SeccompCmpOp::Le, arg.value),
+            "SCMP_CMP_GT" => (SeccompCmpOp::Gt, arg.value),
+            "SCMP_CMP_GE" => (SeccompCmpOp::Ge, arg.value),
+            // value = mask, value_two = expected result of (arg & mask)
+            "SCMP_CMP_MASKED_EQ" => (SeccompCmpOp::MaskedEq(arg.value), arg.value_two),
+            _ => return None,
+        };
+        SeccompCondition::new(arg.index as u8, SeccompCmpArgLen::Qword, op, value).ok()
+    }
+
     let default_action = oci_action_to_seccomp(&config.default_action).ok_or_else(|| {
         io::Error::other(format!(
             "unknown seccomp defaultAction: {}",
@@ -474,43 +493,9 @@ pub fn filter_from_oci(config: &crate::oci::OciSeccomp) -> Result<BpfProgram, io
         ))
     })?;
 
-    // Build syscall → rules map. For each rule, the action overrides the default.
-    let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
-
-    for rule in &config.syscalls {
-        let action = match oci_action_to_seccomp(&rule.action) {
-            Some(a) => a,
-            None => continue, // skip unknown actions
-        };
-
-        // Only add rules that differ from the default (seccompiler semantics:
-        // rules map is "match → match_action"; default_action is the fallback).
-        // We unconditionally add the entry; seccompiler handles the logic.
-        for name in &rule.names {
-            if let Ok(num) = syscall_number(name) {
-                rules.entry(num).or_default();
-                // An empty Vec<SeccompRule> means "match any args → match_action".
-                // We use the action as the match_action; but SeccompFilter only has
-                // one match_action. Work around this by building one filter per
-                // unique action if needed — for now handle the common case where
-                // all syscall rules share the same action.
-                let _ = action; // captured per-loop below
-            }
-        }
-    }
-
-    // Simplified but correct approach: build a single filter where:
-    // - rules map contains all syscalls with the per-rule action that matches
-    // - For heterogeneous actions we build them as separate entries
-    // The seccompiler model: filter has ONE match_action and ONE default_action.
-    // Entries in the rules map use the match_action if they match.
-    //
-    // This means we can only represent "allowlist" (default=KILL, rules=ALLOW)
-    // or "denylist" (default=ALLOW, rules=ERRNO) in a single filter.
-    //
-    // For full generality we'd need multiple chained filters. For now we collect
-    // only the rules whose action differs from the default.
-
+    // seccompiler supports a single match_action per filter. Collect all rules
+    // whose action differs from the default; warn and drop any that introduce a
+    // second distinct non-default action (see issue #166 for multi-filter support).
     let mut filtered_rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
     let mut match_action: Option<SeccompAction> = None;
 
@@ -520,23 +505,36 @@ pub fn filter_from_oci(config: &crate::oci::OciSeccomp) -> Result<BpfProgram, io
             None => continue,
         };
         if action == default_action {
-            continue; // Same as default — no need to add to map
+            continue;
         }
         if match_action.is_none() {
             match_action = Some(action.clone());
         } else if Some(&action) != match_action.as_ref() {
-            // seccompiler supports only one match_action per filter.  Rules
-            // whose action differs from the first non-default action seen are
-            // silently dropped.  See issue #166 for the proper multi-filter fix.
             log::warn!(
                 "seccomp: OCI rule action {:?} differs from filter match_action {:?} — rule(s) for {:?} dropped (issue #166)",
                 rule.action, match_action, rule.names
             );
             continue;
         }
+
         for name in &rule.names {
             if let Ok(num) = syscall_number(name) {
-                filtered_rules.entry(num).or_default();
+                let entry = filtered_rules.entry(num).or_default();
+                if rule.args.is_empty() {
+                    // Unconditional rule: clear any prior arg-conditional rules
+                    // for this syscall — an unconditional match supersedes them.
+                    entry.clear();
+                } else {
+                    // Build AND-conditions for this rule; push as one SeccompRule
+                    // (ORed with any other rules already in the Vec for this syscall).
+                    let conditions: Vec<SeccompCondition> =
+                        rule.args.iter().filter_map(oci_arg_to_condition).collect();
+                    if !conditions.is_empty() {
+                        if let Ok(sr) = SeccompRule::new(conditions) {
+                            entry.push(sr);
+                        }
+                    }
+                }
             }
         }
     }
@@ -1239,5 +1237,57 @@ mod tests {
         assert!(syscall_number("io_uring_setup").is_ok());
         assert!(syscall_number("io_uring_enter").is_ok());
         assert!(syscall_number("io_uring_register").is_ok());
+    }
+
+    #[test]
+    fn test_filter_from_oci_with_args() {
+        // Verify that OCI seccomp arg conditions compile to a BpfProgram.
+        // Policy: allow everything except socket(AF_NETLINK, ...) → EPERM.
+        // AF_NETLINK = 16.
+        let config = crate::oci::OciSeccomp {
+            default_action: "SCMP_ACT_ALLOW".to_string(),
+            architectures: vec![],
+            syscalls: vec![crate::oci::OciSyscallRule {
+                names: vec!["socket".to_string()],
+                action: "SCMP_ACT_ERRNO".to_string(),
+                args: vec![crate::oci::OciSyscallArg {
+                    index: 0,
+                    value: 16, // AF_NETLINK
+                    value_two: 0,
+                    op: "SCMP_CMP_EQ".to_string(),
+                }],
+            }],
+        };
+        let result = filter_from_oci(&config);
+        assert!(
+            result.is_ok(),
+            "filter_from_oci with args should compile: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_filter_from_oci_masked_eq() {
+        // Verify SCMP_CMP_MASKED_EQ compiles: value=mask, value_two=expected result.
+        let config = crate::oci::OciSeccomp {
+            default_action: "SCMP_ACT_ALLOW".to_string(),
+            architectures: vec![],
+            syscalls: vec![crate::oci::OciSyscallRule {
+                names: vec!["mmap".to_string()],
+                action: "SCMP_ACT_ERRNO".to_string(),
+                args: vec![crate::oci::OciSyscallArg {
+                    index: 3,
+                    value: 0x0f, // mask: lower 4 bits
+                    value_two: 0x02,
+                    op: "SCMP_CMP_MASKED_EQ".to_string(),
+                }],
+            }],
+        };
+        let result = filter_from_oci(&config);
+        assert!(
+            result.is_ok(),
+            "filter_from_oci MASKED_EQ should compile: {:?}",
+            result
+        );
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5701,6 +5701,130 @@ mod oci_lifecycle {
         oci_run_to_completion(&id, bundle_dir.path(), 5);
     }
 
+    /// test_oci_seccomp_args
+    ///
+    /// Requires: root.
+    ///
+    /// Builds a seccomp filter via `filter_from_oci` with an argument condition:
+    /// default=ALLOW, but block `socket` when arg[0] == 16 (AF_NETLINK). Compiles a
+    /// small static C binary at test time that calls both socket(AF_INET) and
+    /// socket(AF_NETLINK) and prints INET_OK/NETLINK_OK or INET_FAIL/NETLINK_FAIL.
+    ///
+    /// Runs two containers using the library API:
+    /// 1. Without seccomp: both sockets succeed (INET_OK, NETLINK_OK).
+    /// 2. With the arg-filtered filter: AF_INET succeeds, AF_NETLINK is blocked (NETLINK_FAIL).
+    ///
+    /// Failure indicates that `OciSyscallArg` → `SeccompCondition` translation in
+    /// `filter_from_oci` is broken, or seccompiler arg conditions are mis-wired.
+    #[test]
+    fn test_oci_seccomp_args() {
+        if !is_root() {
+            eprintln!("Skipping test_oci_seccomp_args: requires root");
+            return;
+        }
+
+        // Compile a tiny static binary that probes AF_INET and AF_NETLINK sockets.
+        // Static linking avoids any dependency on dynamic libraries in the rootfs.
+        let src = r#"
+#include <sys/socket.h>
+#include <linux/netlink.h>
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+int main(void) {
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd >= 0) { close(fd); puts("INET_OK"); } else { puts("INET_FAIL"); }
+    fd = socket(AF_NETLINK, SOCK_RAW, 0);
+    if (fd >= 0) { close(fd); puts("NETLINK_OK"); } else { puts("NETLINK_FAIL"); }
+    return 0;
+}
+"#;
+        let tmp = tempfile::tempdir().expect("tempdir for seccomp_args test");
+        let src_path = tmp.path().join("probe.c");
+        let bin_path = tmp.path().join("probe");
+        std::fs::write(&src_path, src).expect("write probe.c");
+        let cc_out = std::process::Command::new("cc")
+            .args([
+                "-static",
+                "-o",
+                bin_path.to_str().unwrap(),
+                src_path.to_str().unwrap(),
+            ])
+            .output()
+            .expect("cc");
+        assert!(
+            cc_out.status.success(),
+            "failed to compile probe: {}",
+            String::from_utf8_lossy(&cc_out.stderr)
+        );
+
+        // Minimal rootfs: just the probe binary at /probe. Static binary needs nothing else.
+        let rootfs = tmp.path().join("rootfs");
+        std::fs::create_dir(&rootfs).expect("mkdir rootfs");
+        std::fs::copy(&bin_path, rootfs.join("probe")).expect("cp probe");
+
+        // Build seccomp filter: allow everything except socket(AF_NETLINK=16, ...).
+        let oci_seccomp = pelagos::oci::OciSeccomp {
+            default_action: "SCMP_ACT_ALLOW".to_string(),
+            architectures: vec![],
+            syscalls: vec![pelagos::oci::OciSyscallRule {
+                names: vec!["socket".to_string()],
+                action: "SCMP_ACT_ERRNO".to_string(),
+                args: vec![pelagos::oci::OciSyscallArg {
+                    index: 0,
+                    value: 16, // AF_NETLINK
+                    value_two: 0,
+                    op: "SCMP_CMP_EQ".to_string(),
+                }],
+            }],
+        };
+        let prog =
+            pelagos::seccomp::filter_from_oci(&oci_seccomp).expect("filter_from_oci should work");
+
+        // Baseline: no seccomp — both sockets should open.
+        let mut child_plain = Command::new("/probe")
+            .with_chroot(&rootfs)
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS)
+            .stdout(Stdio::Piped)
+            .stderr(Stdio::Null)
+            .spawn()
+            .expect("spawn plain");
+        let (_, stdout_plain_bytes, _) = child_plain
+            .wait_with_output()
+            .expect("wait_with_output plain");
+        let stdout_plain = String::from_utf8_lossy(&stdout_plain_bytes).into_owned();
+
+        // With arg-filtered seccomp: AF_INET allowed, AF_NETLINK blocked.
+        let mut child_filtered = Command::new("/probe")
+            .with_chroot(&rootfs)
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS)
+            .stdout(Stdio::Piped)
+            .stderr(Stdio::Null)
+            .with_seccomp_program(prog)
+            .spawn()
+            .expect("spawn with arg-filtered seccomp");
+        let (_, stdout_filtered_bytes, _) = child_filtered
+            .wait_with_output()
+            .expect("wait_with_output filtered");
+        let stdout_filtered = String::from_utf8_lossy(&stdout_filtered_bytes).into_owned();
+
+        assert!(
+            stdout_plain.contains("INET_OK") && stdout_plain.contains("NETLINK_OK"),
+            "baseline should allow both sockets: got {:?}",
+            stdout_plain
+        );
+        assert!(
+            stdout_filtered.contains("INET_OK"),
+            "arg-filtered seccomp should allow AF_INET: got {:?}",
+            stdout_filtered
+        );
+        assert!(
+            stdout_filtered.contains("NETLINK_FAIL"),
+            "arg-filtered seccomp should block socket(AF_NETLINK=16): got {:?}",
+            stdout_filtered
+        );
+    }
+
     /// test_oci_kernel_mounts
     ///
     /// Requires: root, alpine-rootfs.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5825,6 +5825,279 @@ int main(void) {
         );
     }
 
+    /// test_oci_seccomp_args_operators
+    ///
+    /// Requires: root (no rootfs required — compiles a static binary at test time).
+    ///
+    /// Extends test_oci_seccomp_args to runtime-verify operators and combination
+    /// semantics that the unit tests only confirm at compile time:
+    ///
+    /// - SCMP_CMP_NE: block socket when arg[0] != AF_INET(2); AF_INET allowed,
+    ///   AF_NETLINK blocked.
+    /// - SCMP_CMP_MASKED_EQ: block socket when (arg[1] & SOCK_NONBLOCK) == SOCK_NONBLOCK;
+    ///   plain SOCK_STREAM allowed, SOCK_STREAM|SOCK_NONBLOCK blocked.
+    /// - Multi-arg AND: block socket when arg[0]==AF_INET AND arg[1]==SOCK_STREAM;
+    ///   exact match blocked, SOCK_STREAM|SOCK_NONBLOCK (arg[1]≠1) and AF_INET6
+    ///   (arg[0]≠2) allowed.
+    /// - Multi-rule OR: two rules for socket — block arg[0]==AF_NETLINK, block
+    ///   arg[0]==AF_INET6; AF_INET allowed, both AF_NETLINK and AF_INET6 blocked.
+    ///
+    /// Failure of any scenario indicates the corresponding seccompiler BPF emission
+    /// path or the OCI→SeccompCondition translation is wrong at the kernel level.
+    #[test]
+    fn test_oci_seccomp_args_operators() {
+        if !is_root() {
+            eprintln!("Skipping test_oci_seccomp_args_operators: requires root");
+            return;
+        }
+
+        // Probe binary: calls several socket variants and prints a label per result.
+        // Uses numeric constants to avoid header portability issues with SOCK_NONBLOCK.
+        let src = r#"
+#include <sys/socket.h>
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+
+static void probe(const char *label, int domain, int type, int protocol) {
+    int fd = socket(domain, type, protocol);
+    if (fd >= 0) { close(fd); printf("%s_OK\n", label); }
+    else          { printf("%s_FAIL\n", label); }
+}
+
+int main(void) {
+    probe("INET_STREAM",         2,      1,      0);  /* AF_INET, SOCK_STREAM */
+    probe("INET_STREAM_NB",      2,  0x801,      0);  /* AF_INET, SOCK_STREAM|SOCK_NONBLOCK */
+    probe("INET6_STREAM",       10,      1,      0);  /* AF_INET6, SOCK_STREAM */
+    probe("NETLINK_RAW",        16,      3,      0);  /* AF_NETLINK, SOCK_RAW */
+    return 0;
+}
+"#;
+        let tmp = tempfile::tempdir().expect("tempdir for seccomp_args_operators");
+        let src_path = tmp.path().join("probe.c");
+        let bin_path = tmp.path().join("probe");
+        std::fs::write(&src_path, src).expect("write probe.c");
+        let cc_out = std::process::Command::new("cc")
+            .args([
+                "-static",
+                "-o",
+                bin_path.to_str().unwrap(),
+                src_path.to_str().unwrap(),
+            ])
+            .output()
+            .expect("cc");
+        assert!(
+            cc_out.status.success(),
+            "failed to compile probe: {}",
+            String::from_utf8_lossy(&cc_out.stderr)
+        );
+        let rootfs = tmp.path().join("rootfs");
+        std::fs::create_dir(&rootfs).expect("mkdir rootfs");
+        std::fs::copy(&bin_path, rootfs.join("probe")).expect("cp probe");
+
+        // Helper: run /probe in a chroot with the given seccomp filter; return stdout.
+        let run_probe = |prog: seccompiler::BpfProgram| -> String {
+            let mut child = Command::new("/probe")
+                .with_chroot(&rootfs)
+                .with_namespaces(Namespace::MOUNT | Namespace::UTS)
+                .stdout(Stdio::Piped)
+                .stderr(Stdio::Null)
+                .with_seccomp_program(prog)
+                .spawn()
+                .expect("spawn");
+            let (_, out, _) = child.wait_with_output().expect("wait_with_output");
+            String::from_utf8_lossy(&out).into_owned()
+        };
+
+        // Baseline: no seccomp — all four sockets should open.
+        let mut baseline = Command::new("/probe")
+            .with_chroot(&rootfs)
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS)
+            .stdout(Stdio::Piped)
+            .stderr(Stdio::Null)
+            .spawn()
+            .expect("spawn baseline");
+        let (_, base_out, _) = baseline.wait_with_output().expect("wait baseline");
+        let base = String::from_utf8_lossy(&base_out).into_owned();
+        assert!(
+            base.contains("INET_STREAM_OK"),
+            "baseline INET_STREAM: {base:?}"
+        );
+        assert!(
+            base.contains("INET_STREAM_NB_OK"),
+            "baseline INET_STREAM_NB: {base:?}"
+        );
+        assert!(
+            base.contains("INET6_STREAM_OK"),
+            "baseline INET6_STREAM: {base:?}"
+        );
+        assert!(
+            base.contains("NETLINK_RAW_OK"),
+            "baseline NETLINK_RAW: {base:?}"
+        );
+
+        // ---- SCMP_CMP_NE ----
+        // Block socket when arg[0] != AF_INET(2): INET allowed, INET6/NETLINK blocked.
+        let ne_filter = pelagos::seccomp::filter_from_oci(&pelagos::oci::OciSeccomp {
+            default_action: "SCMP_ACT_ALLOW".to_string(),
+            architectures: vec![],
+            syscalls: vec![pelagos::oci::OciSyscallRule {
+                names: vec!["socket".to_string()],
+                action: "SCMP_ACT_ERRNO".to_string(),
+                args: vec![pelagos::oci::OciSyscallArg {
+                    index: 0,
+                    value: 2,
+                    value_two: 0,
+                    op: "SCMP_CMP_NE".to_string(),
+                }],
+            }],
+        })
+        .expect("ne filter");
+        let ne = run_probe(ne_filter);
+        assert!(
+            ne.contains("INET_STREAM_OK"),
+            "NE: INET_STREAM should be allowed: {ne:?}"
+        );
+        assert!(
+            ne.contains("INET_STREAM_NB_OK"),
+            "NE: INET_STREAM_NB should be allowed: {ne:?}"
+        );
+        assert!(
+            ne.contains("INET6_STREAM_FAIL"),
+            "NE: INET6 should be blocked: {ne:?}"
+        );
+        assert!(
+            ne.contains("NETLINK_RAW_FAIL"),
+            "NE: NETLINK should be blocked: {ne:?}"
+        );
+
+        // ---- SCMP_CMP_MASKED_EQ ----
+        // Block socket when (arg[1] & SOCK_NONBLOCK=0x800) == 0x800.
+        // SOCK_STREAM(1) → 1&0x800=0 ≠ 0x800 → allowed.
+        // SOCK_STREAM|SOCK_NONBLOCK(0x801) → 0x801&0x800=0x800 == 0x800 → blocked.
+        let meq_filter = pelagos::seccomp::filter_from_oci(&pelagos::oci::OciSeccomp {
+            default_action: "SCMP_ACT_ALLOW".to_string(),
+            architectures: vec![],
+            syscalls: vec![pelagos::oci::OciSyscallRule {
+                names: vec!["socket".to_string()],
+                action: "SCMP_ACT_ERRNO".to_string(),
+                args: vec![pelagos::oci::OciSyscallArg {
+                    index: 1,
+                    value: 0x800,
+                    value_two: 0x800,
+                    op: "SCMP_CMP_MASKED_EQ".to_string(),
+                }],
+            }],
+        })
+        .expect("masked_eq filter");
+        let meq = run_probe(meq_filter);
+        assert!(
+            meq.contains("INET_STREAM_OK"),
+            "MASKED_EQ: plain SOCK_STREAM allowed: {meq:?}"
+        );
+        assert!(
+            meq.contains("INET_STREAM_NB_FAIL"),
+            "MASKED_EQ: SOCK_NONBLOCK blocked: {meq:?}"
+        );
+        assert!(
+            meq.contains("INET6_STREAM_OK"),
+            "MASKED_EQ: INET6 allowed: {meq:?}"
+        );
+        assert!(
+            meq.contains("NETLINK_RAW_OK"),
+            "MASKED_EQ: NETLINK allowed: {meq:?}"
+        );
+
+        // ---- Multi-arg AND ----
+        // Block socket when arg[0]==AF_INET(2) AND arg[1]==SOCK_STREAM(1).
+        // Only exact {AF_INET, SOCK_STREAM} is blocked; SOCK_NONBLOCK variant and INET6 pass.
+        let and_filter = pelagos::seccomp::filter_from_oci(&pelagos::oci::OciSeccomp {
+            default_action: "SCMP_ACT_ALLOW".to_string(),
+            architectures: vec![],
+            syscalls: vec![pelagos::oci::OciSyscallRule {
+                names: vec!["socket".to_string()],
+                action: "SCMP_ACT_ERRNO".to_string(),
+                args: vec![
+                    pelagos::oci::OciSyscallArg {
+                        index: 0,
+                        value: 2,
+                        value_two: 0,
+                        op: "SCMP_CMP_EQ".to_string(),
+                    },
+                    pelagos::oci::OciSyscallArg {
+                        index: 1,
+                        value: 1,
+                        value_two: 0,
+                        op: "SCMP_CMP_EQ".to_string(),
+                    },
+                ],
+            }],
+        })
+        .expect("and filter");
+        let and = run_probe(and_filter);
+        assert!(
+            and.contains("INET_STREAM_FAIL"),
+            "AND: AF_INET+SOCK_STREAM blocked: {and:?}"
+        );
+        assert!(
+            and.contains("INET_STREAM_NB_OK"),
+            "AND: SOCK_NONBLOCK variant allowed: {and:?}"
+        );
+        assert!(
+            and.contains("INET6_STREAM_OK"),
+            "AND: INET6 allowed: {and:?}"
+        );
+        assert!(
+            and.contains("NETLINK_RAW_OK"),
+            "AND: NETLINK allowed: {and:?}"
+        );
+
+        // ---- Multi-rule OR ----
+        // Two separate rules for socket: block arg[0]==16 (AF_NETLINK) OR arg[0]==10 (AF_INET6).
+        // AF_INET(2) matches neither rule → allowed.
+        let or_filter = pelagos::seccomp::filter_from_oci(&pelagos::oci::OciSeccomp {
+            default_action: "SCMP_ACT_ALLOW".to_string(),
+            architectures: vec![],
+            syscalls: vec![
+                pelagos::oci::OciSyscallRule {
+                    names: vec!["socket".to_string()],
+                    action: "SCMP_ACT_ERRNO".to_string(),
+                    args: vec![pelagos::oci::OciSyscallArg {
+                        index: 0,
+                        value: 16,
+                        value_two: 0,
+                        op: "SCMP_CMP_EQ".to_string(),
+                    }],
+                },
+                pelagos::oci::OciSyscallRule {
+                    names: vec!["socket".to_string()],
+                    action: "SCMP_ACT_ERRNO".to_string(),
+                    args: vec![pelagos::oci::OciSyscallArg {
+                        index: 0,
+                        value: 10,
+                        value_two: 0,
+                        op: "SCMP_CMP_EQ".to_string(),
+                    }],
+                },
+            ],
+        })
+        .expect("or filter");
+        let or = run_probe(or_filter);
+        assert!(or.contains("INET_STREAM_OK"), "OR: INET allowed: {or:?}");
+        assert!(
+            or.contains("INET_STREAM_NB_OK"),
+            "OR: INET_NB allowed: {or:?}"
+        );
+        assert!(
+            or.contains("INET6_STREAM_FAIL"),
+            "OR: INET6 blocked by rule 2: {or:?}"
+        );
+        assert!(
+            or.contains("NETLINK_RAW_FAIL"),
+            "OR: NETLINK blocked by rule 1: {or:?}"
+        );
+    }
+
     /// test_oci_kernel_mounts
     ///
     /// Requires: root, alpine-rootfs.


### PR DESCRIPTION
## Summary

Implements `linux.seccomp[].args` argument conditions from the OCI Runtime Spec. Previously, `filter_from_oci` in `src/seccomp.rs` explicitly ignored the `args` field with a comment saying "Argument conditions (`args`) are ignored in this first-pass implementation."

- Translates each `OciSyscallArg` to a `seccompiler::SeccompCondition`
- Supports all six OCI comparison operators: `SCMP_CMP_EQ`, `SCMP_CMP_NE`, `SCMP_CMP_LT`, `SCMP_CMP_LE`, `SCMP_CMP_GT`, `SCMP_CMP_GE`, and `SCMP_CMP_MASKED_EQ`
- Adds `value_two` field to `OciSyscallArg` for `SCMP_CMP_MASKED_EQ` (mask=`value`, expected=`value_two`)
- OCI semantics map directly to seccompiler: multiple `args` within one rule → AND (single `SeccompRule`); multiple rules for same syscall → OR (`Vec<SeccompRule>`)
- Removes a dead first-pass loop that built a `rules` map but was never used

## Tests

- 2 new unit tests: `test_filter_from_oci_with_args`, `test_filter_from_oci_masked_eq`
- 1 new integration test: `test_oci_seccomp_args` — compiles a static C binary at test time, verifies `socket(AF_NETLINK=16)` is blocked while `socket(AF_INET=2)` is allowed under the arg-filtered policy

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)