### PR TITLE
fix(seccomp): honour errnoRet and SCMP_ACT_ENOSYS in OCI linux.seccomp rules (issue #267)

### DIFF
--- a/ONGOING_TASKS.md
+++ b/ONGOING_TASKS.md
@@ -1,111 +1,111 @@
 # Ongoing Tasks
 
-## Session 2026-05-29 — Issue #265: OCI seccomp arg conditions (feat/oci-seccomp-args-devices-265)
+## Session 2026-05-29 — Issue #267: fix errnoRet in OCI seccomp (fix/seccomp-errno-ret-267)
 
-### Scope adjustment
+### Problem
 
-After reading the code, `linux.devices` node creation is **already implemented** —
-`oci.rs` translates each `linux.devices[]` entry to a `DeviceNode` and calls
-`cmd.with_device()`, which does `mknod` in pre_exec (container.rs). No work needed there.
+`filter_from_oci` maps both `SCMP_ACT_ERRNO` and `SCMP_ACT_ENOSYS` to
+`SeccompAction::Errno(libc::EPERM as u32)`. Two OCI spec fields are ignored:
 
-The sole remaining work is **`linux.seccomp` argument conditions** (`args` field per
-syscall rule). The comment in `src/seccomp.rs:454` explicitly says:
-> "Argument conditions (`args`) are ignored in this first-pass implementation."
+- `OciSeccomp.defaultErrnoRet` — errno for the default action when it is ERRNO
+- `OciSyscallRule.errnoRet` — per-rule errno override
 
-### Root cause
+Docker's profile uses `SCMP_ACT_ENOSYS` (errno 38) extensively to signal
+"not implemented" vs "not permitted". Containers get EPERM (1) where they
+should get ENOSYS (38).
 
-`filter_from_oci` in `src/seccomp.rs` builds `filtered_rules` by calling
-`filtered_rules.entry(num).or_default()` — this creates an empty `Vec<SeccompRule>`,
-meaning "match any call to this syscall → match_action". The `rule.args` field is
-parsed (already in `OciSyscallArg`) but never translated to `SeccompCondition`s.
+### Changes
 
-### What needs to change
+#### `src/oci.rs`
 
-#### 1. `src/oci.rs` — add `value_two` to `OciSyscallArg`
-
-`SCMP_CMP_MASKED_EQ` requires two values: `value` is the mask, `valueTwo` is the
-expected masked result. The field is missing from our struct.
+Add `default_errno_ret` to `OciSeccomp` and `errno_ret` to `OciSyscallRule`:
 
 ```rust
-#[derive(Debug, Deserialize)]
-pub struct OciSyscallArg {
-    pub index: u32,
-    pub value: u64,
-    #[serde(default, rename = "valueTwo")]
-    pub value_two: u64,
-    pub op: String,
+pub struct OciSeccomp {
+    pub default_action: String,
+    #[serde(default, rename = "defaultErrnoRet")]
+    pub default_errno_ret: Option<u32>,
+    ...
+}
+
+pub struct OciSyscallRule {
+    pub names: Vec<String>,
+    pub action: String,
+    #[serde(default, rename = "errnoRet")]
+    pub errno_ret: Option<u32>,
+    pub args: Vec<OciSyscallArg>,
 }
 ```
 
-#### 2. `src/seccomp.rs` — translate args to SeccompConditions
+Note: `OciSeccomp` uses `#[serde(rename_all = "camelCase")]` so `default_errno_ret`
+would auto-rename to `defaultErrnoRet` — but be explicit with `rename` to be safe.
+Actually since `rename_all = "camelCase"` is on the struct, `default_errno_ret` → 
+`defaultErrnoRet` automatically. Add explicit `rename` anyway for clarity.
 
-Update imports:
+#### `src/seccomp.rs`
+
+Update `oci_action_to_seccomp` to accept an `errno_ret: Option<u32>` parameter:
+
 ```rust
-use seccompiler::{
-    BpfProgram, SeccompAction, SeccompCmpArgLen, SeccompCmpOp,
-    SeccompCondition, SeccompFilter, SeccompRule,
-};
+fn oci_action_to_seccomp(action: &str, errno_ret: Option<u32>) -> Option<SeccompAction> {
+    match action {
+        "SCMP_ACT_ALLOW" => Some(SeccompAction::Allow),
+        "SCMP_ACT_ERRNO" => Some(SeccompAction::Errno(
+            errno_ret.unwrap_or(libc::EPERM as u32)
+        )),
+        "SCMP_ACT_ENOSYS" => Some(SeccompAction::Errno(libc::ENOSYS as u32)),
+        "SCMP_ACT_KILL" | "SCMP_ACT_KILL_THREAD" => Some(SeccompAction::KillThread),
+        "SCMP_ACT_KILL_PROCESS" => Some(SeccompAction::KillProcess),
+        "SCMP_ACT_LOG" => Some(SeccompAction::Log),
+        "SCMP_ACT_TRAP" => Some(SeccompAction::Trap),
+        _ => None,
+    }
+}
 ```
 
-Add helper `oci_arg_to_condition(arg: &OciSyscallArg) -> Option<SeccompCondition>`:
-- Maps OCI op strings to `SeccompCmpOp` variants
-- `SCMP_CMP_MASKED_EQ`: op = `MaskedEq(arg.value)`, comparison value = `arg.value_two`
-- All other ops: use `arg.value` as the comparison value
-- Uses `SeccompCmpArgLen::Qword` for all conditions (64-bit, safe for all syscall args)
-
-In the rule-building loop, replace `entry.or_default()` with:
-- If `rule.args` is empty → clear the entry (unconditional match wins over any
-  prior arg-conditional rules for the same syscall)
-- If `rule.args` is non-empty → build `SeccompCondition`s (ANDed), push a
-  `SeccompRule::new(conditions)` to the entry (ORed with other rules for same syscall)
-
-OCI semantics map directly to seccompiler:
-- Multiple `args` within one rule → AND (all conditions in one `SeccompRule`)
-- Multiple `OciSyscallRule` entries for same syscall → OR (multiple `SeccompRule`s in Vec)
-
-Also remove the dead first-pass loop (lines 478-499) that built `rules` but was
-never used. Update the doc comment to remove "args are ignored".
+Update all three call sites:
+- `oci_action_to_seccomp(&config.default_action, config.default_errno_ret)`
+- `oci_action_to_seccomp(&rule.action, rule.errno_ret)` (appears twice in the rule loop)
 
 ### Test plan
 
-#### Unit test in `src/seccomp.rs`
+#### Unit test
 
-`test_filter_from_oci_with_args` — build an `OciSeccomp` directly in code with:
-- `defaultAction: SCMP_ACT_ALLOW`
-- One syscall rule: `socket`, action `SCMP_ACT_ERRNO`, args `[{index:0, op:SCMP_CMP_EQ, value:16}]`
+`test_filter_from_oci_errno_ret` — build `OciSeccomp` with `SCMP_ACT_ERRNO` and
+`errno_ret: Some(38)` (ENOSYS). Verify it compiles. Also verify default (no
+`errno_ret`) maps to EPERM. Pure compilation check, no kernel needed.
 
-Assert the BpfProgram compiles without error (no kernel required).
+#### Integration test `test_oci_seccomp_errno_ret`
 
-#### Integration test `test_oci_seccomp_args`
+Compile a static C binary that:
+1. Calls a blocked syscall (e.g. `personality(0xffffffff)`)
+2. Prints `ERRNO:<n>` where n is the errno value
+3. Runs with two OCI seccomp configs:
+   - `errnoRet: 38` → assert output is `ERRNO:38`
+   - No `errnoRet` → assert output is `ERRNO:1` (EPERM)
 
-OCI bundle with `defaultAction: SCMP_ACT_ALLOW` and one rule:
-- block `socket` when `arg[0] == 16` (AF_NETLINK = 16)
+Also verify `SCMP_ACT_ENOSYS` returns 38 without needing `errnoRet`.
 
-Run a shell command inside the container that:
-1. Opens an AF_INET socket (must succeed → prints `INET_OK`)
-2. Opens an AF_NETLINK socket (must fail with EPERM → prints `NETLINK_FAIL`)
-
-Use a small static C program compiled inside the test or a direct syscall via
-`busybox` approach. Simplest: compile a small C source via `cc` in the test tmpdir,
-copy into the bundle rootfs overlay, and run it via the OCI lifecycle.
-
-Assert stdout contains `INET_OK` and `NETLINK_FAIL`.
-
-Document in `docs/INTEGRATION_TESTS.md`.
+`personality` is a good test syscall — it's in the Docker blocked list, takes a
+single argument, and doesn't require any special privileges or setup.
 
 ### Files to change
 
-1. `src/oci.rs` — add `value_two` to `OciSyscallArg`
-2. `src/seccomp.rs` — implement arg conditions in `filter_from_oci`
-3. `tests/integration_tests.rs` — `test_oci_seccomp_args`
+1. `src/oci.rs` — add `default_errno_ret` to `OciSeccomp`, `errno_ret` to `OciSyscallRule`
+2. `src/seccomp.rs` — update `oci_action_to_seccomp` + three call sites
+3. `tests/integration_tests.rs` — `test_oci_seccomp_errno_ret`
 4. `docs/INTEGRATION_TESTS.md` — document new test
 
 ---
 
-## Previous: Session 2026-05-29 — Issue #263 CRI cleanup COMPLETE
+## Previous: Issue #265 COMPLETE
 
-PR #264 merged. Issue #263 closed. pasta installed on ipc1/ipc2/ipc3.
+PR #266 merged. OCI seccomp arg conditions fully implemented and kernel-verified.
 
-## Previous: Session 2026-05-29 — Issue #261 COMPLETE; v0.64.0 RELEASED
+## Previous: Issue #263 CRI cleanup COMPLETE
+
+PR #264 merged. pasta installed on ipc1/ipc2/ipc3.
+
+## Previous: Issue #261 COMPLETE; v0.64.0 RELEASED
 
 Final tag: `b93d473` — https://github.com/pelagos-containers/pelagos/releases/tag/v0.64.0

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -1122,6 +1122,20 @@ one without any seccomp (both sockets must succeed), one with the arg-filtered f
 → `SeccompCondition` translation in `filter_from_oci` is broken or seccompiler arg
 conditions are mis-wired.
 
+### `test_oci_seccomp_errno_ret`
+**Requires:** root (no rootfs required — compiles a static binary at test time)
+
+Verifies that `errnoRet` and `SCMP_ACT_ENOSYS` are honoured at the kernel level. Compiles
+a static binary that calls `personality(0xffffffff)` and prints `ERRNO:<n>`. Runs it under
+three seccomp policies:
+
+- `SCMP_ACT_ERRNO` with `errnoRet: 38` → must return errno 38 (ENOSYS), not 1 (EPERM)
+- `SCMP_ACT_ERRNO` without `errnoRet` → must return errno 1 (EPERM, default)
+- `SCMP_ACT_ENOSYS` action → must return errno 38 regardless of `errnoRet` field
+
+Failure indicates `oci_action_to_seccomp` is ignoring the `errno_ret` parameter or
+`SCMP_ACT_ENOSYS` is incorrectly mapped to EPERM instead of ENOSYS.
+
 ### `test_oci_seccomp_args_operators`
 **Requires:** root (no rootfs required — compiles a static binary at test time)
 

--- a/src/oci.rs
+++ b/src/oci.rs
@@ -296,6 +296,9 @@ fn default_file_mode() -> u32 {
 #[serde(rename_all = "camelCase")]
 pub struct OciSeccomp {
     pub default_action: String,
+    /// Errno returned when the default action is `SCMP_ACT_ERRNO`. Defaults to EPERM.
+    #[serde(default)]
+    pub default_errno_ret: Option<u32>,
     #[serde(default)]
     pub architectures: Vec<String>,
     #[serde(default)]
@@ -307,6 +310,9 @@ pub struct OciSyscallRule {
     #[serde(default)]
     pub names: Vec<String>,
     pub action: String,
+    /// Per-rule errno override for `SCMP_ACT_ERRNO`. Defaults to EPERM when absent.
+    #[serde(default, rename = "errnoRet")]
+    pub errno_ret: Option<u32>,
     #[serde(default)]
     pub args: Vec<OciSyscallArg>,
 }

--- a/src/seccomp.rs
+++ b/src/seccomp.rs
@@ -459,10 +459,14 @@ pub fn minimal_filter() -> Result<BpfProgram, io::Error> {
 pub fn filter_from_oci(config: &crate::oci::OciSeccomp) -> Result<BpfProgram, io::Error> {
     use std::convert::TryInto;
 
-    fn oci_action_to_seccomp(action: &str) -> Option<SeccompAction> {
+    fn oci_action_to_seccomp(action: &str, errno_ret: Option<u32>) -> Option<SeccompAction> {
         match action {
             "SCMP_ACT_ALLOW" => Some(SeccompAction::Allow),
-            "SCMP_ACT_ERRNO" | "SCMP_ACT_ENOSYS" => Some(SeccompAction::Errno(libc::EPERM as u32)),
+            "SCMP_ACT_ERRNO" => Some(SeccompAction::Errno(
+                errno_ret.unwrap_or(libc::EPERM as u32),
+            )),
+            // SCMP_ACT_ENOSYS always returns ENOSYS (38), regardless of errnoRet.
+            "SCMP_ACT_ENOSYS" => Some(SeccompAction::Errno(libc::ENOSYS as u32)),
             "SCMP_ACT_KILL" | "SCMP_ACT_KILL_THREAD" => Some(SeccompAction::KillThread),
             "SCMP_ACT_KILL_PROCESS" => Some(SeccompAction::KillProcess),
             "SCMP_ACT_LOG" => Some(SeccompAction::Log),
@@ -486,12 +490,13 @@ pub fn filter_from_oci(config: &crate::oci::OciSeccomp) -> Result<BpfProgram, io
         SeccompCondition::new(arg.index as u8, SeccompCmpArgLen::Qword, op, value).ok()
     }
 
-    let default_action = oci_action_to_seccomp(&config.default_action).ok_or_else(|| {
-        io::Error::other(format!(
-            "unknown seccomp defaultAction: {}",
-            config.default_action
-        ))
-    })?;
+    let default_action = oci_action_to_seccomp(&config.default_action, config.default_errno_ret)
+        .ok_or_else(|| {
+            io::Error::other(format!(
+                "unknown seccomp defaultAction: {}",
+                config.default_action
+            ))
+        })?;
 
     // seccompiler supports a single match_action per filter. Collect all rules
     // whose action differs from the default; warn and drop any that introduce a
@@ -500,7 +505,7 @@ pub fn filter_from_oci(config: &crate::oci::OciSeccomp) -> Result<BpfProgram, io
     let mut match_action: Option<SeccompAction> = None;
 
     for rule in &config.syscalls {
-        let action = match oci_action_to_seccomp(&rule.action) {
+        let action = match oci_action_to_seccomp(&rule.action, rule.errno_ret) {
             Some(a) => a,
             None => continue,
         };
@@ -1229,6 +1234,43 @@ mod tests {
     }
 
     #[test]
+    fn test_filter_from_oci_errno_ret() {
+        // SCMP_ACT_ERRNO with errnoRet:38 should produce Errno(38), not Errno(EPERM).
+        let config_enosys = crate::oci::OciSeccomp {
+            default_action: "SCMP_ACT_ALLOW".to_string(),
+            default_errno_ret: None,
+            architectures: vec![],
+            syscalls: vec![crate::oci::OciSyscallRule {
+                names: vec!["personality".to_string()],
+                action: "SCMP_ACT_ERRNO".to_string(),
+                errno_ret: Some(libc::ENOSYS as u32),
+                args: vec![],
+            }],
+        };
+        assert!(
+            filter_from_oci(&config_enosys).is_ok(),
+            "errnoRet=ENOSYS should compile"
+        );
+
+        // SCMP_ACT_ENOSYS (no errnoRet field) should also compile.
+        let config_act_enosys = crate::oci::OciSeccomp {
+            default_action: "SCMP_ACT_ALLOW".to_string(),
+            default_errno_ret: None,
+            architectures: vec![],
+            syscalls: vec![crate::oci::OciSyscallRule {
+                names: vec!["personality".to_string()],
+                action: "SCMP_ACT_ENOSYS".to_string(),
+                errno_ret: None,
+                args: vec![],
+            }],
+        };
+        assert!(
+            filter_from_oci(&config_act_enosys).is_ok(),
+            "SCMP_ACT_ENOSYS should compile"
+        );
+    }
+
+    #[test]
     fn test_docker_filter_blocks_io_uring_syscalls() {
         // docker_default_filter must include io_uring in its blocked list.
         // We verify this by checking that syscall_number succeeds for all three
@@ -1246,10 +1288,12 @@ mod tests {
         // AF_NETLINK = 16.
         let config = crate::oci::OciSeccomp {
             default_action: "SCMP_ACT_ALLOW".to_string(),
+            default_errno_ret: None,
             architectures: vec![],
             syscalls: vec![crate::oci::OciSyscallRule {
                 names: vec!["socket".to_string()],
                 action: "SCMP_ACT_ERRNO".to_string(),
+                errno_ret: None,
                 args: vec![crate::oci::OciSyscallArg {
                     index: 0,
                     value: 16, // AF_NETLINK
@@ -1271,10 +1315,12 @@ mod tests {
         // Verify SCMP_CMP_MASKED_EQ compiles: value=mask, value_two=expected result.
         let config = crate::oci::OciSeccomp {
             default_action: "SCMP_ACT_ALLOW".to_string(),
+            default_errno_ret: None,
             architectures: vec![],
             syscalls: vec![crate::oci::OciSyscallRule {
                 names: vec!["mmap".to_string()],
                 action: "SCMP_ACT_ERRNO".to_string(),
+                errno_ret: None,
                 args: vec![crate::oci::OciSyscallArg {
                     index: 3,
                     value: 0x0f, // mask: lower 4 bits

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5766,10 +5766,12 @@ int main(void) {
         // Build seccomp filter: allow everything except socket(AF_NETLINK=16, ...).
         let oci_seccomp = pelagos::oci::OciSeccomp {
             default_action: "SCMP_ACT_ALLOW".to_string(),
+            default_errno_ret: None,
             architectures: vec![],
             syscalls: vec![pelagos::oci::OciSyscallRule {
                 names: vec!["socket".to_string()],
                 action: "SCMP_ACT_ERRNO".to_string(),
+                errno_ret: None,
                 args: vec![pelagos::oci::OciSyscallArg {
                     index: 0,
                     value: 16, // AF_NETLINK
@@ -5940,10 +5942,12 @@ int main(void) {
         // Block socket when arg[0] != AF_INET(2): INET allowed, INET6/NETLINK blocked.
         let ne_filter = pelagos::seccomp::filter_from_oci(&pelagos::oci::OciSeccomp {
             default_action: "SCMP_ACT_ALLOW".to_string(),
+            default_errno_ret: None,
             architectures: vec![],
             syscalls: vec![pelagos::oci::OciSyscallRule {
                 names: vec!["socket".to_string()],
                 action: "SCMP_ACT_ERRNO".to_string(),
+                errno_ret: None,
                 args: vec![pelagos::oci::OciSyscallArg {
                     index: 0,
                     value: 2,
@@ -5977,10 +5981,12 @@ int main(void) {
         // SOCK_STREAM|SOCK_NONBLOCK(0x801) → 0x801&0x800=0x800 == 0x800 → blocked.
         let meq_filter = pelagos::seccomp::filter_from_oci(&pelagos::oci::OciSeccomp {
             default_action: "SCMP_ACT_ALLOW".to_string(),
+            default_errno_ret: None,
             architectures: vec![],
             syscalls: vec![pelagos::oci::OciSyscallRule {
                 names: vec!["socket".to_string()],
                 action: "SCMP_ACT_ERRNO".to_string(),
+                errno_ret: None,
                 args: vec![pelagos::oci::OciSyscallArg {
                     index: 1,
                     value: 0x800,
@@ -6013,10 +6019,12 @@ int main(void) {
         // Only exact {AF_INET, SOCK_STREAM} is blocked; SOCK_NONBLOCK variant and INET6 pass.
         let and_filter = pelagos::seccomp::filter_from_oci(&pelagos::oci::OciSeccomp {
             default_action: "SCMP_ACT_ALLOW".to_string(),
+            default_errno_ret: None,
             architectures: vec![],
             syscalls: vec![pelagos::oci::OciSyscallRule {
                 names: vec!["socket".to_string()],
                 action: "SCMP_ACT_ERRNO".to_string(),
+                errno_ret: None,
                 args: vec![
                     pelagos::oci::OciSyscallArg {
                         index: 0,
@@ -6057,11 +6065,13 @@ int main(void) {
         // AF_INET(2) matches neither rule → allowed.
         let or_filter = pelagos::seccomp::filter_from_oci(&pelagos::oci::OciSeccomp {
             default_action: "SCMP_ACT_ALLOW".to_string(),
+            default_errno_ret: None,
             architectures: vec![],
             syscalls: vec![
                 pelagos::oci::OciSyscallRule {
                     names: vec!["socket".to_string()],
                     action: "SCMP_ACT_ERRNO".to_string(),
+                    errno_ret: None,
                     args: vec![pelagos::oci::OciSyscallArg {
                         index: 0,
                         value: 16,
@@ -6072,6 +6082,7 @@ int main(void) {
                 pelagos::oci::OciSyscallRule {
                     names: vec!["socket".to_string()],
                     action: "SCMP_ACT_ERRNO".to_string(),
+                    errno_ret: None,
                     args: vec![pelagos::oci::OciSyscallArg {
                         index: 0,
                         value: 10,
@@ -6095,6 +6106,138 @@ int main(void) {
         assert!(
             or.contains("NETLINK_RAW_FAIL"),
             "OR: NETLINK blocked by rule 1: {or:?}"
+        );
+    }
+
+    /// test_oci_seccomp_errno_ret
+    ///
+    /// Requires: root (no rootfs required — compiles a static binary at test time).
+    ///
+    /// Verifies that `errnoRet` and `SCMP_ACT_ENOSYS` are honoured at the kernel level:
+    ///
+    /// - `SCMP_ACT_ERRNO` with `errnoRet: 38` (ENOSYS) → container gets errno 38, not 1 (EPERM)
+    /// - `SCMP_ACT_ERRNO` without `errnoRet` → container gets errno 1 (EPERM, the default)
+    /// - `SCMP_ACT_ENOSYS` → container gets errno 38 regardless of errnoRet field
+    ///
+    /// Uses `personality(0xffffffff)` as the probe syscall — it's in Docker's blocked list,
+    /// takes a single argument, and requires no special privileges or setup.
+    ///
+    /// Failure indicates that `errnoRet` or `SCMP_ACT_ENOSYS` translation in
+    /// `filter_from_oci` / `oci_action_to_seccomp` is wrong.
+    #[test]
+    fn test_oci_seccomp_errno_ret() {
+        if !is_root() {
+            eprintln!("Skipping test_oci_seccomp_errno_ret: requires root");
+            return;
+        }
+
+        // Probe: call personality(0xffffffff) and print the errno value.
+        // personality() with 0xffffffff queries the current domain without changing it;
+        // when blocked by seccomp it returns -1 with the configured errno.
+        let src = r#"
+#include <sys/personality.h>
+#include <errno.h>
+#include <stdio.h>
+int main(void) {
+    int r = personality(0xffffffffUL);
+    if (r == -1) printf("ERRNO:%d\n", errno);
+    else         printf("OK:%d\n", r);
+    return 0;
+}
+"#;
+        let tmp = tempfile::tempdir().expect("tempdir for seccomp_errno_ret");
+        let src_path = tmp.path().join("probe.c");
+        let bin_path = tmp.path().join("probe");
+        std::fs::write(&src_path, src).expect("write probe.c");
+        let cc_out = std::process::Command::new("cc")
+            .args([
+                "-static",
+                "-o",
+                bin_path.to_str().unwrap(),
+                src_path.to_str().unwrap(),
+            ])
+            .output()
+            .expect("cc");
+        assert!(
+            cc_out.status.success(),
+            "compile: {}",
+            String::from_utf8_lossy(&cc_out.stderr)
+        );
+        let rootfs = tmp.path().join("rootfs");
+        std::fs::create_dir(&rootfs).expect("mkdir rootfs");
+        std::fs::copy(&bin_path, rootfs.join("probe")).expect("cp probe");
+
+        let run_probe = |prog: seccompiler::BpfProgram| -> String {
+            let mut child = Command::new("/probe")
+                .with_chroot(&rootfs)
+                .with_namespaces(Namespace::MOUNT | Namespace::UTS)
+                .stdout(Stdio::Piped)
+                .stderr(Stdio::Null)
+                .with_seccomp_program(prog)
+                .spawn()
+                .expect("spawn");
+            let (_, out, _) = child.wait_with_output().expect("wait");
+            String::from_utf8_lossy(&out).into_owned()
+        };
+
+        // SCMP_ACT_ERRNO with errnoRet:38 → should return ENOSYS (38).
+        let prog_enosys_ret = pelagos::seccomp::filter_from_oci(&pelagos::oci::OciSeccomp {
+            default_action: "SCMP_ACT_ALLOW".to_string(),
+            default_errno_ret: None,
+            architectures: vec![],
+            syscalls: vec![pelagos::oci::OciSyscallRule {
+                names: vec!["personality".to_string()],
+                action: "SCMP_ACT_ERRNO".to_string(),
+                errno_ret: Some(38), // ENOSYS
+                args: vec![],
+            }],
+        })
+        .expect("filter with errnoRet");
+        let out = run_probe(prog_enosys_ret);
+        assert_eq!(
+            out.trim(),
+            "ERRNO:38",
+            "errnoRet:38 should return ENOSYS: got {out:?}"
+        );
+
+        // SCMP_ACT_ERRNO without errnoRet → should return EPERM (1).
+        let prog_eperm = pelagos::seccomp::filter_from_oci(&pelagos::oci::OciSeccomp {
+            default_action: "SCMP_ACT_ALLOW".to_string(),
+            default_errno_ret: None,
+            architectures: vec![],
+            syscalls: vec![pelagos::oci::OciSyscallRule {
+                names: vec!["personality".to_string()],
+                action: "SCMP_ACT_ERRNO".to_string(),
+                errno_ret: None,
+                args: vec![],
+            }],
+        })
+        .expect("filter without errnoRet");
+        let out = run_probe(prog_eperm);
+        assert_eq!(
+            out.trim(),
+            "ERRNO:1",
+            "no errnoRet should return EPERM(1): got {out:?}"
+        );
+
+        // SCMP_ACT_ENOSYS → should return ENOSYS (38) without errnoRet field.
+        let prog_act_enosys = pelagos::seccomp::filter_from_oci(&pelagos::oci::OciSeccomp {
+            default_action: "SCMP_ACT_ALLOW".to_string(),
+            default_errno_ret: None,
+            architectures: vec![],
+            syscalls: vec![pelagos::oci::OciSyscallRule {
+                names: vec!["personality".to_string()],
+                action: "SCMP_ACT_ENOSYS".to_string(),
+                errno_ret: None,
+                args: vec![],
+            }],
+        })
+        .expect("SCMP_ACT_ENOSYS filter");
+        let out = run_probe(prog_act_enosys);
+        assert_eq!(
+            out.trim(),
+            "ERRNO:38",
+            "SCMP_ACT_ENOSYS should return ENOSYS(38): got {out:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- `SCMP_ACT_ERRNO` with `errnoRet: 38` now returns ENOSYS (38) to the container, not EPERM (1)
- `SCMP_ACT_ENOSYS` now correctly returns errno 38 (was incorrectly mapped to EPERM)
- `SCMP_ACT_ERRNO` without `errnoRet` continues to return EPERM (backward-compatible)
- Adds `defaultErrnoRet` support on `OciSeccomp` for the default action errno

## Changes

- `src/oci.rs`: `errno_ret: Option<u32>` on `OciSyscallRule`, `default_errno_ret: Option<u32>` on `OciSeccomp`
- `src/seccomp.rs`: `oci_action_to_seccomp(action, errno_ret)` — ERRNO uses `errno_ret.unwrap_or(EPERM)`, ENOSYS always returns 38

## Tests

New integration test `test_oci_seccomp_errno_ret` verifies all three cases at the kernel level using `personality(0xffffffff)` as the probe syscall.

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)