### PR TITLE
refactor(network): eliminate last ip/nft shell-outs (closes #260, #271)

### DIFF
--- a/ONGOING_TASKS.md
+++ b/ONGOING_TASKS.md
@@ -1,6 +1,54 @@
 # Ongoing Tasks
 
-## Session 2026-05-29 — Issue #269: pelagos stats (feat/stats-269)
+## Session 2026-05-29 — Issue #271: replace remaining ip/nft shell-outs (refactor/native-netlink-271)
+
+### Goal
+
+Eliminate the last four `ip` and one `nft` shell-outs. All are in teardown/cleanup paths.
+
+### Changes
+
+#### `src/netlink.rs`
+
+Add `pub fn netns_del(name: &str) -> io::Result<()>`:
+- `umount2("/run/netns/<name>", MNT_DETACH)` — detach the bind mount
+- `unlink("/run/netns/<name>")` — remove the file
+- Both errors are non-fatal (best-effort); return last error if both fail
+
+#### `src/sandbox.rs`
+
+Replace:
+- `ip link del <veth_host>` → `crate::netlink::link_del(&veth_host)`
+- `ip netns del <ns_name>` → `crate::netlink::netns_del(&state.ns_name)`
+
+#### `src/cli/cleanup.rs`
+
+Replace:
+- `ip netns del <name>` → `pelagos::netlink::netns_del(&name)`
+
+#### `src/cli/network.rs`
+
+Replace:
+- `ip link del <bridge>` → `pelagos::netlink::link_del(&net.bridge_name)`
+- `nft delete table ip <table>` → `pelagos::nfnetlink::nft_delete_ip_table(&table)`
+
+### Test plan
+
+`test_netns_del` unit test: create a netns with `netns_create`, verify the path exists,
+call `netns_del`, verify the path is gone.
+
+Also run the full bridge/NAT integration tests to confirm teardown still works.
+
+### Files to change
+
+1. `src/netlink.rs` — add `netns_del`
+2. `src/sandbox.rs` — 2 replacements
+3. `src/cli/cleanup.rs` — 1 replacement
+4. `src/cli/network.rs` — 2 replacements
+
+---
+
+## Previous: Issue #269: pelagos stats (feat/stats-269)
 
 ### Goal
 

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -4413,3 +4413,27 @@ name on a data row. Cleans up the container after the assertions.
 
 Failure indicates the stats command cannot discover a running container via state files,
 crashes during cgroup probing, or produces output missing expected columns or the container name.
+
+### `test_network_rm_uses_native_netlink`
+**Requires:** root
+**Module:** `native_netlink_teardown`
+
+Creates a named network via `pelagos network create`, then removes it via `pelagos network rm`.
+Verifies the command exits 0 and the config directory is gone. Exercises the `netlink::link_del`
+and `nfnetlink::nft_delete_ip_table` paths that replaced the `ip`/`nft` shell-outs in
+`cmd_network_rm`. Both calls are expected to return non-fatal "not found" errors (no container
+ran on this network, so no bridge or nft table was created); the test confirms the command
+handles those gracefully and still removes the config.
+
+Failure indicates `cmd_network_rm` is crashing on non-fatal link_del/nft errors, or the
+config directory cleanup is broken.
+
+### `test_netns_del_roundtrip`
+**Requires:** root
+**Module:** `native_netlink_teardown`
+
+Calls `netlink::netns_create` then `netlink::netns_del` and asserts the `/run/netns/<name>`
+bind-mount is present after create and absent after del.
+
+Failure indicates `netns_del`'s `umount2(MNT_DETACH)` or `unlink` is broken, or the path
+construction is wrong.

--- a/src/cli/cleanup.rs
+++ b/src/cli/cleanup.rs
@@ -50,27 +50,12 @@ fn cleanup_netns() -> Result<u32, Box<dyn std::error::Error>> {
         if pid_alive(pid) {
             continue;
         }
-        // Use `ip netns del` to properly unmount + remove the entry.
         log::info!("removing stale netns: {}", name);
-        let status = std::process::Command::new("ip")
-            .args(["netns", "del", &name])
-            .status();
-        match status {
-            Ok(s) if s.success() => {
-                count += 1;
-                println!("  removed netns {}", name);
-            }
-            _ => {
-                // Fallback: try direct unmount + unlink.
-                let path = netns_dir.join(&*name);
-                let _ = nix::mount::umount2(&path, nix::mount::MntFlags::MNT_DETACH);
-                if std::fs::remove_file(&path).is_ok() {
-                    count += 1;
-                    println!("  removed netns {} (fallback)", name);
-                } else {
-                    log::warn!("failed to remove stale netns {}", name);
-                }
-            }
+        if pelagos::netlink::netns_del(&name).is_ok() {
+            count += 1;
+            println!("  removed netns {}", name);
+        } else {
+            log::warn!("failed to remove stale netns {}", name);
         }
     }
     Ok(count)

--- a/src/cli/network.rs
+++ b/src/cli/network.rs
@@ -183,25 +183,10 @@ pub fn cmd_network_rm(name: &str) -> Result<(), Box<dyn std::error::Error>> {
     let net = NetworkDef::load(name)?;
 
     // Delete the bridge interface if it exists (non-fatal).
-    let _ = std::process::Command::new("ip")
-        .args(["link", "del", &net.bridge_name])
-        .stderr(std::process::Stdio::null())
-        .status();
+    let _ = pelagos::netlink::link_del(&net.bridge_name);
 
     // Delete the nft table if it exists (non-fatal).
-    let table = net.nft_table_name();
-    let script = format!("delete table ip {}\n", table);
-    let _ = std::process::Command::new("nft")
-        .args(["-f", "-"])
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .and_then(|mut child| {
-            use std::io::Write;
-            child.stdin.as_mut().unwrap().write_all(script.as_bytes())?;
-            child.wait()
-        });
+    pelagos::nfnetlink::nft_delete_ip_table(&net.nft_table_name());
 
     // Remove config dir.
     std::fs::remove_dir_all(&config_dir)?;

--- a/src/netlink.rs
+++ b/src/netlink.rs
@@ -545,6 +545,41 @@ pub fn neigh_add_ipv6(dev: &str, ip: Ipv6Addr, mac: &[u8; 6]) -> io::Result<()> 
 /// Spawns a thread that calls `unshare(CLONE_NEWNET)` and then bind-mounts
 /// `/proc/thread-self/ns/net` onto the file.  Returns Ok if the namespace
 /// already exists.
+/// Delete a named network namespace created by [`netns_create`].
+///
+/// Detaches the bind mount at `/run/netns/<name>` and removes the file.
+/// Both steps are attempted; the first error encountered is returned if
+/// neither succeeds (best-effort teardown).
+pub fn netns_del(name: &str) -> io::Result<()> {
+    let path = format!("/run/netns/{name}");
+    let cpath = CString::new(path.as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "netns name contains NUL"))?;
+
+    let umount_err = unsafe {
+        let ret = libc::umount2(cpath.as_ptr(), libc::MNT_DETACH);
+        if ret < 0 {
+            Some(io::Error::last_os_error())
+        } else {
+            None
+        }
+    };
+
+    let unlink_err = unsafe {
+        let ret = libc::unlink(cpath.as_ptr());
+        if ret < 0 {
+            Some(io::Error::last_os_error())
+        } else {
+            None
+        }
+    };
+
+    match (umount_err, unlink_err) {
+        (_, None) => Ok(()),
+        (None, Some(e)) => Err(e),
+        (Some(e), Some(_)) => Err(e),
+    }
+}
+
 pub fn netns_create(name: &str) -> io::Result<()> {
     let path = format!("/run/netns/{name}");
     std::fs::create_dir_all("/run/netns")?;
@@ -658,6 +693,26 @@ mod tests {
         assert_eq!(&b.0[16..18], &(8u16).to_le_bytes());
         assert_eq!(&b.0[18..20], &IFA_LOCAL.to_le_bytes());
         assert_eq!(&b.0[20..24], &data);
+    }
+
+    /// Verify netns_create + netns_del round-trip: path must exist after create,
+    /// be gone after del.  Requires root (bind-mount needs CAP_SYS_ADMIN).
+    #[test]
+    fn test_netns_create_del_roundtrip() {
+        if unsafe { libc::getuid() } != 0 {
+            return;
+        }
+        let name = format!("pelagos-test-ns-{}", unsafe { libc::getpid() });
+        netns_create(&name).expect("netns_create");
+        assert!(
+            std::path::Path::new(&format!("/run/netns/{name}")).exists(),
+            "netns path must exist after create"
+        );
+        netns_del(&name).expect("netns_del");
+        assert!(
+            !std::path::Path::new(&format!("/run/netns/{name}")).exists(),
+            "netns path must be gone after del"
+        );
     }
 
     #[test]

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -271,12 +271,8 @@ pub fn remove_sandbox(id: &str) -> io::Result<()> {
     // Tear down the network namespace.
     let veth_host = state.veth_host.clone();
     // Best-effort: ignore errors (veth may already be gone if container died).
-    let _ = std::process::Command::new("ip")
-        .args(["link", "del", &veth_host])
-        .status();
-    let _ = std::process::Command::new("ip")
-        .args(["netns", "del", &state.ns_name])
-        .status();
+    let _ = crate::netlink::link_del(&veth_host);
+    let _ = crate::netlink::netns_del(&state.ns_name);
 
     // Remove the state directory.
     let dir = crate::paths::sandbox_dir(id);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -24250,3 +24250,80 @@ mod nfnetlink_native {
         );
     }
 }
+
+mod native_netlink_teardown {
+    use super::*;
+
+    /// `pelagos network rm` must remove the network config dir via `cmd_network_rm`,
+    /// which now calls `netlink::link_del` + `nfnetlink::nft_delete_ip_table` instead
+    /// of shelling out to `ip` / `nft`.
+    ///
+    /// Requires root (writes to /var/lib/pelagos/networks/).
+    /// Creates a named network config (no bridge/nft rules, since no container ran on it),
+    /// then calls `pelagos network rm` via the CLI binary and asserts the config dir is gone.
+    /// Both `link_del` and `nft_delete_ip_table` are expected to return non-fatal "not found"
+    /// errors for a network that was never activated; the test verifies the command still
+    /// exits 0 and cleans up the config directory.
+    #[test]
+    #[serial(nat)]
+    fn test_network_rm_uses_native_netlink() {
+        if !is_root() {
+            eprintln!("Skipping test_network_rm_uses_native_netlink: requires root");
+            return;
+        }
+        let name = "nl-rm-test";
+        let config_dir = pelagos::paths::network_config_dir(name);
+        // Clean up any leftover state.
+        let _ = std::fs::remove_dir_all(&config_dir);
+
+        // Create the network via CLI.
+        let create = std::process::Command::new(env!("CARGO_BIN_EXE_pelagos"))
+            .args(["network", "create", name, "--subnet", "10.239.7.0/24"])
+            .output()
+            .expect("pelagos network create");
+        assert!(
+            create.status.success(),
+            "network create failed: {}",
+            String::from_utf8_lossy(&create.stderr)
+        );
+        assert!(config_dir.exists(), "config dir should exist after create");
+
+        // Remove via CLI — exercises link_del + nft_delete_ip_table.
+        let rm = std::process::Command::new(env!("CARGO_BIN_EXE_pelagos"))
+            .args(["network", "rm", name])
+            .output()
+            .expect("pelagos network rm");
+        assert!(
+            rm.status.success(),
+            "network rm failed: {}",
+            String::from_utf8_lossy(&rm.stderr)
+        );
+        assert!(
+            !config_dir.exists(),
+            "config dir should be gone after network rm"
+        );
+    }
+
+    /// `netlink::netns_del` round-trip via the library: create a named netns with
+    /// `netns_create`, verify the bind-mount exists, call `netns_del`, verify it is gone.
+    ///
+    /// Requires root (bind-mount needs CAP_SYS_ADMIN).
+    #[test]
+    fn test_netns_del_roundtrip() {
+        if !is_root() {
+            eprintln!("Skipping test_netns_del_roundtrip: requires root");
+            return;
+        }
+        let name = format!("pelagos-itns-{}", std::process::id());
+        pelagos::netlink::netns_create(&name).expect("netns_create");
+        assert!(
+            std::path::Path::new(&format!("/run/netns/{name}")).exists(),
+            "netns path should exist after create"
+        );
+        pelagos::netlink::netns_del(&name).expect("netns_del");
+        assert!(
+            !std::path::Path::new(&format!("/run/netns/{name}")).exists(),
+            "netns path should be gone after del"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `ip` and `nft` are no longer exec'd anywhere in Pelagos (outside intentional external processes like `pasta`)
- Adds `netlink::netns_del` — the only new function needed; inverse of `netns_create`
- Replaces 4 `ip` and 1 `nft` invocations all in teardown/cleanup paths

| Before | After |
|---|---|
| `ip link del <veth>` in sandbox.rs | `netlink::link_del` |
| `ip netns del <ns>` in sandbox.rs | `netlink::netns_del` |
| `ip netns del <ns>` in cli/cleanup.rs | `netlink::netns_del` |
| `ip link del <bridge>` in cli/network.rs | `netlink::link_del` |
| `nft delete table ip <t>` in cli/network.rs | `nfnetlink::nft_delete_ip_table` |

## Test plan

- [x] `test_netns_create_del_roundtrip` unit test (root): create → verify exists → del → verify gone
- [x] `networking::test_bridge_network_*` (3 tests) — teardown still works
- [x] `sandbox::test_sandbox_*` (4 tests) — sandbox netns/veth teardown still works
- [x] `cargo test --lib` (364/364 pass)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)