### PR TITLE
fix(wasm): route embedded Wasm stdout/stderr to pipes in detached mode (#153)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -2971,6 +2971,20 @@ Failure indicates the P2 / Component Model execution path is broken: the
 functioning correctly.  This test verifies the full component execution round-trip
 (component detection → P2 linker → WASI Command world → exit code 0).
 
+### `wasm_embedded_tests::test_wasm_embedded_piped_stdout`
+**Type:** Unit, requires `--features embedded-wasm`
+**Root:** no  **Rootfs:** no
+
+Creates an OS pipe with `libc::pipe2`, passes the write-end as the `stdout`
+`Option<std::fs::File>` to `run_embedded_module`, and reads the read-end after
+the module exits.  The WAT module writes `"hello wasm\n"` to WASI fd 1 via
+`fd_write`, so the captured bytes must match exactly.
+
+Failure indicates the `OutputFile` redirection path in `run_embedded_module` is
+broken: embedded Wasm stdout is inherited from fd 1 instead of being routed to
+the supplied file.  In `--detach` mode fd 1 is `/dev/null`, so all Wasm output
+would be silently discarded.  This is the regression guard for issue #153.
+
 ---
 
 ## Build Regression Tests (`build_regression_tests`)

--- a/src/container.rs
+++ b/src/container.rs
@@ -5185,23 +5185,66 @@ impl Command {
     ) -> Result<Child, Error> {
         // ── Embedded path: in-process wasmtime (no subprocess) ──
         //
-        // wasmtime inherits the process stdio directly via inherit_stdout()/
-        // inherit_stderr() in the WasiCtxBuilder.  Output flows to the pelagos
-        // process's fd 1/2, which is correct: the test shell's $(...) or the
-        // terminal sees it without any relay thread.  take_stdout()/take_stderr()
-        // return None; relay threads in cli/run.rs gracefully no-op on None.
+        // When Stdio::Piped is requested we create OS pipes and pass the write
+        // ends to wasmtime via OutputFile, returning the read ends as
+        // ChildStdout/ChildStderr.  This ensures that in detached mode (where
+        // the watcher's fd 1/2 are redirected to /dev/null) the Wasm module's
+        // output still reaches the log relay threads.
+        //
+        // When Stdio::Inherit (the default), wasmtime inherits the process
+        // stdio directly — the old behaviour, correct for interactive use.
         #[cfg(feature = "embedded-wasm")]
         {
+            use std::os::unix::io::FromRawFd as _;
+
+            // Create a pipe for stdout if Piped was requested.
+            let (stdout_r_fd, stdout_w_file) = if self.stdio_out == Stdio::Piped {
+                let mut fds = [-1i32; 2];
+                unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) };
+                (
+                    Some(fds[0]),
+                    Some(unsafe { std::fs::File::from_raw_fd(fds[1]) }),
+                )
+            } else {
+                (None, None)
+            };
+
+            // Create a pipe for stderr if Piped was requested.
+            let (stderr_r_fd, stderr_w_file) = if self.stdio_err == Stdio::Piped {
+                let mut fds = [-1i32; 2];
+                unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) };
+                (
+                    Some(fds[0]),
+                    Some(unsafe { std::fs::File::from_raw_fd(fds[1]) }),
+                )
+            } else {
+                (None, None)
+            };
+
             let extra_args: Vec<std::ffi::OsString> =
                 self.inner.get_args().map(|a| a.to_owned()).collect();
             let handle = std::thread::spawn(move || {
-                crate::wasm::run_wasm_embedded(&prog_path, &extra_args, &wasi)
+                crate::wasm::run_wasm_embedded(
+                    &prog_path,
+                    &extra_args,
+                    &wasi,
+                    stdout_w_file,
+                    stderr_w_file,
+                )
             });
+
+            let child_stdout = stdout_r_fd.map(|fd| unsafe {
+                std::process::ChildStdout::from(std::os::fd::OwnedFd::from_raw_fd(fd))
+            });
+            let child_stderr = stderr_r_fd.map(|fd| unsafe {
+                std::process::ChildStderr::from(std::os::fd::OwnedFd::from_raw_fd(fd))
+            });
+
             return Ok(Child {
                 inner: ChildInner::Embedded {
                     handle: Some(handle),
-                    stdout: None,
-                    stderr: None,
+                    stdout: child_stdout,
+                    stderr: child_stderr,
                 },
                 cgroup: None,
                 network: None,

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -242,6 +242,10 @@ fn build_wasmedge_cmd(
 /// Only available with `--features embedded-wasm`. Runs synchronously — call
 /// from a dedicated thread when a non-blocking `Child` handle is needed.
 ///
+/// When `stdout`/`stderr` are `Some`, the Wasm module's output is directed to
+/// those files (e.g. the write end of an OS pipe).  When `None`, the module
+/// inherits the process's fd 1/2 directly.
+///
 /// Returns the WASI exit code (0 = success). Panics from the Wasm module are
 /// logged and mapped to exit code 1.
 #[cfg(feature = "embedded-wasm")]
@@ -249,8 +253,10 @@ pub fn run_wasm_embedded(
     program: &Path,
     extra_args: &[std::ffi::OsString],
     wasi: &WasiConfig,
+    stdout: Option<std::fs::File>,
+    stderr: Option<std::fs::File>,
 ) -> i32 {
-    match run_embedded_inner(program, extra_args, wasi) {
+    match run_embedded_inner(program, extra_args, wasi, stdout, stderr) {
         Ok(code) => code,
         Err(e) => {
             log::error!("embedded wasm: {}", e);
@@ -264,18 +270,20 @@ fn run_embedded_inner(
     program: &Path,
     extra_args: &[std::ffi::OsString],
     wasi: &WasiConfig,
+    stdout: Option<std::fs::File>,
+    stderr: Option<std::fs::File>,
 ) -> Result<i32, Box<dyn std::error::Error + Send + Sync>> {
     if is_wasm_component_binary(program).unwrap_or(false) {
         log::info!(
             "embedded wasm: '{}' is a component — using P2 path",
             program.display()
         );
-        run_embedded_component_file(program, extra_args, wasi)
+        run_embedded_component_file(program, extra_args, wasi, stdout, stderr)
     } else {
         use wasmtime::{Engine, Module};
         let engine = Engine::default();
         let module = Module::from_file(&engine, program)?;
-        run_embedded_module(&engine, &module, extra_args, wasi)
+        run_embedded_module(&engine, &module, extra_args, wasi, stdout, stderr)
     }
 }
 
@@ -285,6 +293,8 @@ fn run_embedded_component_file(
     program: &Path,
     extra_args: &[std::ffi::OsString],
     wasi: &WasiConfig,
+    stdout: Option<std::fs::File>,
+    stderr: Option<std::fs::File>,
 ) -> Result<i32, Box<dyn std::error::Error + Send + Sync>> {
     use wasmtime::component::Component;
     use wasmtime::{Config, Engine};
@@ -292,26 +302,48 @@ fn run_embedded_component_file(
     config.wasm_component_model(true);
     let engine = Engine::new(&config)?;
     let component = Component::from_file(&engine, program)?;
-    run_embedded_component(&engine, &component, extra_args, wasi)
+    run_embedded_component(&engine, &component, extra_args, wasi, stdout, stderr)
 }
 
 /// Execute a pre-compiled Wasm module synchronously via embedded wasmtime.
 ///
 /// Exposed as `pub` so integration tests in `tests/` can pass WAT-compiled modules
 /// without going through the filesystem.
+///
+/// When `stdout`/`stderr` are `Some`, the module's output is directed to those
+/// files instead of inheriting the process's fd 1/2.
 #[cfg(feature = "embedded-wasm")]
 pub fn run_embedded_module(
     engine: &wasmtime::Engine,
     module: &wasmtime::Module,
     extra_args: &[std::ffi::OsString],
     wasi: &WasiConfig,
+    stdout: Option<std::fs::File>,
+    stderr: Option<std::fs::File>,
 ) -> Result<i32, Box<dyn std::error::Error + Send + Sync>> {
     use wasmtime::{Linker, Store};
+    use wasmtime_wasi::cli::OutputFile;
     use wasmtime_wasi::p1::{self, WasiP1Ctx};
     use wasmtime_wasi::{DirPerms, FilePerms, WasiCtxBuilder};
 
     let mut builder = WasiCtxBuilder::new();
-    builder.inherit_stdin().inherit_stdout().inherit_stderr();
+    builder.inherit_stdin();
+    match stdout {
+        Some(f) => {
+            builder.stdout(OutputFile::new(f));
+        }
+        None => {
+            builder.inherit_stdout();
+        }
+    }
+    match stderr {
+        Some(f) => {
+            builder.stderr(OutputFile::new(f));
+        }
+        None => {
+            builder.inherit_stderr();
+        }
+    }
 
     for (k, v) in &wasi.env {
         builder.env(k, v);
@@ -365,15 +397,21 @@ pub fn run_embedded_module(
 ///
 /// Exposed as `pub` so integration tests can pass pre-loaded components without
 /// going through the filesystem.
+///
+/// When `stdout`/`stderr` are `Some`, the component's output is directed to those
+/// files instead of inheriting the process's fd 1/2.
 #[cfg(feature = "embedded-wasm")]
 pub fn run_embedded_component(
     engine: &wasmtime::Engine,
     component: &wasmtime::component::Component,
     extra_args: &[std::ffi::OsString],
     wasi: &WasiConfig,
+    stdout: Option<std::fs::File>,
+    stderr: Option<std::fs::File>,
 ) -> Result<i32, Box<dyn std::error::Error + Send + Sync>> {
     use wasmtime::component::Linker;
     use wasmtime::Store;
+    use wasmtime_wasi::cli::OutputFile;
     use wasmtime_wasi::{DirPerms, FilePerms, ResourceTable, WasiCtx, WasiCtxBuilder, WasiView};
 
     struct WasiState {
@@ -391,7 +429,23 @@ pub fn run_embedded_component(
     }
 
     let mut builder = WasiCtxBuilder::new();
-    builder.inherit_stdin().inherit_stdout().inherit_stderr();
+    builder.inherit_stdin();
+    match stdout {
+        Some(f) => {
+            builder.stdout(OutputFile::new(f));
+        }
+        None => {
+            builder.inherit_stdout();
+        }
+    }
+    match stderr {
+        Some(f) => {
+            builder.stderr(OutputFile::new(f));
+        }
+        None => {
+            builder.inherit_stderr();
+        }
+    }
 
     // argv[0] = "module.wasm", then caller-supplied args.
     builder.arg("module.wasm");
@@ -449,7 +503,7 @@ mod embedded_tests {
     fn run_wat(wat: &str) -> i32 {
         let engine = Engine::default();
         let module = Module::new(&engine, wat.as_bytes()).unwrap();
-        run_embedded_module(&engine, &module, &[], &WasiConfig::default()).unwrap()
+        run_embedded_module(&engine, &module, &[], &WasiConfig::default(), None, None).unwrap()
     }
 
     // WASI P1 requires modules to export a `memory` (used by many WASI syscalls).

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -15624,7 +15624,8 @@ mod wasm_embedded_tests {
             (func $_start i32.const 7 call $proc_exit)
             (export "_start" (func $_start)))"#;
         let module = Module::new(&engine, wat.as_bytes()).unwrap();
-        let code = run_embedded_module(&engine, &module, &[], &WasiConfig::default()).unwrap();
+        let code =
+            run_embedded_module(&engine, &module, &[], &WasiConfig::default(), None, None).unwrap();
         assert_eq!(code, 7, "embedded wasm should return exit code 7");
     }
 
@@ -15718,8 +15719,74 @@ mod wasm_embedded_tests {
         let engine = Engine::new(&config).unwrap();
         let component = Component::from_file(&engine, &wasm_path).unwrap();
         let code =
-            run_embedded_component(&engine, &component, &[], &WasiConfig::default()).unwrap();
+            run_embedded_component(&engine, &component, &[], &WasiConfig::default(), None, None)
+                .unwrap();
         assert_eq!(code, 0, "component should exit with code 0");
+    }
+
+    /// test_wasm_embedded_piped_stdout
+    ///
+    /// Requires: --features embedded-wasm
+    /// Root: no   Rootfs: no
+    ///
+    /// Verifies that `run_embedded_module` routes stdout to the supplied
+    /// `std::fs::File` (write-end of an OS pipe) rather than inheriting the
+    /// process's fd 1.  Creates a pipe, passes the write-end as `stdout`, reads
+    /// from the read-end, and asserts that the module's `fd_write` output arrives.
+    ///
+    /// Failure means the `OutputFile` redirection path is broken — embedded Wasm
+    /// output would be lost when containers run in `--detach` mode (issue #153).
+    #[test]
+    fn test_wasm_embedded_piped_stdout() {
+        use std::io::Read as _;
+        use std::os::unix::io::FromRawFd;
+
+        let engine = wasmtime::Engine::default();
+        // Minimal WAT: writes "hello wasm\n" to stdout (fd 1) then exits 0.
+        let wat = r#"(module
+            (import "wasi_snapshot_preview1" "fd_write"
+                (func $fd_write (param i32 i32 i32 i32) (result i32)))
+            (import "wasi_snapshot_preview1" "proc_exit"
+                (func $proc_exit (param i32)))
+            (memory 1)
+            (export "memory" (memory 0))
+            (data (i32.const 16) "hello wasm\n")
+            (func $_start
+                ;; iovec at offset 0: ptr=16, len=11
+                (i32.store (i32.const 0) (i32.const 16))
+                (i32.store (i32.const 4) (i32.const 11))
+                ;; fd_write(1, iovec_ptr=0, iovec_count=1, nwritten_ptr=8)
+                (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 8)))
+                (call $proc_exit (i32.const 0)))
+            (export "_start" (func $_start)))"#;
+        let module = wasmtime::Module::new(&engine, wat.as_bytes()).unwrap();
+
+        // Create an OS pipe; give the write-end to the module.
+        let mut pipe_fds = [-1i32; 2];
+        let rc = unsafe { libc::pipe2(pipe_fds.as_mut_ptr(), libc::O_CLOEXEC) };
+        assert_eq!(rc, 0, "pipe2 failed");
+        let (read_fd, write_fd) = (pipe_fds[0], pipe_fds[1]);
+        let write_file = unsafe { std::fs::File::from_raw_fd(write_fd) };
+
+        let code = run_embedded_module(
+            &engine,
+            &module,
+            &[],
+            &WasiConfig::default(),
+            Some(write_file),
+            None,
+        )
+        .unwrap();
+        assert_eq!(code, 0, "module should exit 0");
+
+        // Read-end: close write half (already moved) then drain.
+        let mut read_file = unsafe { std::fs::File::from_raw_fd(read_fd) };
+        let mut got = String::new();
+        read_file.read_to_string(&mut got).unwrap();
+        assert_eq!(
+            got, "hello wasm\n",
+            "module stdout should be captured via pipe"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `stdout: Option<std::fs::File>` and `stderr: Option<std::fs::File>` params to `run_wasm_embedded`, `run_embedded_module`, and `run_embedded_component`
- In `spawn_wasm_impl`, create OS pipes when `Stdio::Piped` is requested and pass write-ends to the wasmtime thread; read-ends are returned as `ChildStdout`/`ChildStderr`
- When `Some`, redirect via `wasmtime_wasi::cli::OutputFile`; when `None`, inherit fd 1/2 as before

## Test plan
- [x] `cargo test --lib` — 349/349 pass
- [x] `sudo -E cargo test --test integration_tests --features embedded-wasm wasm_embedded` — 4/4 pass
- [x] New test `test_wasm_embedded_piped_stdout`: creates a real OS pipe, runs a WAT module that writes `"hello wasm\n"`, asserts captured bytes match
- [x] `cargo clippy --features embedded-wasm -- -D warnings` — clean
- [x] `cargo fmt` — no diffs

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)