### PR TITLE
test(wasm): add e2e --detach stdout test for embedded Wasm (issue #153)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -2926,6 +2926,59 @@ the identity form.
 Constructs a `WasiConfig` with two env vars and asserts both appear as
 `--env KEY=val` in the wasmtime command args.
 
+## E2E Embedded Wasm Tests (`scripts/test-wasm-embedded-e2e.sh`)
+
+Shell-level end-to-end tests that drive the `pelagos` CLI with a real embedded
+Wasm module (no external wasmtime/wasmedge in PATH). Require root and the
+`wasm32-wasip1` Rust target; skip automatically if either is absent.
+
+Run with:
+```
+sudo -E scripts/test-wasm-embedded-e2e.sh
+```
+
+### `1. run — basic output (embedded path)`
+**Type:** E2E, requires root + `--features embedded-wasm` + `wasm32-wasip1`
+
+Builds a Wasm image from `scripts/wasm-embedded-context/hello.rs`, strips
+wasmtime/wasmedge from PATH, and runs `pelagos run <image>`.  Asserts output
+contains `hello embedded wasm`.  Failure means the embedded execution path isn't
+activating or the module is silently erroring.
+
+### `2. run — env passthrough`
+**Type:** E2E, requires root + embedded-wasm
+
+Runs the same image with `--env EMBED_VAR=hello42`.  Asserts `env:EMBED_VAR=hello42`
+appears in output.  Failure means `WasiConfig.env` is not wired into the
+embedded `WasiCtxBuilder`.
+
+### `3. run — preopened directory (--bind)`
+**Type:** E2E, requires root + embedded-wasm
+
+Creates a host directory with `test.txt` and runs with `--bind <host>:/data`.
+Asserts `file:embed test` in output.  Failure means `WasiCtxBuilder`
+preopened-dir setup is broken for the embedded path.
+
+### `4–6. Component Model (wasm32-wasip2) — basic output, env, bind`
+**Type:** E2E, requires root + embedded-wasm + `wasm32-wasip2` (skipped if absent)
+
+Same three checks for a P2 Component Model binary compiled to `wasm32-wasip2`.
+Verifies the `run_embedded_component` P2 path works end-to-end.
+
+### `7. run --detach — stdout captured via pelagos logs (issue #153)`
+**Type:** E2E, requires root + embedded-wasm
+
+Runs the Wasm image with `--detach`, polls until the container exits, then
+reads output via `pelagos logs`.  Asserts `hello embedded wasm` is present.
+
+This is the direct regression guard for issue #153: in `--detach` mode the
+watcher process inherits fd 1/2 pointing at `/dev/null`, so without the fix
+all Wasm module output is silently discarded.  The fix pipes wasmtime stdout
+through an OS pipe to the container log file; this test confirms it works
+end-to-end through the CLI.
+
+---
+
 ### `wasm_embedded_tests::test_wasm_embedded_exit_code`
 **Type:** Unit, requires `--features embedded-wasm`
 **Root:** no  **Rootfs:** no

--- a/scripts/test-wasm-embedded-e2e.sh
+++ b/scripts/test-wasm-embedded-e2e.sh
@@ -325,6 +325,38 @@ REMEOF
     fi
 fi
 
+# ── Test 7: --detach stdout captured via pelagos logs (issue #153) ───────────
+#
+# In --detach mode the watcher's fd 1/2 are /dev/null; without the fix the
+# embedded Wasm module's output would be silently discarded.  The fix pipes
+# wasmtime's stdout through an OS pipe → log file so `pelagos logs` retrieves it.
+
+echo ""
+echo "--- 7. pelagos run --detach — stdout captured via pelagos logs (issue #153) ---"
+
+DETACH_NAME="wasm-e2e-detach-$$"
+"$BINARY" rm -f "$DETACH_NAME" 2>/dev/null || true
+
+"$BINARY" run --detach --name "$DETACH_NAME" "$TEST_IMAGE_REF" >/dev/null 2>&1
+DETACH_RC=$?
+
+if [ "$DETACH_RC" -ne 0 ]; then
+    fail "run --detach: pelagos exited with code $DETACH_RC"
+else
+    # Poll until the container is no longer running (embedded Wasm exits fast).
+    for _i in $(seq 1 40); do
+        STATUS=$("$BINARY" ps 2>/dev/null | awk -v n="$DETACH_NAME" '$1==n {print $2}')
+        [ "$STATUS" = "running" ] || break
+        sleep 0.25
+    done
+
+    DETACH_LOGS=$("$BINARY" logs "$DETACH_NAME" 2>&1)
+    check_contains "$DETACH_LOGS" "hello embedded wasm" \
+        "run --detach: Wasm stdout captured in log file (issue #153)"
+
+    "$BINARY" rm -f "$DETACH_NAME" 2>/dev/null || true
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 
 export PATH="$ORIG_PATH"


### PR DESCRIPTION
## Summary
- Add test 7 to `scripts/test-wasm-embedded-e2e.sh`: runs the embedded Wasm image with `--detach`, polls until the container exits, reads `pelagos logs`, asserts `hello embedded wasm` is present
- Document the full embedded e2e test suite in `docs/INTEGRATION_TESTS.md` (previously undocumented)

## Why
The unit test (`test_wasm_embedded_piped_stdout`) verifies `run_embedded_module` routes output to a supplied file. This e2e test covers the path above it: `pelagos run --detach` → `spawn_wasm_impl` pipe creation → log file → `pelagos logs`. A regression in that wiring would only be caught here.

## Test plan
- [x] `sudo -E bash scripts/test-wasm-embedded-e2e.sh` — 9 passed, 0 failed (test 7 PASS)
- [x] `cargo test --lib` — clean

Closes #153 (follow-up coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)