### PR TITLE
chore(ci): build and release pelagos-cri binary alongside pelagos (#283)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y nftables iproute2 passt
+          sudo apt-get install -y nftables iproute2 passt protobuf-compiler
       - name: Build
         run: cargo build -p pelagos -p pelagos-dockerd -p pelagos-cri
       - name: Build rootfs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,15 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y nftables iproute2 passt protobuf-compiler
+          sudo apt-get install -y nftables iproute2 passt
+      - name: Install protoc (>=23 for debug_redact support)
+        run: |
+          PROTOC_VERSION=25.3
+          ARCH=$(dpkg --print-architecture)
+          case "$ARCH" in amd64) PA=x86_64 ;; arm64) PA=aarch_64 ;; esac
+          curl -sL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PA}.zip" -o /tmp/protoc.zip
+          sudo unzip -q /tmp/protoc.zip bin/protoc -d /usr/local
+          sudo chmod +x /usr/local/bin/protoc
       - name: Build
         run: cargo build -p pelagos -p pelagos-dockerd -p pelagos-cri
       - name: Build rootfs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y nftables iproute2 passt
       - name: Build
-        run: cargo build -p pelagos -p pelagos-dockerd
+        run: cargo build -p pelagos -p pelagos-dockerd -p pelagos-cri
       - name: Build rootfs
         run: sudo ./scripts/build-rootfs-tarball.sh
       - name: Reset test environment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y nftables iproute2 passt
       - name: Build
-        run: cargo build -p pelagos -p pelagos-dockerd
+        run: cargo build -p pelagos -p pelagos-dockerd -p pelagos-cri
       - name: Build rootfs
         run: sudo ./scripts/build-rootfs-tarball.sh
       - name: Reset test environment
@@ -53,10 +53,12 @@ jobs:
             runner: ubuntu-latest
             artifact: pelagos-x86_64-linux
             dns_artifact: pelagos-dns-x86_64-linux
+            cri_artifact: pelagos-cri-x86_64-linux
           - target: aarch64-unknown-linux-musl
             runner: ubuntu-24.04-arm
             artifact: pelagos-aarch64-linux
             dns_artifact: pelagos-dns-aarch64-linux
+            cri_artifact: pelagos-cri-aarch64-linux
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -73,6 +75,8 @@ jobs:
           sha256sum ${{ matrix.artifact }} > ${{ matrix.artifact }}.sha256
           cp target/${{ matrix.target }}/release/pelagos-dns ${{ matrix.dns_artifact }}
           sha256sum ${{ matrix.dns_artifact }} > ${{ matrix.dns_artifact }}.sha256
+          cp target/${{ matrix.target }}/release/pelagos-cri ${{ matrix.cri_artifact }}
+          sha256sum ${{ matrix.cri_artifact }} > ${{ matrix.cri_artifact }}.sha256
       - name: Verify static binary
         run: |
           file ${{ matrix.artifact }}
@@ -85,6 +89,8 @@ jobs:
             ${{ matrix.artifact }}.sha256
             ${{ matrix.dns_artifact }}
             ${{ matrix.dns_artifact }}.sha256
+            ${{ matrix.cri_artifact }}
+            ${{ matrix.cri_artifact }}.sha256
           generate_release_notes: true
       - name: Upload binary as artifact
         uses: actions/upload-artifact@v4
@@ -96,6 +102,11 @@ jobs:
         with:
           name: ${{ matrix.dns_artifact }}
           path: ${{ matrix.dns_artifact }}
+      - name: Upload pelagos-cri as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.cri_artifact }}
+          path: ${{ matrix.cri_artifact }}
 
   package:
     needs: [build]
@@ -122,6 +133,16 @@ jobs:
         with:
           name: pelagos-dns-aarch64-linux
           path: dist/arm64
+      - name: Download x86_64 pelagos-cri binary
+        uses: actions/download-artifact@v4
+        with:
+          name: pelagos-cri-x86_64-linux
+          path: dist/amd64
+      - name: Download aarch64 pelagos-cri binary
+        uses: actions/download-artifact@v4
+        with:
+          name: pelagos-cri-aarch64-linux
+          path: dist/arm64
       - name: Install nfpm
         run: |
           echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' \
@@ -133,15 +154,18 @@ jobs:
           VERSION=${GITHUB_REF_NAME#v}
           mkdir -p dist/packages
 
-          for row in "amd64 pelagos-x86_64-linux pelagos-dns-x86_64-linux" "arm64 pelagos-aarch64-linux pelagos-dns-aarch64-linux"; do
+          for row in "amd64 pelagos-x86_64-linux pelagos-dns-x86_64-linux pelagos-cri-x86_64-linux" "arm64 pelagos-aarch64-linux pelagos-dns-aarch64-linux pelagos-cri-aarch64-linux"; do
             ARCH=$(echo $row | cut -d' ' -f1)
             BINARY_NAME=$(echo $row | cut -d' ' -f2)
             DNS_BINARY_NAME=$(echo $row | cut -d' ' -f3)
+            CRI_BINARY_NAME=$(echo $row | cut -d' ' -f4)
             BINARY="dist/$ARCH/$BINARY_NAME"
             DNS_BINARY="dist/$ARCH/$DNS_BINARY_NAME"
-            chmod +x "$BINARY" "$DNS_BINARY"
+            CRI_BINARY="dist/$ARCH/$CRI_BINARY_NAME"
+            chmod +x "$BINARY" "$DNS_BINARY" "$CRI_BINARY"
             cp "$BINARY" ./pelagos-current
             cp "$DNS_BINARY" ./pelagos-dns-current
+            cp "$CRI_BINARY" ./pelagos-cri-current
 
             ARCH=$ARCH VERSION=$VERSION \
               nfpm package --config pkg/nfpm/nfpm.yaml --packager deb \
@@ -204,6 +228,8 @@ jobs:
         run: |
           test "$(which pelagos)" = "/usr/bin/pelagos"
           pelagos --version
+          test "$(which pelagos-cri)" = "/usr/bin/pelagos-cri"
+          pelagos-cri --version
           test -d /var/lib/pelagos
           test -f /usr/share/pelagos/setup.sh
           test -f /usr/lib/tmpfiles.d/pelagos.conf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y nftables iproute2 passt
+          sudo apt-get install -y nftables iproute2 passt protobuf-compiler
       - name: Build
         run: cargo build -p pelagos -p pelagos-dockerd -p pelagos-cri
       - name: Build rootfs
@@ -66,7 +66,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - name: Install musl toolchain and build deps
-        run: sudo apt-get install -y musl-tools cmake
+        run: sudo apt-get install -y musl-tools cmake protobuf-compiler
       - name: Build release binary (musl static)
         run: cargo build --release --target ${{ matrix.target }}
       - name: Prepare artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,15 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y nftables iproute2 passt protobuf-compiler
+          sudo apt-get install -y nftables iproute2 passt
+      - name: Install protoc (>=23 for debug_redact support)
+        run: |
+          PROTOC_VERSION=25.3
+          ARCH=$(dpkg --print-architecture)
+          case "$ARCH" in amd64) PA=x86_64 ;; arm64) PA=aarch_64 ;; esac
+          curl -sL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PA}.zip" -o /tmp/protoc.zip
+          sudo unzip -q /tmp/protoc.zip bin/protoc -d /usr/local
+          sudo chmod +x /usr/local/bin/protoc
       - name: Build
         run: cargo build -p pelagos -p pelagos-dockerd -p pelagos-cri
       - name: Build rootfs
@@ -66,7 +74,15 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - name: Install musl toolchain and build deps
-        run: sudo apt-get install -y musl-tools cmake protobuf-compiler
+        run: sudo apt-get install -y musl-tools cmake
+      - name: Install protoc (>=23 for debug_redact support)
+        run: |
+          PROTOC_VERSION=25.3
+          ARCH=$(dpkg --print-architecture)
+          case "$ARCH" in amd64) PA=x86_64 ;; arm64) PA=aarch_64 ;; esac
+          curl -sL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PA}.zip" -o /tmp/protoc.zip
+          sudo unzip -q /tmp/protoc.zip bin/protoc -d /usr/local
+          sudo chmod +x /usr/local/bin/protoc
       - name: Build release binary (musl static)
         run: cargo build --release --target ${{ matrix.target }}
       - name: Prepare artifact

--- a/pelagos-cri/src/main.rs
+++ b/pelagos-cri/src/main.rs
@@ -20,7 +20,7 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio_stream::wrappers::UnixListenerStream;
 
 #[derive(Parser)]
-#[clap(name = "pelagos-cri", about = "CRI gRPC server for pelagos")]
+#[clap(name = "pelagos-cri", about = "CRI gRPC server for pelagos", version)]
 struct Args {
     /// Unix socket path to listen on.
     #[clap(long, default_value = "/run/pelagos/cri.sock")]

--- a/pkg/nfpm/nfpm.yaml
+++ b/pkg/nfpm/nfpm.yaml
@@ -30,6 +30,11 @@ contents:
     file_info:
       mode: 0755
 
+  - src: ./pelagos-cri-current
+    dst: /usr/bin/pelagos-cri
+    file_info:
+      mode: 0755
+
   - src: scripts/setup.sh
     dst: /usr/share/pelagos/setup.sh
     file_info:


### PR DESCRIPTION
## Summary
- Add `pelagos-cri` to CI integration-tests build step (catches breakage on every PR)
- Add `pelagos-cri` to release build matrix — produces `pelagos-cri-{x86_64,aarch64}-linux` musl static binaries + sha256 as GitHub release assets
- Include `pelagos-cri` in `.deb`/`.rpm` packages via nfpm (`/usr/bin/pelagos-cri`)
- Add `pelagos-cri --version` check to package-test smoke test
- Add `--version` flag to `pelagos-cri` clap Args (required for the smoke test)

## Before this PR
`pelagos-cri` received fixes (e.g. #280) but was never compiled in CI, never shipped as a release artifact, and was absent from the installable packages. Users had to build from source.

## Test plan
- [x] `cargo test --lib` — 364 pass
- [x] `cargo test -p pelagos-cri` — 6 pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] CI on this PR will exercise the build step with `pelagos-cri` included

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)