### PR TITLE
fix(cri): bind-mount terminationMessagePath and populate ContainerStatus.message

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -355,6 +355,16 @@ This tests the `run.rs` parser path (distinct from `test_bind_mount_ro` which ca
 `:ro`/`:rw` from the mount-target path has regressed, causing the suffix to be treated
 as part of the filesystem path instead of a mount option.
 
+### `test_bind_mount_into_dev`
+**Requires:** root, rootfs
+
+Bind-mounts a host-side temp file at `/dev/termination-log` inside the container, then
+writes to it and reads it back. Also verifies that the written content is visible on the
+host-side file. Guards against the regression where user bind mounts were applied BEFORE
+the `/dev/` tmpfs setup: the tmpfs would cover the bind mount, making `/dev/termination-log`
+appear to not exist. This is the path taken by the Kubernetes CRI kubelet when it passes a
+termination log mount for `terminationMessagePath`.
+
 ### `test_tmpfs_mount`
 **Requires:** root, rootfs
 

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -731,6 +731,21 @@ impl RuntimeService for RuntimeSvc {
             })
             .unwrap_or((None, None));
 
+        // Identify the termination log mount.  Kubelet passes terminationMessagePath
+        // (default /dev/termination-log) as a regular bind mount; after the container
+        // exits we read that host-side file and return it as ContainerStatus.message.
+        let termination_msg_container_path = config
+            .annotations
+            .get("io.kubernetes.container.terminationMessagePath")
+            .map(|s| s.as_str())
+            .unwrap_or("/dev/termination-log");
+        let termination_log_host_path = config
+            .mounts
+            .iter()
+            .find(|m| m.container_path == termination_msg_container_path)
+            .map(|m| m.host_path.clone())
+            .unwrap_or_default();
+
         let container = CriContainer {
             id: id.clone(),
             sandbox_id,
@@ -751,6 +766,7 @@ impl RuntimeService for RuntimeSvc {
             exit_code: 0,
             run_as_user,
             run_as_group,
+            termination_log_host_path,
         };
 
         {
@@ -1019,6 +1035,17 @@ impl RuntimeService for RuntimeSvc {
 
         let cstate = cri_container_state_val(&container.state);
 
+        // Read termination message (up to 4096 bytes per CRI convention).
+        let message = if !container.termination_log_host_path.is_empty() {
+            std::fs::read_to_string(&container.termination_log_host_path)
+                .unwrap_or_default()
+                .chars()
+                .take(4096)
+                .collect()
+        } else {
+            String::new()
+        };
+
         let status = CriContainerStatus {
             id: container.id.clone(),
             metadata: Some(ContainerMetadata {
@@ -1037,7 +1064,7 @@ impl RuntimeService for RuntimeSvc {
             }),
             image_ref: container.image.clone(),
             reason: String::new(),
-            message: String::new(),
+            message,
             labels: container.labels.clone(),
             annotations: container.annotations.clone(),
             mounts: vec![],

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -78,6 +78,10 @@ pub struct CriContainer {
     /// Override GID from pod securityContext.runAsGroup (None = use image default).
     #[serde(default)]
     pub run_as_group: Option<i64>,
+    /// Host-side path of the termination log file (empty when not set).
+    /// Populated from the mount whose container_path matches terminationMessagePath.
+    #[serde(default)]
+    pub termination_log_host_path: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/container.rs
+++ b/src/container.rs
@@ -4152,68 +4152,6 @@ impl Command {
                         }
                     }
 
-                    // Perform bind mounts BEFORE chroot — source paths are host paths,
-                    // unreachable once we chroot.
-                    for bm in &bind_mounts {
-                        use std::os::unix::ffi::OsStrExt as _;
-                        // Target inside the effective root on the host side
-                        let rel = bm.target.strip_prefix("/").unwrap_or(&bm.target);
-                        let host_target = effective_root.join(rel);
-                        // Linux requires the mount target to exist and be the same type
-                        // (file or directory) as the source.
-                        if bm.source.is_dir() {
-                            std::fs::create_dir_all(&host_target).map_err(|e| {
-                                io::Error::other(format!("bind mount mkdir: {}", e))
-                            })?;
-                        } else {
-                            if let Some(parent) = host_target.parent() {
-                                std::fs::create_dir_all(parent).map_err(|e| {
-                                    io::Error::other(format!("bind mount mkdir: {}", e))
-                                })?;
-                            }
-                            if !host_target.exists() {
-                                std::fs::File::create(&host_target).map_err(|e| {
-                                    io::Error::other(format!("bind mount mkfile: {}", e))
-                                })?;
-                            }
-                        }
-                        let src_c = CString::new(bm.source.as_os_str().as_bytes()).unwrap();
-                        let tgt_c = CString::new(host_target.as_os_str().as_bytes()).unwrap();
-                        // Step 1: establish the bind
-                        let r = libc::mount(
-                            src_c.as_ptr(),
-                            tgt_c.as_ptr(),
-                            ptr::null(),
-                            libc::MS_BIND,
-                            ptr::null(),
-                        );
-                        if r != 0 {
-                            return Err(io::Error::other(format!(
-                                "bind mount {} -> {}: {}",
-                                bm.source.display(),
-                                host_target.display(),
-                                io::Error::last_os_error()
-                            )));
-                        }
-                        // Step 2 (if readonly): remount read-only — Linux requires two calls
-                        if bm.readonly {
-                            let r2 = libc::mount(
-                                ptr::null(),
-                                tgt_c.as_ptr(),
-                                ptr::null(),
-                                libc::MS_REMOUNT | libc::MS_BIND | libc::MS_RDONLY,
-                                ptr::null(),
-                            );
-                            if r2 != 0 {
-                                return Err(io::Error::other(format!(
-                                    "bind mount remount ro {}: {}",
-                                    host_target.display(),
-                                    io::Error::last_os_error()
-                                )));
-                            }
-                        }
-                    }
-
                     // Minimal /dev setup BEFORE chroot — host /dev paths still accessible.
                     if mount_dev {
                         use std::os::unix::ffi::OsStrExt as _;
@@ -4380,6 +4318,70 @@ impl Command {
                                     dev.path.display(),
                                     io::Error::last_os_error()
                                 );
+                            }
+                        }
+                    }
+
+                    // Bind mounts run after /dev/ tmpfs setup so that mounts targeting
+                    // /dev/** (e.g. /dev/termination-log) land in the tmpfs rather than
+                    // being covered by it.  Source paths are still host paths here
+                    // (chroot has not happened yet).
+                    for bm in &bind_mounts {
+                        use std::os::unix::ffi::OsStrExt as _;
+                        // Target inside the effective root on the host side
+                        let rel = bm.target.strip_prefix("/").unwrap_or(&bm.target);
+                        let host_target = effective_root.join(rel);
+                        // Linux requires the mount target to exist and be the same type
+                        // (file or directory) as the source.
+                        if bm.source.is_dir() {
+                            std::fs::create_dir_all(&host_target).map_err(|e| {
+                                io::Error::other(format!("bind mount mkdir: {}", e))
+                            })?;
+                        } else {
+                            if let Some(parent) = host_target.parent() {
+                                std::fs::create_dir_all(parent).map_err(|e| {
+                                    io::Error::other(format!("bind mount mkdir: {}", e))
+                                })?;
+                            }
+                            if !host_target.exists() {
+                                std::fs::File::create(&host_target).map_err(|e| {
+                                    io::Error::other(format!("bind mount mkfile: {}", e))
+                                })?;
+                            }
+                        }
+                        let src_c = CString::new(bm.source.as_os_str().as_bytes()).unwrap();
+                        let tgt_c = CString::new(host_target.as_os_str().as_bytes()).unwrap();
+                        // Step 1: establish the bind
+                        let r = libc::mount(
+                            src_c.as_ptr(),
+                            tgt_c.as_ptr(),
+                            ptr::null(),
+                            libc::MS_BIND,
+                            ptr::null(),
+                        );
+                        if r != 0 {
+                            return Err(io::Error::other(format!(
+                                "bind mount {} -> {}: {}",
+                                bm.source.display(),
+                                host_target.display(),
+                                io::Error::last_os_error()
+                            )));
+                        }
+                        // Step 2 (if readonly): remount read-only — Linux requires two calls
+                        if bm.readonly {
+                            let r2 = libc::mount(
+                                ptr::null(),
+                                tgt_c.as_ptr(),
+                                ptr::null(),
+                                libc::MS_REMOUNT | libc::MS_BIND | libc::MS_RDONLY,
+                                ptr::null(),
+                            );
+                            if r2 != 0 {
+                                return Err(io::Error::other(format!(
+                                    "bind mount remount ro {}: {}",
+                                    host_target.display(),
+                                    io::Error::last_os_error()
+                                )));
                             }
                         }
                     }
@@ -6629,63 +6631,6 @@ impl Command {
                         }
                     }
 
-                    // Perform bind mounts BEFORE chroot — source paths are host paths,
-                    // unreachable once we chroot.
-                    for bm in &bind_mounts {
-                        use std::os::unix::ffi::OsStrExt as _;
-                        let rel = bm.target.strip_prefix("/").unwrap_or(&bm.target);
-                        let host_target = effective_root.join(rel);
-                        if bm.source.is_dir() {
-                            std::fs::create_dir_all(&host_target).map_err(|e| {
-                                io::Error::other(format!("bind mount mkdir: {}", e))
-                            })?;
-                        } else {
-                            if let Some(parent) = host_target.parent() {
-                                std::fs::create_dir_all(parent).map_err(|e| {
-                                    io::Error::other(format!("bind mount mkdir: {}", e))
-                                })?;
-                            }
-                            if !host_target.exists() {
-                                std::fs::File::create(&host_target).map_err(|e| {
-                                    io::Error::other(format!("bind mount mkfile: {}", e))
-                                })?;
-                            }
-                        }
-                        let src_c = CString::new(bm.source.as_os_str().as_bytes()).unwrap();
-                        let tgt_c = CString::new(host_target.as_os_str().as_bytes()).unwrap();
-                        let r = libc::mount(
-                            src_c.as_ptr(),
-                            tgt_c.as_ptr(),
-                            ptr::null(),
-                            libc::MS_BIND,
-                            ptr::null(),
-                        );
-                        if r != 0 {
-                            return Err(io::Error::other(format!(
-                                "bind mount {} -> {}: {}",
-                                bm.source.display(),
-                                host_target.display(),
-                                io::Error::last_os_error()
-                            )));
-                        }
-                        if bm.readonly {
-                            let r2 = libc::mount(
-                                ptr::null(),
-                                tgt_c.as_ptr(),
-                                ptr::null(),
-                                libc::MS_REMOUNT | libc::MS_BIND | libc::MS_RDONLY,
-                                ptr::null(),
-                            );
-                            if r2 != 0 {
-                                return Err(io::Error::other(format!(
-                                    "bind mount remount ro {}: {}",
-                                    host_target.display(),
-                                    io::Error::last_os_error()
-                                )));
-                            }
-                        }
-                    }
-
                     // Minimal /dev setup BEFORE chroot — host /dev paths still accessible.
                     if mount_dev {
                         use std::os::unix::ffi::OsStrExt as _;
@@ -6839,6 +6784,65 @@ impl Command {
                                     dev.path.display(),
                                     io::Error::last_os_error()
                                 );
+                            }
+                        }
+                    }
+
+                    // Bind mounts run after /dev/ tmpfs setup so that mounts targeting
+                    // /dev/** (e.g. /dev/termination-log) land in the tmpfs rather than
+                    // being covered by it.  Source paths are still host paths here
+                    // (chroot has not happened yet).
+                    for bm in &bind_mounts {
+                        use std::os::unix::ffi::OsStrExt as _;
+                        let rel = bm.target.strip_prefix("/").unwrap_or(&bm.target);
+                        let host_target = effective_root.join(rel);
+                        if bm.source.is_dir() {
+                            std::fs::create_dir_all(&host_target).map_err(|e| {
+                                io::Error::other(format!("bind mount mkdir: {}", e))
+                            })?;
+                        } else {
+                            if let Some(parent) = host_target.parent() {
+                                std::fs::create_dir_all(parent).map_err(|e| {
+                                    io::Error::other(format!("bind mount mkdir: {}", e))
+                                })?;
+                            }
+                            if !host_target.exists() {
+                                std::fs::File::create(&host_target).map_err(|e| {
+                                    io::Error::other(format!("bind mount mkfile: {}", e))
+                                })?;
+                            }
+                        }
+                        let src_c = CString::new(bm.source.as_os_str().as_bytes()).unwrap();
+                        let tgt_c = CString::new(host_target.as_os_str().as_bytes()).unwrap();
+                        let r = libc::mount(
+                            src_c.as_ptr(),
+                            tgt_c.as_ptr(),
+                            ptr::null(),
+                            libc::MS_BIND,
+                            ptr::null(),
+                        );
+                        if r != 0 {
+                            return Err(io::Error::other(format!(
+                                "bind mount {} -> {}: {}",
+                                bm.source.display(),
+                                host_target.display(),
+                                io::Error::last_os_error()
+                            )));
+                        }
+                        if bm.readonly {
+                            let r2 = libc::mount(
+                                ptr::null(),
+                                tgt_c.as_ptr(),
+                                ptr::null(),
+                                libc::MS_REMOUNT | libc::MS_BIND | libc::MS_RDONLY,
+                                ptr::null(),
+                            );
+                            if r2 != 0 {
+                                return Err(io::Error::other(format!(
+                                    "bind mount remount ro {}: {}",
+                                    host_target.display(),
+                                    io::Error::last_os_error()
+                                )));
                             }
                         }
                     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1747,6 +1747,60 @@ mod filesystem {
         );
     }
 
+    /// test_bind_mount_into_dev
+    ///
+    /// Requires: root, rootfs.
+    ///
+    /// Verifies that a bind mount whose container path is inside /dev/ (e.g.
+    /// /dev/termination-log as used by the Kubernetes CRI) is writable from
+    /// inside the container.  The regression this guards against: user bind
+    /// mounts were applied BEFORE the /dev/ tmpfs setup, so they got covered
+    /// by the tmpfs and became inaccessible (the file appeared to not exist).
+    #[test]
+    fn test_bind_mount_into_dev() {
+        if !is_root() {
+            eprintln!("Skipping test_bind_mount_into_dev: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping test_bind_mount_into_dev: alpine-rootfs not found");
+            return;
+        };
+
+        let host_file = tempfile::NamedTempFile::new().expect("temp file");
+
+        let mut child = Command::new("/bin/ash")
+            .args([
+                "-c",
+                "echo termination-msg > /dev/termination-log && cat /dev/termination-log",
+            ])
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS)
+            .with_chroot(&rootfs)
+            .env("PATH", ALPINE_PATH)
+            .with_bind_mount(host_file.path(), "/dev/termination-log")
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Piped)
+            .stderr(Stdio::Piped)
+            .spawn()
+            .expect("Failed to spawn with /dev bind mount");
+
+        let (status, stdout, _) = child.wait_with_output().expect("Failed to collect output");
+        assert!(status.success(), "Container should exit cleanly");
+        let out = String::from_utf8_lossy(&stdout);
+        assert!(
+            out.contains("termination-msg"),
+            "Write+read to /dev/termination-log should work, got: {:?}",
+            out
+        );
+        // The host-side file should also have the written content.
+        let host_content = std::fs::read_to_string(host_file.path()).expect("read host file");
+        assert!(
+            host_content.contains("termination-msg"),
+            "Host-side file should reflect write, got: {:?}",
+            host_content
+        );
+    }
+
     #[test]
     fn test_tmpfs_mount() {
         if !is_root() {


### PR DESCRIPTION
## Summary

- **Root cause 1 (src/container.rs)**: User bind mounts ran *before* the `/dev/` tmpfs setup in both spawn paths. Any mount targeting `/dev/**` (e.g. `/dev/termination-log`) was immediately covered by the tmpfs and became inaccessible inside the container. Fixed by moving the bind mount loop to *after* the `/dev/` tmpfs + device setup in both spawn paths. Source paths are still host paths at that point (chroot hasn't happened yet), so this is safe.
- **Root cause 2 (pelagos-cri)**: `ContainerStatus.message` was always empty. Fixed by detecting the termination log mount in `create_container` (via `io.kubernetes.container.terminationMessagePath` annotation or the default path `/dev/termination-log`), persisting the host-side path in `CriContainer`, and reading it for `ContainerStatus.message` after exit.
- Added integration test `test_bind_mount_into_dev` that bind-mounts a host file at `/dev/termination-log`, writes to it from the container, and asserts both the container and host-side file contents.

Closes #285, #286.

## Test plan
- [ ] `sudo -E cargo test --test integration_tests test_bind_mount_into_dev`
- [ ] CI passes (lint + unit + integration)
- [ ] klipper-helm pod on k3s no longer fails with "can't create /dev/termination-log: Permission denied"

🤖 Generated with [Claude Code](https://claude.com/claude-code)