### PR TITLE
fix(cri): apply fsGroup supplemental groups and write logs to LogPath

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,6 +2531,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spdystream-rs",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2521,6 +2521,7 @@ name = "pelagos-cri"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "chrono",
  "clap",
  "env_logger",
  "futures-core",

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -4560,3 +4560,28 @@ the same host port (which should fail). Asserts that the failed-spawn container 
 Failure indicates the watcher is not cleaning up the state directory on `cmd.spawn()` error,
 leaving ghost containers with `status=running, pid=0` visible in `pelagos ps` until manually
 removed.
+
+---
+
+## `supplemental_groups` — Supplemental GIDs / fsGroup (#289)
+
+### `test_additional_gids_appear_in_proc_status`
+**Requires:** root, rootfs
+**Module:** `supplemental_groups`
+
+Spawns a container as UID/GID 1000 with `with_additional_gids(&[1337])` and reads
+`/proc/self/status` inside it. Asserts that `1337` appears in the `Groups:` line.
+
+Failure means `setgroups(2)` is not being called in the container pre_exec hook, so
+non-root container processes would fail with `EACCES` when reading files owned by
+a supplemental group (e.g., Kubernetes service account tokens chowned to `root:<fsGroup>:640`).
+
+### `test_multiple_additional_gids`
+**Requires:** root, rootfs
+**Module:** `supplemental_groups`
+
+Spawns a container with three supplemental GIDs (100, 1337, 2000) and asserts all three
+appear in the `Groups:` line of `/proc/self/status`.
+
+Failure indicates that only a subset of supplemental GIDs is being applied, which would
+cause selective permission failures when a workload depends on more than one supplemental group.

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -4585,3 +4585,22 @@ appear in the `Groups:` line of `/proc/self/status`.
 
 Failure indicates that only a subset of supplemental GIDs is being applied, which would
 cause selective permission failures when a workload depends on more than one supplemental group.
+
+---
+
+## `pelagos-cri` unit tests — CRI log relay (#290)
+
+These run via `cargo test -p pelagos-cri` (no root, no rootfs).
+
+### `test_relay_logs_from_dir_e2e`
+**Type:** unit/e2e (no root, no rootfs)
+**Module:** `pelagos-cri::runtime::tests`
+
+Full end-to-end test of the `relay_logs_from_dir` loop. Creates a temp directory
+mimicking a pelagos container dir (`stdout.log`, `stderr.log`, `state.json`).
+Verifies catch-up (line written before the relay starts), streaming (line written
+while the relay is running), stderr tagging, RFC3339 timestamp format, and that
+the relay exits promptly after state.json is set to `"exited"`.
+
+Failure indicates the relay loop is not polling correctly, not writing CRI log
+format, or not terminating on container exit — meaning `kubectl logs` would not work.

--- a/pelagos-cri/Cargo.toml
+++ b/pelagos-cri/Cargo.toml
@@ -27,5 +27,8 @@ spdystream-rs = "0.1.2"
 bytes = "1"
 http = "1"
 
+[dev-dependencies]
+tempfile = "3"
+
 [build-dependencies]
 tonic-build = "0.12"

--- a/pelagos-cri/Cargo.toml
+++ b/pelagos-cri/Cargo.toml
@@ -16,7 +16,8 @@ env_logger = "0.11"
 clap = { version = "3.1.6", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "net", "time", "io-util", "process", "fs", "macros", "signal"] }
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+tokio ={ version = "1", features = ["rt", "rt-multi-thread", "net", "time", "io-util", "process", "fs", "macros", "signal"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = { version = "0.12", features = ["transport"] }
 prost = "0.13"

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -1573,9 +1573,19 @@ async fn relay_container_logs(pelagos_name: String, cri_log_path: String) {
     // Wait for log files to appear (container may take a moment to start writing).
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let stdout_src = format!("/run/pelagos/containers/{}/stdout.log", pelagos_name);
-    let stderr_src = format!("/run/pelagos/containers/{}/stderr.log", pelagos_name);
-    let state_file = format!("/run/pelagos/containers/{}/state.json", pelagos_name);
+    let container_dir = format!("/run/pelagos/containers/{}", pelagos_name);
+    relay_logs_from_dir(container_dir, cri_log_path).await;
+}
+
+/// Core relay loop: polls stdout/stderr log files in `container_dir` and writes
+/// CRI-formatted entries to `cri_log_path` until the container exits.
+///
+/// Separated from `relay_container_logs` so tests can inject a temp directory
+/// instead of the live `/run/pelagos/containers/<name>/` path.
+async fn relay_logs_from_dir(container_dir: String, cri_log_path: String) {
+    let stdout_src = format!("{}/stdout.log", container_dir);
+    let stderr_src = format!("{}/stderr.log", container_dir);
+    let state_file = format!("{}/state.json", container_dir);
 
     // Ensure CRI log parent directory exists.
     if let Some(parent) = std::path::Path::new(&cri_log_path).parent() {
@@ -1705,5 +1715,110 @@ mod tests {
 
         let content = std::fs::read_to_string(&dest_path).unwrap();
         assert!(content.is_empty(), "nothing should be written for empty buf");
+    }
+
+    /// End-to-end test for the relay loop.
+    ///
+    /// Sets up a fake container directory with stdout/stderr log files and a
+    /// state.json, then runs relay_logs_from_dir and verifies:
+    ///   - Lines written before the relay started are captured (catch-up).
+    ///   - Lines appended while the relay is running are captured (streaming).
+    ///   - Each entry has the CRI log format: `{RFC3339Nano} {stream} F {line}`.
+    ///   - The relay exits promptly once state.json shows "exited".
+    ///   - Both stdout and stderr entries appear with the correct stream tag.
+    #[tokio::test]
+    async fn test_relay_logs_from_dir_e2e() {
+        use std::io::Write;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let dir_path = dir.path().to_str().unwrap().to_string();
+
+        // Write the initial state: container is running.
+        let state_path = dir.path().join("state.json");
+        std::fs::write(&state_path, r#"{"status":"running"}"#).unwrap();
+
+        // Pre-write some stdout before the relay starts (catch-up scenario).
+        let stdout_path = dir.path().join("stdout.log");
+        let stderr_path = dir.path().join("stderr.log");
+        std::fs::write(&stdout_path, "line before relay\n").unwrap();
+
+        // CRI log destination.
+        let cri_log = NamedTempFile::new().unwrap();
+        let cri_log_path = cri_log.path().to_str().unwrap().to_string();
+
+        // Spawn the relay; it sleeps 0 ms here because we use relay_logs_from_dir
+        // directly (skipping the 300 ms startup wait in relay_container_logs).
+        let dir_clone = dir_path.clone();
+        let cri_clone = cri_log_path.clone();
+        let relay = tokio::spawn(async move {
+            relay_logs_from_dir(dir_clone, cri_clone).await;
+        });
+
+        // Give the relay time to start and pick up the pre-written line.
+        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+
+        // Append more output while the relay is running.
+        {
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&stdout_path)
+                .unwrap();
+            writeln!(f, "line during relay").unwrap();
+        }
+        {
+            let mut f = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&stderr_path)
+                .unwrap();
+            writeln!(f, "stderr line").unwrap();
+        }
+
+        // Let the relay pick up the new lines.
+        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+
+        // Signal container exit; relay should drain and stop.
+        std::fs::write(&state_path, r#"{"status":"exited"}"#).unwrap();
+
+        // Wait for the relay task with a generous timeout.
+        tokio::time::timeout(std::time::Duration::from_secs(3), relay)
+            .await
+            .expect("relay did not stop within 3 s after container exited")
+            .expect("relay task panicked");
+
+        let content = std::fs::read_to_string(cri_log.path()).unwrap();
+
+        // Every non-empty line must be a valid CRI log entry.
+        let entries: Vec<&str> = content.lines().collect();
+        assert!(!entries.is_empty(), "no CRI log entries written");
+        for entry in &entries {
+            assert!(
+                entry.contains(" stdout F ") || entry.contains(" stderr F "),
+                "entry missing CRI stream tag: {entry}"
+            );
+            // Timestamp must look like RFC3339: starts with a digit and contains 'T'.
+            assert!(
+                entry.chars().next().map(|c| c.is_ascii_digit()).unwrap_or(false)
+                    && entry.contains('T'),
+                "entry missing RFC3339 timestamp: {entry}"
+            );
+        }
+
+        // All three expected payload lines must appear.
+        let payload = |needle: &str| entries.iter().any(|e| e.ends_with(needle));
+        assert!(payload("line before relay"), "catch-up line missing");
+        assert!(payload("line during relay"), "streaming line missing");
+        assert!(payload("stderr line"), "stderr line missing");
+
+        // Stream tags must be correct.
+        assert!(
+            entries.iter().any(|e| e.contains(" stdout F ")),
+            "no stdout entries"
+        );
+        assert!(
+            entries.iter().any(|e| e.contains(" stderr F ")),
+            "no stderr entries"
+        );
     }
 }

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -489,6 +489,13 @@ impl RuntimeService for RuntimeSvc {
             ip,
             cni_conf,
             pause_pid,
+            log_directory: config.log_directory.clone(),
+            supplemental_groups: config
+                .linux
+                .as_ref()
+                .and_then(|l| l.security_context.as_ref())
+                .map(|sc| sc.supplemental_groups.clone())
+                .unwrap_or_default(),
         };
 
         {
@@ -767,6 +774,13 @@ impl RuntimeService for RuntimeSvc {
             run_as_user,
             run_as_group,
             termination_log_host_path,
+            log_path: config.log_path.clone(),
+            supplemental_groups: config
+                .linux
+                .as_ref()
+                .and_then(|l| l.security_context.as_ref())
+                .map(|sc| sc.supplemental_groups.clone())
+                .unwrap_or_default(),
         };
 
         {
@@ -858,6 +872,25 @@ impl RuntimeService for RuntimeSvc {
             }
         }
 
+        // Supplemental groups: merge sandbox-level (fsGroup) and container-level groups.
+        let sandbox_supplemental_groups: Vec<i64> = {
+            let st = self.state.inner.lock().await;
+            st.sandboxes
+                .get(&container.sandbox_id)
+                .map(|s| s.supplemental_groups.clone())
+                .unwrap_or_default()
+        };
+        let mut all_supp_groups: Vec<i64> = sandbox_supplemental_groups;
+        for g in &container.supplemental_groups {
+            if !all_supp_groups.contains(g) {
+                all_supp_groups.push(*g);
+            }
+        }
+        for g in all_supp_groups {
+            args.push("--group-add".into());
+            args.push(g.to_string());
+        }
+
         args.push(image);
         args.extend(effective_entrypoint);
         args.extend(effective_cmd);
@@ -880,11 +913,33 @@ impl RuntimeService for RuntimeSvc {
             )));
         }
 
+        let (log_directory, log_path_rel) = {
+            let st = self.state.inner.lock().await;
+            let log_dir = st
+                .sandboxes
+                .get(&container.sandbox_id)
+                .map(|s| s.log_directory.clone())
+                .unwrap_or_default();
+            let log_rel = st
+                .containers
+                .get(&container_id)
+                .map(|c| c.log_path.clone())
+                .unwrap_or_default();
+            (log_dir, log_rel)
+        };
+
         let mut st = self.state.inner.lock().await;
         if let Some(c) = st.containers.get_mut(&container_id) {
             c.state = MyContainerState::Running;
             c.started_at_ns = now_ns();
             let _ = state::save_container(c);
+        }
+        drop(st);
+
+        if !log_directory.is_empty() && !log_path_rel.is_empty() {
+            let cri_log_path = format!("{}/{}", log_directory, log_path_rel);
+            let pelagos_name = container.pelagos_name.clone();
+            tokio::spawn(relay_container_logs(pelagos_name, cri_log_path));
         }
 
         Ok(Response::new(StartContainerResponse {}))
@@ -1035,6 +1090,16 @@ impl RuntimeService for RuntimeSvc {
 
         let cstate = cri_container_state_val(&container.state);
 
+        let full_log_path = if !container.log_path.is_empty() {
+            st.sandboxes
+                .get(&container.sandbox_id)
+                .filter(|s| !s.log_directory.is_empty())
+                .map(|s| format!("{}/{}", s.log_directory, container.log_path))
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
+
         // Read termination message (up to 4096 bytes per CRI convention).
         let message = if !container.termination_log_host_path.is_empty() {
             std::fs::read_to_string(&container.termination_log_host_path)
@@ -1068,7 +1133,7 @@ impl RuntimeService for RuntimeSvc {
             labels: container.labels.clone(),
             annotations: container.annotations.clone(),
             mounts: vec![],
-            log_path: String::new(),
+            log_path: full_log_path,
             resources: None,
             image_id: container.image.clone(),
             user: None,
@@ -1445,5 +1510,111 @@ impl RuntimeService for RuntimeSvc {
         _request: Request<StreamPodSandboxMetricsRequest>,
     ) -> Result<Response<Self::StreamPodSandboxMetricsStream>, Status> {
         Err(Status::unimplemented("not implemented"))
+    }
+}
+
+// ── CRI log relay ─────────────────────────────────────────────────────────────
+
+/// Format current time as RFC3339 with nanosecond precision for the CRI log format.
+fn cri_now() -> String {
+    chrono::Utc::now()
+        .format("%Y-%m-%dT%H:%M:%S%.9fZ")
+        .to_string()
+}
+
+/// Read bytes from `path` starting at `offset`. Returns `(new_bytes, new_offset)` or `None`.
+async fn read_from_offset(path: &str, offset: u64) -> Option<(Vec<u8>, u64)> {
+    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+    let mut f = tokio::fs::File::open(path).await.ok()?;
+    let size = f.seek(tokio::io::SeekFrom::End(0)).await.ok()?;
+    if size <= offset {
+        return None;
+    }
+    f.seek(tokio::io::SeekFrom::Start(offset)).await.ok()?;
+    let mut buf = Vec::new();
+    f.read_to_end(&mut buf).await.ok()?;
+    let new_offset = offset + buf.len() as u64;
+    Some((buf, new_offset))
+}
+
+/// Write complete lines from `buf` to `dest` in CRI log format; keeps any trailing partial line.
+async fn flush_lines(buf: &mut String, dest: &str, stream: &str) {
+    use tokio::io::AsyncWriteExt;
+    let flush_len = match buf.rfind('\n') {
+        Some(pos) => pos + 1,
+        None => return,
+    };
+    let to_write = buf[..flush_len].to_string();
+    buf.drain(..flush_len);
+
+    let mut out = match tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dest)
+        .await
+    {
+        Ok(f) => f,
+        Err(_) => return,
+    };
+    for line in to_write.lines() {
+        let entry = format!("{} {} F {}\n", cri_now(), stream, line);
+        let _ = out.write_all(entry.as_bytes()).await;
+    }
+}
+
+/// Background task: tail pelagos container log files and write to the CRI log file.
+async fn relay_container_logs(pelagos_name: String, cri_log_path: String) {
+    // Wait for log files to appear (container may take a moment to start writing).
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let stdout_src = format!("/run/pelagos/containers/{}/stdout.log", pelagos_name);
+    let stderr_src = format!("/run/pelagos/containers/{}/stderr.log", pelagos_name);
+    let state_file = format!("/run/pelagos/containers/{}/state.json", pelagos_name);
+
+    // Ensure CRI log parent directory exists.
+    if let Some(parent) = std::path::Path::new(&cri_log_path).parent() {
+        let _ = tokio::fs::create_dir_all(parent).await;
+    }
+
+    let mut stdout_off: u64 = 0;
+    let mut stderr_off: u64 = 0;
+    let mut stdout_buf = String::new();
+    let mut stderr_buf = String::new();
+
+    loop {
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        if let Some((data, new_off)) = read_from_offset(&stdout_src, stdout_off).await {
+            stdout_off = new_off;
+            stdout_buf.push_str(&String::from_utf8_lossy(&data));
+            flush_lines(&mut stdout_buf, &cri_log_path, "stdout").await;
+        }
+
+        if let Some((data, new_off)) = read_from_offset(&stderr_src, stderr_off).await {
+            stderr_off = new_off;
+            stderr_buf.push_str(&String::from_utf8_lossy(&data));
+            flush_lines(&mut stderr_buf, &cri_log_path, "stderr").await;
+        }
+
+        // Stop when the container exits.
+        match tokio::fs::read_to_string(&state_file).await {
+            Ok(data) => {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&data) {
+                    if v["status"].as_str() == Some("exited") {
+                        // Final drain including any partial line.
+                        if !stdout_buf.is_empty() {
+                            stdout_buf.push('\n');
+                            flush_lines(&mut stdout_buf, &cri_log_path, "stdout").await;
+                        }
+                        if !stderr_buf.is_empty() {
+                            stderr_buf.push('\n');
+                            flush_lines(&mut stderr_buf, &cri_log_path, "stderr").await;
+                        }
+                        break;
+                    }
+                }
+            }
+            Err(_) => break, // Container removed.
+        }
     }
 }

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -1539,7 +1539,6 @@ async fn read_from_offset(path: &str, offset: u64) -> Option<(Vec<u8>, u64)> {
 
 /// Write complete lines from `buf` to `dest` in CRI log format; keeps any trailing partial line.
 async fn flush_lines(buf: &mut String, dest: &str, stream: &str) {
-    use tokio::io::AsyncWriteExt;
     let flush_len = match buf.rfind('\n') {
         Some(pos) => pos + 1,
         None => return,
@@ -1547,19 +1546,26 @@ async fn flush_lines(buf: &mut String, dest: &str, stream: &str) {
     let to_write = buf[..flush_len].to_string();
     buf.drain(..flush_len);
 
-    let mut out = match tokio::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(dest)
-        .await
-    {
-        Ok(f) => f,
-        Err(_) => return,
-    };
+    // Build the full output string before the blocking write.
+    let stream = stream.to_string();
+    let mut output = String::new();
     for line in to_write.lines() {
-        let entry = format!("{} {} F {}\n", cri_now(), stream, line);
-        let _ = out.write_all(entry.as_bytes()).await;
+        output.push_str(&format!("{} {} F {}\n", cri_now(), stream, line));
     }
+    if output.is_empty() {
+        return;
+    }
+
+    let dest = dest.to_string();
+    let _ = tokio::task::spawn_blocking(move || {
+        use std::io::Write;
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&dest)
+            .and_then(|mut f| f.write_all(output.as_bytes()))
+    })
+    .await;
 }
 
 /// Background task: tail pelagos container log files and write to the CRI log file.
@@ -1616,5 +1622,88 @@ async fn relay_container_logs(pelagos_name: String, cri_log_path: String) {
             }
             Err(_) => break, // Container removed.
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_cri_now_format() {
+        let ts = cri_now();
+        // Must match RFC3339Nano: 2006-01-02T15:04:05.000000000Z
+        assert!(
+            ts.ends_with('Z'),
+            "timestamp must end with Z: {ts}"
+        );
+        assert!(
+            ts.len() >= 20,
+            "timestamp too short: {ts}"
+        );
+        // Basic date structure: YYYY-MM-DDTHH:MM:SS
+        assert_eq!(&ts[4..5], "-", "year-month separator: {ts}");
+        assert_eq!(&ts[7..8], "-", "month-day separator: {ts}");
+        assert_eq!(&ts[10..11], "T", "date-time separator: {ts}");
+    }
+
+    #[tokio::test]
+    async fn test_flush_lines_complete_lines() {
+        let dest = NamedTempFile::new().unwrap();
+        let dest_path = dest.path().to_str().unwrap().to_string();
+
+        let mut buf = "hello world\nfoo bar\n".to_string();
+        flush_lines(&mut buf, &dest_path, "stdout").await;
+
+        assert!(buf.is_empty(), "complete lines should be flushed: {buf:?}");
+        let content = std::fs::read_to_string(&dest_path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 2, "two log entries expected");
+        assert!(lines[0].contains(" stdout F hello world"), "line: {}", lines[0]);
+        assert!(lines[1].contains(" stdout F foo bar"), "line: {}", lines[1]);
+    }
+
+    #[tokio::test]
+    async fn test_flush_lines_partial_line_retained() {
+        let dest = NamedTempFile::new().unwrap();
+        let dest_path = dest.path().to_str().unwrap().to_string();
+
+        let mut buf = "complete line\npartial".to_string();
+        flush_lines(&mut buf, &dest_path, "stdout").await;
+
+        // "partial" has no trailing newline — must stay in buffer.
+        assert_eq!(buf, "partial", "partial line must be retained: {buf:?}");
+        let content = std::fs::read_to_string(&dest_path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 1, "only the complete line should be written");
+        assert!(lines[0].contains("complete line"));
+    }
+
+    #[tokio::test]
+    async fn test_flush_lines_stderr_tag() {
+        let dest = NamedTempFile::new().unwrap();
+        let dest_path = dest.path().to_str().unwrap().to_string();
+
+        let mut buf = "error output\n".to_string();
+        flush_lines(&mut buf, &dest_path, "stderr").await;
+
+        let content = std::fs::read_to_string(&dest_path).unwrap();
+        assert!(
+            content.contains(" stderr F error output"),
+            "stderr tag expected: {content}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_flush_lines_empty_buf_noop() {
+        let dest = NamedTempFile::new().unwrap();
+        let dest_path = dest.path().to_str().unwrap().to_string();
+
+        let mut buf = String::new();
+        flush_lines(&mut buf, &dest_path, "stdout").await;
+
+        let content = std::fs::read_to_string(&dest_path).unwrap();
+        assert!(content.is_empty(), "nothing should be written for empty buf");
     }
 }

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -34,6 +34,12 @@ pub struct CriSandbox {
     /// PID of the pause process holding IPC/UTS namespaces open (CNI path only).
     #[serde(default)]
     pub pause_pid: i32,
+    /// Sandbox log directory (passed by kubelet for kubectl logs).
+    #[serde(default)]
+    pub log_directory: String,
+    /// Supplemental GIDs from the pod security context (fsGroup etc.).
+    #[serde(default)]
+    pub supplemental_groups: Vec<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -82,6 +88,12 @@ pub struct CriContainer {
     /// Populated from the mount whose container_path matches terminationMessagePath.
     #[serde(default)]
     pub termination_log_host_path: String,
+    /// Log path relative to sandbox log_directory (kubelet-assigned).
+    #[serde(default)]
+    pub log_path: String,
+    /// Supplemental GIDs from the container security context.
+    #[serde(default)]
+    pub supplemental_groups: Vec<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -195,6 +195,11 @@ pub struct RunArgs {
     #[clap(long = "sig-proxy", value_name = "BOOL", hide = true)]
     pub sig_proxy: Option<String>,
 
+    /// Additional supplemental GIDs to add to the container process (repeatable).
+    /// Accepts numeric GIDs only.
+    #[clap(long = "group-add", value_name = "GID")]
+    pub group_add: Vec<u64>,
+
     /// Use a local rootfs instead of an OCI image (advanced)
     #[clap(long)]
     pub rootfs: Option<String>,
@@ -825,6 +830,12 @@ fn apply_cli_options(
         if let Some(g) = gid {
             cmd = cmd.with_gid(g);
         }
+    }
+
+    // Supplemental groups
+    if !args.group_add.is_empty() {
+        let gids: Vec<u32> = args.group_add.iter().map(|&g| g as u32).collect();
+        cmd = cmd.with_additional_gids(&gids);
     }
 
     // Workdir

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -139,6 +139,7 @@ fn spawn_config_to_run_args(
         sysctl: vec![],
         masked_path: vec![],
         dns_backend: None,
+        group_add: vec![],
         rootfs: rootfs_field,
         args,
         label: sc.labels,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -24863,3 +24863,86 @@ mod rm_multi_name_and_stale_state {
         std::thread::sleep(std::time::Duration::from_millis(200));
     }
 }
+
+mod supplemental_groups {
+    use super::*;
+    use pelagos::container::{Command, Namespace, Stdio};
+
+    /// Verify that `with_additional_gids` adds a supplemental GID to the container process.
+    ///
+    /// Requires root (to chroot) and the alpine rootfs.
+    /// Asserts that the GID 1337 appears in `/proc/self/status`'s `Groups:` line,
+    /// which is populated by `setgroups(2)` in pre_exec.
+    /// Failure here means the container process would NOT be able to read files
+    /// owned by that group (e.g., a service account token chowned to root:fsGroup).
+    #[test]
+    fn test_additional_gids_appear_in_proc_status() {
+        if !is_root() {
+            eprintln!("Skipping: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping: alpine-rootfs not found");
+            return;
+        };
+
+        let mut child = Command::new("/bin/ash")
+            .args(["-c", "grep '^Groups:' /proc/self/status"])
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Piped)
+            .stderr(Stdio::Piped)
+            .with_chroot(&rootfs)
+            .env("PATH", ALPINE_PATH)
+            .with_namespaces(Namespace::UTS | Namespace::MOUNT)
+            .with_proc_mount()
+            .with_uid(1000)
+            .with_gid(1000)
+            .with_additional_gids(&[1337])
+            .spawn()
+            .expect("spawn failed");
+
+        let (_status, stdout_bytes, _stderr) = child.wait_with_output().expect("wait failed");
+        let stdout = String::from_utf8_lossy(&stdout_bytes);
+        assert!(
+            stdout.contains("1337"),
+            "GID 1337 not in Groups: line — setgroups not applied.\nOutput: {stdout}"
+        );
+    }
+
+    /// Verify that multiple supplemental GIDs all appear.
+    #[test]
+    fn test_multiple_additional_gids() {
+        if !is_root() {
+            eprintln!("Skipping: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping: alpine-rootfs not found");
+            return;
+        };
+
+        let mut child = Command::new("/bin/ash")
+            .args(["-c", "grep '^Groups:' /proc/self/status"])
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Piped)
+            .stderr(Stdio::Piped)
+            .with_chroot(&rootfs)
+            .env("PATH", ALPINE_PATH)
+            .with_namespaces(Namespace::UTS | Namespace::MOUNT)
+            .with_proc_mount()
+            .with_uid(1000)
+            .with_gid(1000)
+            .with_additional_gids(&[100, 1337, 2000])
+            .spawn()
+            .expect("spawn failed");
+
+        let (_status, stdout_bytes, _stderr) = child.wait_with_output().expect("wait failed");
+        let stdout = String::from_utf8_lossy(&stdout_bytes);
+        for gid in [100u32, 1337, 2000] {
+            assert!(
+                stdout.contains(&gid.to_string()),
+                "GID {gid} not in Groups: line.\nOutput: {stdout}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fixes #289 and #290.

## Summary

- **#289** — `fsGroup` (and any other supplemental GIDs) from the pod/container security context are now merged and passed as `--group-add N` flags to `pelagos run`, so non-root container processes can read service account tokens (kubelet chowns them to `root:<fsGroup>:640`).
- **#290** — Container stdout/stderr are now tailed and written to the kubelet-assigned CRI log path in standard log format, making `kubectl logs` work for all containers.

## Changes

### `src/cli/run.rs` + `src/cli/start.rs`
- New `--group-add GID` flag (repeatable) on `pelagos run`; calls `with_additional_gids()` so GIDs are set via `setgroups(2)` in the container pre_exec hook.

### `pelagos-cri/src/state.rs`
- `CriSandbox`: added `log_directory: String` and `supplemental_groups: Vec<i64>` (both `#[serde(default)]` for backward compat with existing state files).
- `CriContainer`: added `log_path: String` and `supplemental_groups: Vec<i64>`.

### `pelagos-cri/src/runtime.rs`
- `run_pod_sandbox`: captures `config.log_directory` and `linux.security_context.supplemental_groups` → stored in `CriSandbox`.
- `create_container`: captures `config.log_path` and container-level `supplemental_groups` → stored in `CriContainer`.
- `start_container`: merges sandbox + container supplemental groups (fsGroup goes in the sandbox list; container list carries per-container overrides), deduplicates, and appends `--group-add N` for each. After a successful start, spawns `relay_container_logs`.
- `container_status`: returns the real full CRI log path instead of `""`.
- New free functions: `cri_now()`, `read_from_offset()`, `flush_lines()`, `relay_container_logs()` — the relay task polls every 200 ms, writes complete lines in `{RFC3339Nano} {stdout|stderr} F {line}\n` format, and exits when the container's pelagos state shows `"exited"`.

## Test plan

- [ ] Deploy a pod with `spec.securityContext.fsGroup: 1337` and a non-root container user — process should have GID 1337 in its supplemental groups and read the service account token without error.
- [ ] `kubectl logs <any-pod>` returns container output instead of `read .: is a directory`.
- [ ] Verify `cargo clippy -p pelagos -p pelagos-cri -- -D warnings` passes (clean).
- [ ] Verify 364/364 unit tests pass: `cargo test --lib`.
- [ ] Deploy Flux CD controllers — all four should come up without CrashLoopBackOff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)