### PR TITLE
feat(cri): respect namespace_options.pid = NODE for hostPID containers (#299)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -4707,3 +4707,28 @@ using `find_container_pid()` to get the grandchild's host PID.
 
 Failure would indicate the SPIRE-conformant cgroup placement is broken and workload attestation
 would fail because `/proc/<pid>/cgroup` would not match the kubepods hierarchy pattern.
+
+## PID Namespace Mode (`pid_namespace` module)
+
+### `test_isolated_pid_namespace_by_default`
+**Requires:** root, rootfs
+**Module:** `pid_namespace`
+
+Runs `pelagos run --detach /bin/sleep 30` (no `--no-pid-ns`) and reads the grandchild's
+NSpid from `/proc/<container_pid>/status` on the HOST. Asserts that NSpid has exactly two
+entries and the in-namespace PID is 1.
+
+Validates that the default behavior (Namespace::PID included) performs the PID namespace
+double-fork correctly. Failure indicates Namespace::PID is being ignored.
+
+### `test_no_pid_ns_flag_uses_host_pid_namespace`
+**Requires:** root, rootfs
+**Module:** `pid_namespace`
+
+Runs `pelagos run --detach --no-pid-ns /bin/sleep 30`. Without Namespace::PID there is no
+double-fork: `state.pid` IS the container process. Reads `/proc/<state.pid>/status` from the
+host and asserts NSpid has exactly one entry (host namespace only, no isolation).
+
+This is the regression test for issue #299 (hostPID: true / namespace_options.pid = NODE not
+respected). Failure would mean the SPIRE agent cannot attest workloads via SO_PEERCRED because
+the container is in an isolated PID namespace and PID 0 is returned instead of the real PID.

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -516,6 +516,13 @@ impl RuntimeService for RuntimeSvc {
                 .as_ref()
                 .map(|d| d.options.clone())
                 .unwrap_or_default(),
+            pid_namespace_mode: config
+                .linux
+                .as_ref()
+                .and_then(|l| l.security_context.as_ref())
+                .and_then(|sc| sc.namespace_options.as_ref())
+                .map(|no| no.pid)
+                .unwrap_or(0),
         };
 
         {
@@ -911,8 +918,14 @@ impl RuntimeService for RuntimeSvc {
             args.push(g.to_string());
         }
 
-        // DNS config and cgroup placement from the pod sandbox.
-        let (sandbox_dns_servers, sandbox_dns_searches, sandbox_dns_options, sandbox_cgroup_parent) = {
+        // DNS config, cgroup placement, and PID namespace mode from the pod sandbox.
+        let (
+            sandbox_dns_servers,
+            sandbox_dns_searches,
+            sandbox_dns_options,
+            sandbox_cgroup_parent,
+            sandbox_pid_ns_mode,
+        ) = {
             let st = self.state.inner.lock().await;
             st.sandboxes
                 .get(&container.sandbox_id)
@@ -922,6 +935,7 @@ impl RuntimeService for RuntimeSvc {
                         s.dns_searches.clone(),
                         s.dns_options.clone(),
                         s.cgroup_parent.clone(),
+                        s.pid_namespace_mode,
                     )
                 })
                 .unwrap_or_default()
@@ -938,6 +952,12 @@ impl RuntimeService for RuntimeSvc {
             args.push("--dns-option".into());
             args.push(opt.clone());
         }
+        // NODE PID namespace mode (hostPID: true): run in the host PID namespace so
+        // the SPIRE agent can attest workloads via SO_PEERCRED (PID 0 is never returned).
+        if sandbox_pid_ns_mode == 2 {
+            args.push("--no-pid-ns".into());
+        }
+
         // Place the container in the kubelet-assigned cgroup under the pod-level
         // parent so that /proc/<pid>/cgroup encodes the container ID, enabling
         // SPIRE workload attestation and per-container resource accounting.

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -53,6 +53,10 @@ pub struct CriSandbox {
     /// DNS resolver options from the pod DNS config.
     #[serde(default)]
     pub dns_options: Vec<String>,
+    /// PID namespace mode from namespace_options.pid:
+    ///   0 = POD (isolated, default), 1 = CONTAINER (isolated), 2 = NODE (host PID namespace).
+    #[serde(default)]
+    pub pid_namespace_mode: i32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -218,6 +218,10 @@ pub struct SpawnConfig {
     /// tmpfs mounts as "path" or "path:options" strings.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tmpfs: Vec<String>,
+    /// When true, the container runs in the host PID namespace (no CLONE_NEWPID).
+    /// Saved from `--no-pid-ns`; restored by `pelagos start`.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub no_pid_ns: bool,
 }
 
 /// Persisted state for a running or exited container.

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -214,6 +214,12 @@ pub struct RunArgs {
     #[clap(long = "cgroup-path", value_name = "PATH")]
     pub cgroup_path: Option<String>,
 
+    /// Run in the host PID namespace instead of an isolated one (hostPID: true).
+    /// Used by pelagos-cri when namespace_options.pid == NODE (2) so that the
+    /// SPIRE agent can attest workloads via SO_PEERCRED.
+    #[clap(long = "no-pid-ns")]
+    pub no_pid_ns: bool,
+
     /// Use a local rootfs instead of an OCI image (advanced)
     #[clap(long)]
     pub rootfs: Option<String>,
@@ -456,6 +462,7 @@ fn build_spawn_config(args: &RunArgs, rootfs_label: &str, exe_and_args: &[String
         no_nat: args.no_nat,
         labels: args.label.clone(),
         tmpfs: args.tmpfs.clone(),
+        no_pid_ns: args.no_pid_ns,
     }
 }
 
@@ -574,13 +581,18 @@ fn build_image_run(
     let exe = &exe_and_args[0];
     let rest = &exe_and_args[1..];
 
+    let pid_ns = if args.no_pid_ns {
+        Namespace::empty()
+    } else {
+        Namespace::PID
+    };
     let mut cmd = Command::new(exe)
         .args(rest)
         .with_image_layers(layers)
         // Add UTS (hostname isolation) + PID namespace.  Use add_namespaces so
         // we OR into the flags already set by with_image_layers (MOUNT) rather
         // than replacing them.
-        .add_namespaces(Namespace::UTS | Namespace::PID | Namespace::IPC | Namespace::CGROUP);
+        .add_namespaces(Namespace::UTS | pid_ns | Namespace::IPC | Namespace::CGROUP);
 
     // Apply image config environment.  This includes any PATH set by Dockerfile
     // ENV instructions.  apply_cli_options no longer injects a fallback PATH
@@ -647,11 +659,16 @@ fn build_command(
     let exe = &exe_and_args[0];
     let rest = &exe_and_args[1..];
 
+    let pid_ns = if args.no_pid_ns {
+        Namespace::empty()
+    } else {
+        Namespace::PID
+    };
     let mut cmd = Command::new(exe)
         .args(rest)
         .with_chroot(rootfs_dir)
         .with_namespaces(
-            Namespace::UTS | Namespace::MOUNT | Namespace::PID | Namespace::IPC | Namespace::CGROUP,
+            Namespace::UTS | Namespace::MOUNT | pid_ns | Namespace::IPC | Namespace::CGROUP,
         )
         .with_proc_mount()
         .with_dev_mount()

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -118,6 +118,7 @@ fn spawn_config_to_run_args(
         dns_search: sc.dns_search,
         dns_option: sc.dns_options,
         cgroup_path: None,
+        no_pid_ns: sc.no_pid_ns,
         volume: sc.volume,
         bind: sc.bind,
         bind_ro: sc.bind_ro,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -25326,3 +25326,180 @@ mod cgroup_placement {
         );
     }
 }
+
+mod pid_namespace {
+    use super::*;
+
+    /// Verify that a container without --no-pid-ns runs in an isolated PID namespace.
+    /// The container process's NSpid (read from the host) must have exactly two entries:
+    /// the host PID and PID 1 inside the new namespace.  Failure indicates that
+    /// Namespace::PID is being ignored and the container is running in the host PID ns.
+    #[test]
+    fn test_isolated_pid_namespace_by_default() {
+        if !is_root() {
+            eprintln!("Skipping: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping: alpine-rootfs not found");
+            return;
+        };
+
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+        let name = "pelagos-test-isolated-pid-ns";
+
+        let _ = std::process::Command::new(bin)
+            .args(["stop", name])
+            .output();
+        let _ = std::process::Command::new(bin).args(["rm", name]).output();
+
+        let out = std::process::Command::new(bin)
+            .args([
+                "run",
+                "--detach",
+                "--name",
+                name,
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                // No --no-pid-ns: default is isolated PID namespace.
+                "/bin/sleep",
+                "30",
+            ])
+            .output()
+            .expect("pelagos run");
+
+        assert!(
+            out.status.success(),
+            "pelagos run failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        std::thread::sleep(std::time::Duration::from_millis(300));
+
+        let state_path = format!("/run/pelagos/containers/{}/state.json", name);
+        let state_json =
+            std::fs::read_to_string(&state_path).unwrap_or_else(|e| panic!("read state: {e}"));
+        let state: serde_json::Value = serde_json::from_str(&state_json).unwrap();
+        let intermediate_pid = state["pid"].as_i64().expect("pid field") as u32;
+
+        // Find the grandchild (PID 1 in the container's PID namespace).
+        let children_path = format!("/proc/{intermediate_pid}/task/{intermediate_pid}/children");
+        let children = std::fs::read_to_string(&children_path)
+            .unwrap_or_else(|e| panic!("read children: {e}"));
+        let container_pid: u32 = children
+            .split_whitespace()
+            .next()
+            .expect("no grandchild — PID namespace double-fork did not happen?")
+            .parse()
+            .expect("parse container pid");
+
+        // From the HOST's /proc, NSpid has two entries: host_pid and ns_pid (1).
+        let proc_status = std::fs::read_to_string(format!("/proc/{container_pid}/status"))
+            .unwrap_or_else(|e| panic!("read /proc/{container_pid}/status: {e}"));
+
+        let nspid_line = proc_status
+            .lines()
+            .find(|l| l.starts_with("NSpid:"))
+            .expect("NSpid line not found");
+
+        let nspid_values: Vec<&str> = nspid_line.split_whitespace().skip(1).collect();
+
+        // Cleanup before asserting.
+        let _ = std::process::Command::new(bin)
+            .args(["stop", name])
+            .output();
+        let _ = std::process::Command::new(bin).args(["rm", name]).output();
+
+        assert_eq!(
+            nspid_values.len(),
+            2,
+            "isolated PID namespace should produce 2 NSpid entries; got: {nspid_line}"
+        );
+        assert_eq!(
+            nspid_values[1], "1",
+            "container should be PID 1 in its namespace; got: {nspid_line}"
+        );
+    }
+
+    /// Verify that --no-pid-ns runs the container in the host PID namespace.
+    /// The container's /proc/self/status must show exactly one NSpid entry (the host PID),
+    /// meaning no PID namespace isolation is in effect.
+    #[test]
+    fn test_no_pid_ns_flag_uses_host_pid_namespace() {
+        if !is_root() {
+            eprintln!("Skipping: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping: alpine-rootfs not found");
+            return;
+        };
+
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+        let name = "pelagos-test-no-pid-ns";
+
+        // Clean up any leftover from a previous run.
+        let _ = std::process::Command::new(bin)
+            .args(["stop", name])
+            .output();
+        let _ = std::process::Command::new(bin).args(["rm", name]).output();
+
+        let out = std::process::Command::new(bin)
+            .args([
+                "run",
+                "--detach",
+                "--name",
+                name,
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "--no-pid-ns",
+                "/bin/sleep",
+                "30",
+            ])
+            .output()
+            .expect("pelagos run");
+
+        assert!(
+            out.status.success(),
+            "pelagos run failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        std::thread::sleep(std::time::Duration::from_millis(300));
+
+        // Read the container's host PID from the state file.
+        // Without --no-pid-ns, there is no double-fork: state.pid IS the container process.
+        let state_path = format!("/run/pelagos/containers/{}/state.json", name);
+        let state_json =
+            std::fs::read_to_string(&state_path).unwrap_or_else(|e| panic!("read state: {e}"));
+        let state: serde_json::Value = serde_json::from_str(&state_json).unwrap();
+        let container_pid = state["pid"].as_i64().expect("pid field") as u32;
+
+        // Read NSpid from the container's /proc/<host_pid>/status on the HOST.
+        // When running in the host PID namespace, NSpid has exactly one entry.
+        let proc_status = std::fs::read_to_string(format!("/proc/{container_pid}/status"))
+            .unwrap_or_else(|e| panic!("read /proc/{container_pid}/status: {e}"));
+
+        let nspid_line = proc_status
+            .lines()
+            .find(|l| l.starts_with("NSpid:"))
+            .expect("NSpid line not found");
+
+        let nspid_values: Vec<&str> = nspid_line
+            .split_whitespace()
+            .skip(1) // skip "NSpid:"
+            .collect();
+
+        // Cleanup before asserting.
+        let _ = std::process::Command::new(bin)
+            .args(["stop", name])
+            .output();
+        let _ = std::process::Command::new(bin).args(["rm", name]).output();
+
+        assert_eq!(
+            nspid_values.len(),
+            1,
+            "--no-pid-ns should produce exactly 1 NSpid entry (host namespace only); got: {nspid_line}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `--no-pid-ns` flag to `pelagos run` that skips `CLONE_NEWPID`, running the container in the host PID namespace
- `pelagos-cri` extracts `namespace_options.pid` from `RunPodSandboxRequest`, stores it in `CriSandbox.pid_namespace_mode`, and passes `--no-pid-ns` to `start_container` when mode == 2 (NODE / `hostPID: true`)
- Without `Namespace::PID`, there is no double-fork: the container process is a direct child of the watcher, not a grandchild

## Motivation

SPIRE workload attestation requires `hostPID: true` so the SPIRE agent can call `SO_PEERCRED` on workload processes and receive the real host PID. When pelagos-cri ignored `namespace_options.pid`, all containers were placed in isolated PID namespaces and PID 0 was returned instead of the host PID.

Fixes #299.

## Test plan

- [ ] `test_isolated_pid_namespace_by_default` — verifies default (isolated) PID namespace creates a grandchild as PID 1 in the new namespace
- [ ] `test_no_pid_ns_flag_uses_host_pid_namespace` — verifies `--no-pid-ns` produces a container with exactly one NSpid entry (host namespace, no isolation)
- [ ] Full integration suite clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)