### PR TITLE
fix(cri): generate 64-char hex container/sandbox IDs (#301)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -4732,3 +4732,26 @@ host and asserts NSpid has exactly one entry (host namespace only, no isolation)
 This is the regression test for issue #299 (hostPID: true / namespace_options.pid = NODE not
 respected). Failure would mean the SPIRE agent cannot attest workloads via SO_PEERCRED because
 the container is in an isolated PID namespace and PID 0 is returned instead of the real PID.
+
+## CRI Container ID Format (`pelagos-cri` unit tests)
+
+### `test_generate_id_is_64_char_hex`
+**Requires:** nothing (unit test in pelagos-cri)
+**Module:** `runtime::tests`
+
+Calls `generate_id()` and asserts the result is exactly 64 lowercase hex characters.
+This is the de facto standard used by containerd and CRI-O; SPIRE, Fluentd, Fluent Bit,
+OTel, Datadog, and Falco all hardcode `[a-f0-9]{64}` regexes to extract container IDs
+from cgroup paths.
+
+Failure indicates that the ID format regressed back to a shorter form (e.g. 32-char UUID
+simple string) which would silently break workload attestation and log correlation in every
+Kubernetes observability/security tool.
+
+### `test_generate_id_is_unique`
+**Requires:** nothing (unit test in pelagos-cri)
+**Module:** `runtime::tests`
+
+Generates 20 IDs and inserts them into a HashSet, asserting all 20 are distinct.
+Catches obvious bugs such as a zero-initialized RNG or a seeded PRNG that always
+produces the same output.

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -77,6 +77,20 @@ struct PelagosContainerState {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+/// Generate a 64-character lowercase hex container/sandbox ID.
+///
+/// 32 bytes from the OS CSPRNG encoded as hex — identical to the format used
+/// by containerd and CRI-O.  The 64-char length is a de facto standard
+/// hardcoded in SPIRE, Fluentd, Fluent Bit, OTel, Datadog, Falco, and cAdvisor.
+fn generate_id() -> String {
+    use std::io::Read;
+    let mut bytes = [0u8; 32];
+    std::fs::File::open("/dev/urandom")
+        .and_then(|mut f| f.read_exact(&mut bytes))
+        .expect("read /dev/urandom for container ID generation");
+    bytes.map(|b| format!("{:02x}", b)).concat()
+}
+
 fn now_ns() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -384,7 +398,7 @@ impl RuntimeService for RuntimeSvc {
             cni::find_cni_conf()
         {
             // ── CNI path ───────────────────────────────────────────────────
-            let id = uuid::Uuid::new_v4().simple().to_string()[..16].to_string();
+            let id = generate_id();
             let ns_name = format!("pcri-{}", &id[..12]);
 
             let netns_path = cni::create_netns(&ns_name)
@@ -728,7 +742,7 @@ impl RuntimeService for RuntimeSvc {
 
         let image_ref = config.image.map(|s| s.image).unwrap_or_default();
 
-        let id = uuid::Uuid::new_v4().simple().to_string();
+        let id = generate_id();
         let pelagos_name = format!("pcri-{}", &id[..12]);
 
         let envs: Vec<(String, String)> = config
@@ -1927,6 +1941,7 @@ mod tests {
             dns_servers: vec!["10.96.0.10".into()],
             dns_searches: vec!["default.svc.cluster.local".into(), "cluster.local".into()],
             dns_options: vec!["ndots:5".into()],
+            pid_namespace_mode: 0,
         };
 
         let json = serde_json::to_string(&sandbox).expect("serialize");
@@ -1964,6 +1979,7 @@ mod tests {
             dns_servers: vec![],
             dns_searches: vec![],
             dns_options: vec![],
+            pid_namespace_mode: 0,
         };
 
         let json = serde_json::to_string(&sandbox).expect("serialize");
@@ -1994,5 +2010,39 @@ mod tests {
         let container_id = "ctr-xyz";
         let full = format!("{}/{}", stored, container_id);
         assert_eq!(full, "kubepods/besteffort/pod-uid-123/ctr-xyz");
+    }
+
+    /// Verify generate_id() produces a 64-character lowercase hex string.
+    ///
+    /// This is the de facto standard used by containerd and CRI-O.  Tools like SPIRE,
+    /// Fluentd, Fluent Bit, OTel, Datadog, and Falco hardcode `[a-f0-9]{64}` regexes
+    /// to extract container IDs from cgroup paths and log file names.  A 32-char UUID
+    /// simple string would produce zero matches — no workload identity, no log correlation.
+    #[test]
+    fn test_generate_id_is_64_char_hex() {
+        let id = generate_id();
+        assert_eq!(
+            id.len(),
+            64,
+            "container ID must be 64 chars (containerd/CRI-O compat); got {} chars: {}",
+            id.len(),
+            id
+        );
+        assert!(
+            id.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()),
+            "container ID must be lowercase hex; got: {}",
+            id
+        );
+    }
+
+    /// Verify generate_id() produces unique IDs on repeated calls.
+    ///
+    /// Collision probability at 256 bits is negligible, but an obvious bug
+    /// (e.g. seeded PRNG, zero bytes) would produce duplicates.
+    #[test]
+    fn test_generate_id_is_unique() {
+        let ids: std::collections::HashSet<String> = (0..20).map(|_| generate_id()).collect();
+        assert_eq!(ids.len(), 20, "generate_id() produced duplicate IDs");
     }
 }


### PR DESCRIPTION
## Summary

- Replaces `uuid::Uuid::new_v4().simple().to_string()` (32 chars) with 32 bytes from `/dev/urandom` encoded as 64-char lowercase hex — identical to containerd/CRI-O
- The CNI sandbox ID was even worse: `[..16]` was taking only the first 16 chars of a 32-char UUID simple string (16 chars total)
- Adds `generate_id()` helper used at both ID generation sites
- Streaming session tokens (internal, not exposed to Kubernetes) remain as UUIDs

## Why 64 chars matters

SPIRE, Fluentd, Fluent Bit, OTel, Datadog, Falco, and cAdvisor all hardcode `[a-f0-9]{64}` regexes to extract container IDs from cgroup paths and log file names. With 32-char IDs, SPIRE's regex never matches and no workload gets an identity (selectors remain empty, no SVID issued).

Fixes #301.

## Tests

- `test_generate_id_is_64_char_hex` — verifies exact length and character set
- `test_generate_id_is_unique` — verifies 20 consecutive IDs are all distinct
- All 17 pelagos-cri unit tests pass; all 364 pelagos unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)