### PR TITLE
fix(caps): defer capset() to after setuid() — fix EINVAL with --cap-drop ALL --user non-root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos"
-version = "0.65.9"
+version = "0.65.10"
 dependencies = [
  "bitflags 2.11.0",
  "bzip2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ h2 = { path = "vendor/h2" }
 
 [package]
 name = "pelagos"
-version = "0.65.9"
+version = "0.65.10"
 edition = "2021"
 rust-version = "1.76"
 description = "Fast Linux container runtime — OCI-compatible, namespaces, cgroups v2, seccomp, networking, image management"

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -4808,3 +4808,24 @@ If `cgroup_name` is empty in state.json (cgroups unavailable in test environment
 prints a skip message and returns without failing. Failure means `--memory` is not being
 passed through the CRI `LinuxContainerResources.memory_limit_in_bytes` → `--memory` path,
 so kubelet-requested memory limits for Kubernetes pods are silently ignored.
+
+### `test_cap_drop_all_with_non_root_user`
+**Requires:** root, alpine-rootfs
+**Module:** `privileged_mode`
+
+Regression test for issue #308: `--cap-drop ALL --user 1000` previously failed with EINVAL.
+
+Root cause: `capset()` ran at step 4.86 (before `setuid()`), zeroing `CAP_SETUID`.
+When `setuid(1000)` then ran it got EPERM, which became EINVAL via the spawn error pipe
+(`io::Error::other()` has no `raw_os_error`).
+
+Fix: `PR_CAPBSET_DROP` only at step 4.86; `PR_SET_KEEPCAPS` set before `setuid()`
+so the permitted set survives the UID switch; `capset()` moved to step 8.6
+(after `setuid()`).
+
+Runs `pelagos run --cap-drop ALL --user 1000 --network loopback --no-pid-ns`
+and asserts:
+1. The process exits successfully (no EINVAL).
+2. `CapEff` from `/proc/self/status` is exactly 0 (all caps dropped).
+
+Failure means the capset/setuid ordering regression has returned.

--- a/src/container.rs
+++ b/src/container.rs
@@ -4837,19 +4837,18 @@ impl Command {
                     libc::close(notif_child_sock);
                 }
 
-                // Step 4.86: Drop capabilities.
+                // Step 4.86: Drop bounding capability set.
                 //
                 // MUST come after all mount operations (masked paths, readonly
                 // paths, readonly rootfs) AND namespace joins because those
                 // require CAP_SYS_ADMIN.
-                // Two-step drop (mirrors Docker / runc):
                 //
-                // 1. PR_CAPBSET_DROP — remove unwanted caps from the bounding
-                //    set so exec() cannot re-grant them.
-                // 2. capset() — explicitly set the effective, permitted, and
-                //    inheritable kernel sets to the desired mask.  Without this
-                //    step, CapEff/CapPrm remain at their current values (full
-                //    root caps) regardless of what the bounding set says.
+                // Only PR_CAPBSET_DROP is done here; capset() (which sets
+                // effective/permitted/inheritable) is deferred to step 8.6,
+                // AFTER setuid().  Reason: capset() before setuid() zeros the
+                // effective set (including CAP_SETUID), causing the subsequent
+                // setuid(non-root) to fail with EPERM.  PR_CAPBSET_DROP does
+                // not require any capability and is safe to call here.
                 if let Some(keep_caps) = capabilities {
                     const PR_CAPBSET_DROP: i32 = 24;
                     for cap in 0..41u64 {
@@ -4863,45 +4862,6 @@ impl Command {
                                 }
                             }
                         }
-                    }
-
-                    let bits = keep_caps.bits();
-                    let lo = bits as u32;
-                    let hi = (bits >> 32) as u32;
-
-                    #[repr(C)]
-                    struct CapHeader {
-                        version: u32,
-                        pid: i32,
-                    }
-                    #[repr(C)]
-                    struct CapData {
-                        effective: u32,
-                        permitted: u32,
-                        inheritable: u32,
-                    }
-
-                    let header = CapHeader {
-                        version: 0x2008_0522,
-                        pid: 0,
-                    };
-                    let data = [
-                        CapData {
-                            effective: lo,
-                            permitted: lo,
-                            inheritable: lo,
-                        },
-                        CapData {
-                            effective: hi,
-                            permitted: hi,
-                            inheritable: hi,
-                        },
-                    ];
-
-                    let ret =
-                        libc::syscall(libc::SYS_capset, &header as *const CapHeader, data.as_ptr());
-                    if ret != 0 {
-                        return Err(io::Error::last_os_error());
                     }
                 }
 
@@ -5059,9 +5019,12 @@ impl Command {
                 // When switching to a non-root UID, setuid(2) clears both the
                 // effective and ambient capability sets.  It also clears the
                 // permitted set UNLESS PR_SET_KEEPCAPS is set beforehand.
-                // Set it so that we can re-raise ambient caps afterwards.
+                // Set it whenever a capability mask is in play (either ambient
+                // caps to re-raise or an explicit cap set to apply at step 8.6).
                 // (PR_SET_KEEPCAPS is cleared automatically on exec(2).)
-                if uid.is_some_and(|u| u != 0) && !ambient_cap_numbers.is_empty() {
+                if uid.is_some_and(|u| u != 0)
+                    && (!ambient_cap_numbers.is_empty() || capabilities.is_some())
+                {
                     const PR_SET_KEEPCAPS: i32 = 8;
                     libc::prctl(PR_SET_KEEPCAPS, 1, 0, 0, 0);
                 }
@@ -5082,6 +5045,55 @@ impl Command {
                             "setuid: {}",
                             io::Error::last_os_error()
                         )));
+                    }
+                }
+
+                // Step 8.6: Apply capability set after setuid.
+                //
+                // capset() is placed here (not at step 4.86) so that setuid()
+                // still has CAP_SETUID when it runs.  PR_SET_KEEPCAPS (step 8.5)
+                // keeps the permitted set intact through the UID switch so that
+                // we can still capset to the desired mask.  When running as root
+                // (uid == None or uid == 0), setuid is skipped and capabilities
+                // are not needed for capset, so calling it here is also correct.
+                if let Some(keep_caps) = capabilities {
+                    let bits = keep_caps.bits();
+                    let lo = bits as u32;
+                    let hi = (bits >> 32) as u32;
+
+                    #[repr(C)]
+                    struct CapHeader {
+                        version: u32,
+                        pid: i32,
+                    }
+                    #[repr(C)]
+                    struct CapData {
+                        effective: u32,
+                        permitted: u32,
+                        inheritable: u32,
+                    }
+
+                    let header = CapHeader {
+                        version: 0x2008_0522,
+                        pid: 0,
+                    };
+                    let data = [
+                        CapData {
+                            effective: lo,
+                            permitted: lo,
+                            inheritable: lo,
+                        },
+                        CapData {
+                            effective: hi,
+                            permitted: hi,
+                            inheritable: hi,
+                        },
+                    ];
+
+                    let ret =
+                        libc::syscall(libc::SYS_capset, &header as *const CapHeader, data.as_ptr());
+                    if ret != 0 {
+                        return Err(io::Error::last_os_error());
                     }
                 }
 
@@ -7274,8 +7286,9 @@ impl Command {
                     libc::close(notif_child_sock_i);
                 }
 
-                // Drop capabilities after all mount operations.
-                // Same logic as step 4.86 in the chroot path.
+                // Drop bounding capability set after all mount operations.
+                // capset() is deferred to step 8.6 (after setuid) — same fix
+                // as the chroot path (spawn() step 4.86).
                 if let Some(keep_caps) = capabilities {
                     const PR_CAPBSET_DROP: i32 = 24;
                     for cap in 0..41u64 {
@@ -7289,45 +7302,6 @@ impl Command {
                                 }
                             }
                         }
-                    }
-
-                    let bits = keep_caps.bits();
-                    let lo = bits as u32;
-                    let hi = (bits >> 32) as u32;
-
-                    #[repr(C)]
-                    struct CapHeader {
-                        version: u32,
-                        pid: i32,
-                    }
-                    #[repr(C)]
-                    struct CapData {
-                        effective: u32,
-                        permitted: u32,
-                        inheritable: u32,
-                    }
-
-                    let header = CapHeader {
-                        version: 0x2008_0522,
-                        pid: 0,
-                    };
-                    let data = [
-                        CapData {
-                            effective: lo,
-                            permitted: lo,
-                            inheritable: lo,
-                        },
-                        CapData {
-                            effective: hi,
-                            permitted: hi,
-                            inheritable: hi,
-                        },
-                    ];
-
-                    let ret =
-                        libc::syscall(libc::SYS_capset, &header as *const CapHeader, data.as_ptr());
-                    if ret != 0 {
-                        return Err(io::Error::last_os_error());
                     }
                 }
 
@@ -7462,7 +7436,9 @@ impl Command {
                 }
 
                 // PR_SET_KEEPCAPS: preserve permitted caps across setuid(non-root).
-                if uid.is_some_and(|u| u != 0) && !ambient_cap_numbers.is_empty() {
+                if uid.is_some_and(|u| u != 0)
+                    && (!ambient_cap_numbers.is_empty() || capabilities.is_some())
+                {
                     const PR_SET_KEEPCAPS: i32 = 8;
                     libc::prctl(PR_SET_KEEPCAPS, 1, 0, 0, 0);
                 }
@@ -7483,6 +7459,47 @@ impl Command {
                             "setuid: {}",
                             io::Error::last_os_error()
                         )));
+                    }
+                }
+
+                // Step 8.6: Apply capability set after setuid.
+                // capset() must follow setuid() — doing it before zeroes CAP_SETUID,
+                // causing setuid(non-root) to fail with EPERM.
+                if let Some(keep_caps) = capabilities {
+                    let bits = keep_caps.bits();
+                    let lo = bits as u32;
+                    let hi = (bits >> 32) as u32;
+                    #[repr(C)]
+                    struct CapHeader {
+                        version: u32,
+                        pid: i32,
+                    }
+                    #[repr(C)]
+                    struct CapData {
+                        effective: u32,
+                        permitted: u32,
+                        inheritable: u32,
+                    }
+                    let header = CapHeader {
+                        version: 0x2008_0522,
+                        pid: 0,
+                    };
+                    let data = [
+                        CapData {
+                            effective: lo,
+                            permitted: lo,
+                            inheritable: lo,
+                        },
+                        CapData {
+                            effective: hi,
+                            permitted: hi,
+                            inheritable: hi,
+                        },
+                    ];
+                    let ret =
+                        libc::syscall(libc::SYS_capset, &header as *const CapHeader, data.as_ptr());
+                    if ret != 0 {
+                        return Err(io::Error::last_os_error());
                     }
                 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -25498,6 +25498,64 @@ mod privileged_mode {
         );
     }
 
+    /// Regression test for issue #308: `--cap-drop ALL --user 1000` must not EINVAL.
+    ///
+    /// Root cause: capset() before setuid() zeros CAP_SETUID → setuid(non-root) fails
+    /// EPERM → surfaces as EINVAL through the spawn error pipe.
+    /// Fix: defer capset() to after setuid(); set PR_SET_KEEPCAPS beforehand.
+    #[test]
+    fn test_cap_drop_all_with_non_root_user() {
+        if !is_root() {
+            eprintln!("Skipping: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping: alpine-rootfs not found");
+            return;
+        };
+
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+
+        // Drop ALL caps with a non-root user — must not fail with EINVAL.
+        // CapEff should be 0 (no capabilities).
+        let out = std::process::Command::new(bin)
+            .args([
+                "run",
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "--network",
+                "loopback",
+                "--no-pid-ns",
+                "--cap-drop",
+                "ALL",
+                "--user",
+                "1000",
+                "/bin/ash",
+                "-c",
+                "grep CapEff /proc/self/status",
+            ])
+            .output()
+            .expect("pelagos run");
+
+        assert!(
+            out.status.success(),
+            "--cap-drop ALL --user 1000 failed (issue #308 regression): {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let cap_eff_line = stdout
+            .lines()
+            .find(|l| l.starts_with("CapEff:"))
+            .expect("CapEff:");
+        let eff_val = u64::from_str_radix(cap_eff_line.split_whitespace().nth(1).unwrap(), 16)
+            .expect("parse CapEff");
+        assert_eq!(
+            eff_val, 0,
+            "--cap-drop ALL should leave zero effective caps, got {cap_eff_line}"
+        );
+    }
+
     #[test]
     fn test_memory_limit_cli() {
         if !is_root() {


### PR DESCRIPTION
## Summary

- Fixes issue #308: `--cap-drop ALL` combined with `--user <non-root>` caused EINVAL
- Root cause: `capset()` at step 4.86 (before `setuid()`) zeroed `CAP_SETUID`; then `setuid(non-root)` failed EPERM, which became EINVAL via the spawn error pipe (because `io::Error::other()` has no `raw_os_error`)
- Fix: keep only `PR_CAPBSET_DROP` at step 4.86; extend `PR_SET_KEEPCAPS` guard to cover `capabilities.is_some()`; move `capset()` to new step 8.6 (after `setuid()`) in both `spawn()` and `spawn_interactive()` paths

## Test plan

- [ ] `test_cap_drop_all_with_non_root_user` — new regression test; asserts spawn succeeds and `CapEff == 0`
- [ ] Full `privileged_mode` module: 5/5 tests pass locally
- [ ] `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test --lib` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)