### PR TITLE
feat(security): UID overflow guard and effective-root audit log (#317)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -4936,3 +4936,22 @@ Runs `pelagos run --selinux-label system_u:system_r:container_t:s0 /bin/true`. A
 command exits successfully. On non-SELinux systems the label is silently ignored; this test
 verifies the flag is accepted and doesn't crash. Verifies CRI
 `securityContext.selinux_options` → `--selinux-label` wiring (issue #315).
+
+## `cri_uid_hardening::test_uid_u32_max_rejected`
+**Requires root, requires alpine-rootfs.**
+Passes `--user 4294967295` (u32::MAX = `(uid_t)-1`) to `pelagos run` and asserts the
+command exits with an error. On Linux `setuid((uid_t)-1)` returns EINVAL; in some runtime
+implementations this silently leaves the process as root (CVE-2024-40635 class). Verifies
+the UID overflow guard in `resolve_uid` (issue #317).
+
+## `cri_uid_hardening::test_negative_uid_rejected`
+**Requires root, requires alpine-rootfs.**
+Passes `--user -1` to `pelagos run` and asserts rejection. Negative UIDs are not valid on
+Linux; `u32::parse("-1")` fails and the string is not a valid `/etc/passwd` name, so the
+error is caught in `resolve_uid`. Verifies defence against malformed input (issue #317).
+
+## `cri_uid_hardening::test_valid_uid_boundary_accepted`
+**Requires root, requires alpine-rootfs.**
+Passes `--user 0` and then `--user 65534` (nobody) to `pelagos run` and asserts both
+succeed. Verifies that the UID overflow guard does not mistakenly reject legitimate boundary
+values (issue #317).

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -829,6 +829,21 @@ impl RuntimeService for RuntimeSvc {
             })
             .unwrap_or((None, None));
 
+        // B′ — UID overflow/validity guard.
+        // Valid Linux UIDs are 0..=4294967294. The value 4294967295 (u32::MAX) equals
+        // (uid_t)-1; setuid(-1) is a no-op on some paths, silently leaving the process
+        // as root. This is the vector behind CVE-2024-40635 / CVE-2026-46680.
+        // Negative proto values are also nonsensical — reject them too.
+        for (label, maybe_id) in [("run_as_user", run_as_user), ("run_as_group", run_as_group)] {
+            if let Some(id) = maybe_id {
+                if !(0..=4_294_967_294).contains(&id) {
+                    return Err(Status::invalid_argument(format!(
+                        "{label} value {id} is out of the valid Linux UID/GID range (0..=4294967294)"
+                    )));
+                }
+            }
+        }
+
         // Extract security context fields from LinuxContainerSecurityContext.
         let (
             cap_add,
@@ -1074,6 +1089,22 @@ impl RuntimeService for RuntimeSvc {
         } else {
             image_cmd
         };
+
+        // B″ — Effective-UID-is-zero audit log.
+        // If the container will run as root and is not explicitly privileged, warn.
+        // We cannot know the pod's runAsNonRoot intent (the CRI proto doesn't carry it),
+        // but an unexpected effective UID 0 is worth surfacing for misconfiguration diagnosis.
+        if !container.privileged {
+            let effective_uid = container.run_as_user.unwrap_or(0);
+            if effective_uid == 0 {
+                log::warn!(
+                    "container {} ({}) will run as UID 0 (root) without privileged flag; \
+                     verify this is intentional",
+                    container.id,
+                    container.name
+                );
+            }
+        }
 
         // If the pod securityContext specifies runAsUser, override the image default user.
         // This is required for projected volume permissions (e.g. serviceaccount tokens

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -576,6 +576,14 @@ fn resolve_gid_in_layers(s: &str, layer_dirs: &[std::path::PathBuf]) -> Result<u
 
 fn resolve_uid(s: &str) -> Result<u32, String> {
     if let Ok(n) = s.parse::<u32>() {
+        // u32::MAX (4294967295) == (uid_t)-1; setuid(-1) is EINVAL and in some
+        // implementations silently leaves the process as root (CVE-2024-40635 class).
+        if n == u32::MAX {
+            return Err(format!(
+                "UID {} (u32::MAX) is invalid: equals (uid_t)-1, which would not change the process UID",
+                n
+            ));
+        }
         return Ok(n);
     }
     // Symbolic name: look up via getpwnam.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -26478,3 +26478,146 @@ mod cri_phase4_compat {
         );
     }
 }
+
+// ── CRI UID hardening (issue #317) ──────────────────────────────────────────
+
+#[cfg(test)]
+mod cri_uid_hardening {
+    use super::*;
+
+    /// B′: run_as_user = 4294967295 (u32::MAX) must be rejected.
+    /// (uid_t)-1 causes setuid(-1) which is a no-op, leaving the process as root.
+    /// Verifies the UID overflow guard introduced for CVE-2024-40635 / CVE-2026-46680.
+    #[test]
+    fn test_uid_u32_max_rejected() {
+        if !is_root() {
+            eprintln!("Skipping: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping: alpine-rootfs not found");
+            return;
+        };
+
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+
+        // pelagos run validates UID range; 4294967295 must be rejected.
+        let out = std::process::Command::new(bin)
+            .args([
+                "run",
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "--network",
+                "loopback",
+                "--no-pid-ns",
+                "--user",
+                "4294967295",
+                "/bin/true",
+            ])
+            .output()
+            .expect("pelagos run");
+
+        assert!(
+            !out.status.success(),
+            "expected UID 4294967295 to be rejected, but run succeeded"
+        );
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("4294967295") || stderr.contains("invalid") || stderr.contains("range"),
+            "expected rejection message for UID 4294967295, got: {stderr}"
+        );
+    }
+
+    /// B′: run_as_user = -1 (negative) must be rejected.
+    /// Negative UIDs are not valid on Linux and indicate malformed input.
+    #[test]
+    fn test_negative_uid_rejected() {
+        if !is_root() {
+            eprintln!("Skipping: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping: alpine-rootfs not found");
+            return;
+        };
+
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+
+        let out = std::process::Command::new(bin)
+            .args([
+                "run",
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "--network",
+                "loopback",
+                "--no-pid-ns",
+                "--user",
+                "-1",
+                "/bin/true",
+            ])
+            .output()
+            .expect("pelagos run");
+
+        assert!(
+            !out.status.success(),
+            "expected UID -1 to be rejected, but run succeeded"
+        );
+    }
+
+    /// B′: valid boundary UIDs (0 and 65534 / nobody) must be accepted.
+    #[test]
+    fn test_valid_uid_boundary_accepted() {
+        if !is_root() {
+            eprintln!("Skipping: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping: alpine-rootfs not found");
+            return;
+        };
+
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+
+        // UID 0 is valid (root).
+        let out = std::process::Command::new(bin)
+            .args([
+                "run",
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "--network",
+                "loopback",
+                "--no-pid-ns",
+                "--user",
+                "0",
+                "/bin/true",
+            ])
+            .output()
+            .expect("pelagos run");
+        assert!(
+            out.status.success(),
+            "UID 0 should be accepted: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        // UID 65534 (nobody) is valid.
+        let out = std::process::Command::new(bin)
+            .args([
+                "run",
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "--network",
+                "loopback",
+                "--no-pid-ns",
+                "--user",
+                "65534",
+                "/bin/true",
+            ])
+            .output()
+            .expect("pelagos run");
+        assert!(
+            out.status.success(),
+            "UID 65534 should be accepted: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- **B′ (hard reject)**: `resolve_uid()` now rejects `u32::MAX` (4294967295 = `(uid_t)-1`). On Linux, `setuid(-1)` returns EINVAL; in some runtime implementations this silently leaves the process as root — the vector behind CVE-2024-40635 / CVE-2026-46680. The CRI `create_container` path independently validates `run_as_user`/`run_as_group` are in `0..=4294967294`.
- **B″ (audit warn)**: `start_container` emits `log::warn!` when a non-privileged container resolves to UID 0. The CRI v1 proto carries no `runAsNonRoot` intent field, so this is a misconfiguration signal rather than policy enforcement.

## Test plan

- [x] `cri_uid_hardening::test_uid_u32_max_rejected` — u32::MAX rejected with error
- [x] `cri_uid_hardening::test_negative_uid_rejected` — negative UID rejected
- [x] `cri_uid_hardening::test_valid_uid_boundary_accepted` — UID 0 and 65534 accepted
- [x] 364 unit tests pass
- [x] 3/3 new integration tests pass

Closes #317, closes #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)