### PR TITLE
fix(run,exec): resolve --user against container /etc/passwd, not host

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -5011,3 +5011,26 @@ broke klipper-lb in v0.65.22 and was fixed in v0.65.23 (issue #323).
 Runs a container with `--memory-swap -1` (kernel sentinel meaning "unlimited swap") and
 verifies the flag is accepted without clap treating `-1` as an unknown flag. Same
 `allow_hyphen_values` fix as `--oom-score-adj` (issue #323).
+
+## `image_user_resolution::test_user_root_from_image_passwd`
+**Requires root and rootfs.**
+Runs a container with `--user root` and asserts `id -u` outputs `0`. Verifies that
+symbolic user resolution uses the container's Alpine `/etc/passwd`, not the host's (issue #321).
+
+## `image_user_resolution::test_user_nobody_from_image_passwd`
+**Requires root and rootfs.**
+Runs a container with `--user nobody` and asserts UID and GID are both 65534. Verifies
+that the primary GID is also taken from `/etc/passwd` (OCI spec: bare username implies
+the passwd-defined primary group), not defaulted or inherited (issue #321).
+
+## `image_user_resolution::test_user_nonexistent_in_image_fails`
+**Requires root and rootfs.**
+Runs a container with `--user pelagos-nonexistent-user-xyzzy` and asserts the run fails
+with a "not found" error. Verifies that resolution does NOT silently fall back to the
+host `/etc/passwd` — the hard-error behaviour required by OCI spec §5.1 (issue #321).
+
+## `image_user_resolution::test_user_numeric_uid_gid`
+**Requires root and rootfs.**
+Runs a container with `--user 1234:5678` and verifies both IDs are applied correctly.
+Ensures the numeric passthrough path still works after removing the host-lookup fallback
+(issue #321).

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -1,6 +1,8 @@
 //! `pelagos exec` — run a command inside a running container.
 
-use super::{check_liveness, parse_user, read_state, verify_pid_not_recycled, ContainerStatus};
+use super::{
+    check_liveness, parse_user_in_rootfs, read_state, verify_pid_not_recycled, ContainerStatus,
+};
 use pelagos::container::{Command, Namespace, Stdio};
 use pelagos::image;
 use std::os::unix::io::AsRawFd;
@@ -227,6 +229,10 @@ pub fn cmd_exec(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
     // Capture workdir for use in the pre_exec callback.
     let exec_workdir = args.workdir.clone();
 
+    // Resolve the container's merged root once — used both for entering the
+    // rootfs and for /etc/passwd lookup when --user is a symbolic name.
+    let root_pid = find_root_pid(pid);
+
     if has_mount_ns {
         // Open all namespace fds in the parent (before fork) so they are
         // inherited across fork and remain valid in the child's pre_exec.
@@ -266,7 +272,7 @@ pub fn cmd_exec(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
         // process), which never called pivot_root — so /proc/P/root is the HOST
         // root.  Use find_root_pid() to find C (P's only child), which did
         // pivot_root and whose /proc/C/root is the container overlay root.
-        let root_pid = find_root_pid(pid);
+        // root_pid is already computed above.
         let root_path = format!("/proc/{}/root", root_pid);
         let root_file =
             std::fs::File::open(&root_path).map_err(|e| format!("open {}: {}", root_path, e))?;
@@ -317,7 +323,6 @@ pub fn cmd_exec(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
         });
     } else {
         // No mount namespace to join — access rootfs via procfs.
-        let root_pid = find_root_pid(pid);
         cmd = cmd.with_chroot(format!("/proc/{}/root", root_pid));
         // For non-mount-ns exec, use the normal with_cwd mechanism.
         if let Some(ref w) = exec_workdir {
@@ -340,9 +345,12 @@ pub fn cmd_exec(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // User
+    // User: resolve against the running container's merged filesystem
+    // (/proc/{pid}/root) so named users (e.g. "nginx", "nobody") are looked up
+    // in the image's /etc/passwd, not the host's.
     if let Some(ref u) = args.user {
-        let (uid, gid) = parse_user(u)?;
+        let container_root = std::path::PathBuf::from(format!("/proc/{}/root", root_pid));
+        let (uid, gid) = parse_user_in_rootfs(u, &container_root)?;
 
         // Validate UID against the container's user namespace uid_map before
         // attempting to spawn.  setuid(uid) inside the user namespace fails

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -446,24 +446,21 @@ pub fn parse_cpus(s: &str) -> Result<(i64, u64), String> {
     Ok((quota_us, period_us))
 }
 
-/// Parse --user "1000" or "1000:1000" → `(uid, Option<gid>)`.
-/// Resolves symbolic names against the host /etc/passwd only.
-/// Use `parse_user_in_layers` when an image rootfs is available.
-pub fn parse_user(s: &str) -> Result<(u32, Option<u32>), String> {
-    if let Some((u, g)) = s.split_once(':') {
-        let uid = resolve_uid(u.trim())?;
-        let gid = resolve_gid(g.trim())?;
-        Ok((uid, Some(gid)))
-    } else {
-        let uid = resolve_uid(s.trim())?;
-        Ok((uid, None))
-    }
+/// Resolve a `--user` string against a container rootfs directory.
+/// Convenience wrapper around `parse_user_in_layers` for a single directory
+/// (used for `--rootfs` runs and `pelagos exec` against a running container).
+pub fn parse_user_in_rootfs(
+    s: &str,
+    rootfs: &std::path::Path,
+) -> Result<(u32, Option<u32>), String> {
+    parse_user_in_layers(s, &[rootfs.to_path_buf()])
 }
 
-/// Like `parse_user`, but for image-config users: resolves symbolic names
-/// from the container's own layer stack (/etc/passwd inside the image) before
-/// falling back to the host. When a bare username is given, also returns the
-/// primary gid from the image's /etc/passwd (matching OCI spec behaviour).
+/// Resolve a `--user` string against the container's image layer stack.
+/// Searches layers last-to-first (upper wins). When a bare username is given,
+/// also returns the primary GID from `/etc/passwd` (OCI spec behaviour).
+/// Hard error if the name is not found — does NOT fall back to the host
+/// `/etc/passwd` (OCI spec §5.1: unknown username SHOULD cause start failure).
 pub fn parse_user_in_layers(
     s: &str,
     layer_dirs: &[std::path::PathBuf],
@@ -500,22 +497,22 @@ fn lookup_user_in_layers(
             }
         }
     }
-    // Fall back to host /etc/passwd.
-    use std::ffi::CString;
-    let cname = CString::new(name).map_err(|_| format!("invalid user name: {}", name))?;
-    let pw = unsafe { libc::getpwnam(cname.as_ptr()) };
-    if pw.is_null() {
-        Err(format!(
-            "unknown user '{}': not found in container or host /etc/passwd",
-            name
-        ))
-    } else {
-        Ok(unsafe { ((*pw).pw_uid, Some((*pw).pw_gid)) })
-    }
+    Err(format!(
+        "unknown user '{}': not found in container /etc/passwd",
+        name
+    ))
 }
 
 fn resolve_uid_in_layers(s: &str, layer_dirs: &[std::path::PathBuf]) -> Result<u32, String> {
     if let Ok(n) = s.parse::<u32>() {
+        // u32::MAX == (uid_t)-1; setuid(-1) is EINVAL and in some implementations
+        // silently leaves the process as root (CVE-2024-40635 class).
+        if n == u32::MAX {
+            return Err(format!(
+                "UID {} (u32::MAX) is invalid: equals (uid_t)-1, which would not change the process UID",
+                n
+            ));
+        }
         return Ok(n);
     }
     for layer_dir in layer_dirs.iter().rev() {
@@ -531,17 +528,10 @@ fn resolve_uid_in_layers(s: &str, layer_dirs: &[std::path::PathBuf]) -> Result<u
             }
         }
     }
-    use std::ffi::CString;
-    let cname = CString::new(s).map_err(|_| format!("invalid user name: {}", s))?;
-    let pw = unsafe { libc::getpwnam(cname.as_ptr()) };
-    if pw.is_null() {
-        Err(format!(
-            "unknown user '{}': not found in container or host /etc/passwd",
-            s
-        ))
-    } else {
-        Ok(unsafe { (*pw).pw_uid })
-    }
+    Err(format!(
+        "unknown user '{}': not found in container /etc/passwd",
+        s
+    ))
 }
 
 fn resolve_gid_in_layers(s: &str, layer_dirs: &[std::path::PathBuf]) -> Result<u32, String> {
@@ -562,54 +552,10 @@ fn resolve_gid_in_layers(s: &str, layer_dirs: &[std::path::PathBuf]) -> Result<u
             }
         }
     }
-    use std::ffi::CString;
-    let cname = CString::new(s).map_err(|_| format!("invalid group name: {}", s))?;
-    let gr = unsafe { libc::getgrnam(cname.as_ptr()) };
-    if gr.is_null() {
-        Err(format!(
-            "unknown group '{}': not found in container or host /etc/group",
-            s
-        ))
-    } else {
-        Ok(unsafe { (*gr).gr_gid })
-    }
-}
-
-fn resolve_uid(s: &str) -> Result<u32, String> {
-    if let Ok(n) = s.parse::<u32>() {
-        // u32::MAX (4294967295) == (uid_t)-1; setuid(-1) is EINVAL and in some
-        // implementations silently leaves the process as root (CVE-2024-40635 class).
-        if n == u32::MAX {
-            return Err(format!(
-                "UID {} (u32::MAX) is invalid: equals (uid_t)-1, which would not change the process UID",
-                n
-            ));
-        }
-        return Ok(n);
-    }
-    // Symbolic name: look up via getpwnam.
-    use std::ffi::CString;
-    let name = CString::new(s).map_err(|_| format!("invalid user name: {}", s))?;
-    let pw = unsafe { libc::getpwnam(name.as_ptr()) };
-    if pw.is_null() {
-        Err(format!("unknown user '{}': not found in /etc/passwd", s))
-    } else {
-        Ok(unsafe { (*pw).pw_uid })
-    }
-}
-
-fn resolve_gid(s: &str) -> Result<u32, String> {
-    if let Ok(n) = s.parse::<u32>() {
-        return Ok(n);
-    }
-    use std::ffi::CString;
-    let name = CString::new(s).map_err(|_| format!("invalid group name: {}", s))?;
-    let gr = unsafe { libc::getgrnam(name.as_ptr()) };
-    if gr.is_null() {
-        Err(format!("unknown group '{}': not found in /etc/group", s))
-    } else {
-        Ok(unsafe { (*gr).gr_gid })
-    }
+    Err(format!(
+        "unknown group '{}': not found in container /etc/group",
+        s
+    ))
 }
 
 /// Parse --ulimit "nofile=1024:2048" → (resource_int, soft, hard).

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -25,8 +25,8 @@ extern "C" fn watcher_forward_signal(signum: libc::c_int) {
 
 use super::{
     check_liveness, container_dir, containers_dir, generate_name, parse_capability, parse_cpus,
-    parse_memory, parse_ulimit, parse_user, parse_user_in_layers, rootfs_path, write_state,
-    ContainerState, ContainerStatus, HealthConfig, HealthStatus, SpawnConfig,
+    parse_memory, parse_ulimit, parse_user_in_layers, parse_user_in_rootfs, rootfs_path,
+    write_state, ContainerState, ContainerStatus, HealthConfig, HealthStatus, SpawnConfig,
 };
 use pelagos::container::{Capability, Command, Namespace, Stdio, Volume};
 use pelagos::network::NetworkMode;
@@ -696,6 +696,7 @@ fn build_image_run(
     }
 
     // Apply shared CLI options (network, volumes, security, etc.)
+    // Pass layer_dirs so --user NAME is resolved against the image's /etc/passwd.
     cmd = apply_cli_options(
         cmd,
         args,
@@ -703,6 +704,7 @@ fn build_image_run(
         network_mode,
         additional_networks,
         container_name,
+        &layer_dirs,
     )?;
 
     let health_config = manifest.config.healthcheck.clone();
@@ -748,6 +750,7 @@ fn build_command(
             "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         );
 
+    let rootfs_layers = vec![rootfs_dir.to_path_buf()];
     cmd = apply_cli_options(
         cmd,
         args,
@@ -755,12 +758,17 @@ fn build_command(
         network_mode,
         additional_networks,
         container_name,
+        &rootfs_layers,
     )?;
     Ok(cmd)
 }
 
 /// Apply all CLI options (network, filesystem, env, security, etc.) to a Command.
 /// Shared between the rootfs path and the --image path.
+///
+/// `layer_dirs`: the container's filesystem layers (image layers or a single-element
+/// vec containing the rootfs dir). Used to resolve symbolic `--user` names against
+/// the container's own `/etc/passwd` rather than the host's.
 fn apply_cli_options(
     mut cmd: Command,
     args: &RunArgs,
@@ -768,6 +776,7 @@ fn apply_cli_options(
     network_mode: NetworkMode,
     additional_networks: &[String],
     container_name: &str,
+    layer_dirs: &[std::path::PathBuf],
 ) -> Result<Command, Box<dyn std::error::Error>> {
     // Network
     // Sandbox: when --sandbox is given, join the sandbox's NET/IPC/UTS namespaces
@@ -951,9 +960,9 @@ fn apply_cli_options(
     // unconditionally overwrites Dockerfile `ENV PATH=...` entries that were
     // already applied before apply_cli_options is called (issue #114).
 
-    // User
+    // User: resolve against the container's own /etc/passwd, not the host's.
     if let Some(ref u) = args.user {
-        let (uid, gid) = parse_user(u)?;
+        let (uid, gid) = parse_user_in_layers(u, layer_dirs)?;
         cmd = cmd.with_uid(uid);
         if let Some(g) = gid {
             cmd = cmd.with_gid(g);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -26926,3 +26926,183 @@ mod dash_prefixed_args {
         );
     }
 }
+
+// ── User resolution from image /etc/passwd (issue #321) ─────────────────────
+//
+// --user NAME must resolve against the container's /etc/passwd, not the
+// host's. Alpine's rootfs has a known set of users (root=0, nobody=65534,
+// guest=405 depending on version) that differ from typical host systems.
+// These tests verify correct UID/GID resolution and hard failure when the
+// user does not exist in the container image.
+
+#[cfg(test)]
+mod image_user_resolution {
+    use super::*;
+
+    /// --user root resolves to UID 0 from Alpine's /etc/passwd (not the host).
+    #[test]
+    fn test_user_root_from_image_passwd() {
+        if !is_root() {
+            eprintln!("Skipping: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping: alpine-rootfs not found");
+            return;
+        };
+
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+        let out = std::process::Command::new(bin)
+            .args([
+                "run",
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "--network",
+                "loopback",
+                "--no-pid-ns",
+                "--user",
+                "root",
+                "/bin/sh",
+                "-c",
+                "id -u",
+            ])
+            .output()
+            .expect("pelagos run");
+
+        assert!(
+            out.status.success(),
+            "--user root rejected: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout).trim(),
+            "0",
+            "expected UID 0 for 'root'"
+        );
+    }
+
+    /// --user nobody resolves to UID 65534 from Alpine's /etc/passwd.
+    /// On a typical host nobody may be 65534 too but the test verifies the
+    /// container-side lookup path, not coincidental host agreement.
+    #[test]
+    fn test_user_nobody_from_image_passwd() {
+        if !is_root() {
+            eprintln!("Skipping: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping: alpine-rootfs not found");
+            return;
+        };
+
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+        let out = std::process::Command::new(bin)
+            .args([
+                "run",
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "--network",
+                "loopback",
+                "--no-pid-ns",
+                "--user",
+                "nobody",
+                "/bin/sh",
+                "-c",
+                "id -u && id -g",
+            ])
+            .output()
+            .expect("pelagos run");
+
+        assert!(
+            out.status.success(),
+            "--user nobody rejected: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let lines: Vec<&str> = stdout.trim().lines().collect();
+        assert_eq!(lines.len(), 2, "expected two lines of output");
+        assert_eq!(lines[0], "65534", "expected UID 65534 for nobody");
+        assert_eq!(lines[1], "65534", "expected GID 65534 for nobody");
+    }
+
+    /// --user with a name that doesn't exist in the container image must fail
+    /// with a clear error — must NOT silently fall back to the host /etc/passwd.
+    #[test]
+    fn test_user_nonexistent_in_image_fails() {
+        if !is_root() {
+            eprintln!("Skipping: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping: alpine-rootfs not found");
+            return;
+        };
+
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+        let out = std::process::Command::new(bin)
+            .args([
+                "run",
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "--network",
+                "loopback",
+                "--no-pid-ns",
+                "--user",
+                "pelagos-nonexistent-user-xyzzy",
+                "/bin/true",
+            ])
+            .output()
+            .expect("pelagos run");
+
+        assert!(
+            !out.status.success(),
+            "expected failure for unknown user, but run succeeded"
+        );
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("not found"),
+            "expected 'not found' in error, got: {stderr}"
+        );
+    }
+
+    /// --user UID:GID with numeric IDs must still work (no /etc/passwd lookup needed).
+    #[test]
+    fn test_user_numeric_uid_gid() {
+        if !is_root() {
+            eprintln!("Skipping: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping: alpine-rootfs not found");
+            return;
+        };
+
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+        let out = std::process::Command::new(bin)
+            .args([
+                "run",
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "--network",
+                "loopback",
+                "--no-pid-ns",
+                "--user",
+                "1234:5678",
+                "/bin/sh",
+                "-c",
+                "id -u && id -g",
+            ])
+            .output()
+            .expect("pelagos run");
+
+        assert!(
+            out.status.success(),
+            "--user 1234:5678 rejected: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let lines: Vec<&str> = stdout.trim().lines().collect();
+        assert_eq!(lines[0], "1234", "expected UID 1234");
+        assert_eq!(lines[1], "5678", "expected GID 5678");
+    }
+}


### PR DESCRIPTION
## Summary

- `--user NAME` (symbolic names like `nginx`, `www-data`, `nobody`) was resolved against the **host** `/etc/passwd`, not the container image's. Users that only exist in the image failed or silently ran as the wrong UID.
- The OCI spec (§5.1) requires username resolution from the container image; unknown names should cause a start failure, not a silent host fallback.
- `pelagos exec --user NAME` had the same bug.

## Changes

- `apply_cli_options` now receives `layer_dirs` and calls `parse_user_in_layers` instead of the host-only `parse_user`
- `pelagos exec` resolves `--user` via `/proc/{pid}/root` (running container's merged filesystem) using new `parse_user_in_rootfs` helper
- Removed host `/etc/passwd` fallback from all three layer-aware lookup helpers — unknown names are now a **hard error**
- Deleted `parse_user`, `resolve_uid`, `resolve_gid` (host-only functions, no longer needed)
- Moved u32::MAX (UID -1) guard into `resolve_uid_in_layers`

## Test plan

- [ ] `test_user_root_from_image_passwd` — `--user root` → UID 0 from Alpine `/etc/passwd`
- [ ] `test_user_nobody_from_image_passwd` — `--user nobody` → UID/GID 65534, primary GID from passwd (OCI spec)
- [ ] `test_user_nonexistent_in_image_fails` — unknown name → hard error, no host fallback
- [ ] `test_user_numeric_uid_gid` — numeric `UID:GID` passthrough still works
- [ ] All 368 unit tests pass
- [ ] Full integration suite passes

Closes #321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)