### PR TITLE
fix(mounts): resolve symlinked parent dirs in bind destinations (#334)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -5104,3 +5104,20 @@ Starts a container with `--network loopback`, runs `ip link show lo` inside via 
 asserts the output contains `UP` and that `127.0.0.1` is assigned. Failure means
 `bring_up_loopback()` was not called during sandbox netns setup — the root cause of
 issue #331 where intra-pod `127.0.0.1` traffic failed and the sidecar pattern was broken.
+
+## `issue_334_symlinked_mount_dest::test_bind_mount_resolves_symlinked_parent`
+**Requires root and the alpine-rootfs.**
+Builds an isolated `cp -a` copy of the alpine rootfs whose `/var/run` is rewritten to an
+**absolute** symlink to `/run` — exactly how mainstream OCI base images (alpine:3.20,
+debian-slim, ubuntu) ship it. A host directory standing in for the projected Kubernetes
+ServiceAccount token volume is bind-mounted at
+`/var/run/secrets/kubernetes.io/serviceaccount`, then the container `cat`s the token back
+through that path and the test asserts the exact contents are returned. Failure (empty
+stdout or a `cat` error) means the bind destination was not resolved through the image's
+`/var/run -> /run` symlink, so the mount was dropped or escaped the rootfs — the root cause
+of issue #334, where in-cluster `rest.InClusterConfig()` broke for any controller built on
+an Alpine/Debian/Ubuntu base (e.g. `rancher/local-path-provisioner` crashlooping). An
+absolute symlink is used deliberately: a relative `../run` symlink happens to stay inside
+the rootfs and would mask the bug. Complemented by the `container::tests::resolve_mount_target_*`
+unit tests, which pin the path-resolution logic (symlink following, relative targets,
+`..` clamping, loop termination) without requiring root.

--- a/src/container.rs
+++ b/src/container.rs
@@ -859,6 +859,71 @@ pub struct BindMount {
     pub readonly: bool,
 }
 
+/// Resolve a mount destination path within the container rootfs, following any
+/// symlinks encountered along the way — the same handling containerd and CRI-O
+/// apply when realizing mounts.
+///
+/// Mainstream base images (Alpine, Debian, Ubuntu) ship `/var/run` as a symlink
+/// to `/run`.  A naive `root.join("var/run/secrets/...")` would land the bind
+/// mount inside (or on top of) the symlink rather than at the real path the
+/// container process resolves to (`/run/secrets/...`), silently dropping the
+/// mount — most visibly the projected Kubernetes ServiceAccount token, which
+/// breaks `rest.InClusterConfig()` (see issue #334).
+///
+/// Resolution rules, confined to `root` so a symlink can never escape the rootfs:
+/// - absolute symlink targets are reinterpreted relative to `root`;
+/// - `..` is clamped at `root`;
+/// - resolution stops at the first component that does not yet exist, so a
+///   not-yet-created leaf directory is returned unresolved for the caller to
+///   `mkdir` (its already-existing symlinked parents are still resolved);
+/// - a finite link budget guards against symlink loops.
+fn resolve_mount_target_in_root(root: &std::path::Path, target: &std::path::Path) -> PathBuf {
+    use std::collections::VecDeque;
+    use std::ffi::OsString;
+    use std::path::Component;
+
+    let to_queue = |p: &std::path::Path| -> Vec<OsString> {
+        p.components()
+            .filter_map(|c| match c {
+                Component::Normal(s) => Some(s.to_os_string()),
+                Component::ParentDir => Some(OsString::from("..")),
+                // RootDir / CurDir / Prefix carry no path segment to resolve.
+                _ => None,
+            })
+            .collect()
+    };
+
+    let mut pending: VecDeque<OsString> = to_queue(target).into();
+    let mut resolved = PathBuf::new(); // relative to `root`
+    let mut link_budget = 40u32;
+
+    while let Some(comp) = pending.pop_front() {
+        if comp == ".." {
+            resolved.pop();
+            continue;
+        }
+        let candidate = resolved.join(&comp);
+        match std::fs::read_link(root.join(&candidate)) {
+            Ok(link) if link_budget > 0 => {
+                link_budget -= 1;
+                // An absolute target restarts from the rootfs; a relative one is
+                // resolved against the symlink's parent (`resolved`, since we
+                // have not appended `comp`).
+                if link.is_absolute() {
+                    resolved = PathBuf::new();
+                }
+                for seg in to_queue(&link).into_iter().rev() {
+                    pending.push_front(seg);
+                }
+            }
+            // Not a symlink, does not exist, or budget exhausted: accept it.
+            _ => resolved = candidate,
+        }
+    }
+
+    root.join(resolved)
+}
+
 /// A tmpfs mount inside the container.
 #[derive(Debug, Clone)]
 pub struct TmpfsMount {
@@ -4467,9 +4532,11 @@ impl Command {
                     // (chroot has not happened yet).
                     for bm in &bind_mounts {
                         use std::os::unix::ffi::OsStrExt as _;
-                        // Target inside the effective root on the host side
-                        let rel = bm.target.strip_prefix("/").unwrap_or(&bm.target);
-                        let host_target = effective_root.join(rel);
+                        // Target inside the effective root on the host side, with any
+                        // symlinked parent dirs in the image rootfs resolved (e.g.
+                        // /var/run -> /run) so the bind lands where the container
+                        // process resolves the path. See issue #334.
+                        let host_target = resolve_mount_target_in_root(effective_root, &bm.target);
                         // Linux requires the mount target to exist and be the same type
                         // (file or directory) as the source.
                         if bm.source.is_dir() {
@@ -6994,8 +7061,9 @@ impl Command {
                     // (chroot has not happened yet).
                     for bm in &bind_mounts {
                         use std::os::unix::ffi::OsStrExt as _;
-                        let rel = bm.target.strip_prefix("/").unwrap_or(&bm.target);
-                        let host_target = effective_root.join(rel);
+                        // Resolve symlinked parents in the image rootfs (e.g.
+                        // /var/run -> /run) before binding. See issue #334.
+                        let host_target = resolve_mount_target_in_root(effective_root, &bm.target);
                         if bm.source.is_dir() {
                             std::fs::create_dir_all(&host_target).map_err(|e| {
                                 io::Error::other(format!("bind mount mkdir: {}", e))
@@ -8280,6 +8348,65 @@ pub struct DeviceNode {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_resolve_mount_target_follows_var_run_symlink() {
+        // Image rootfs where /var/run is a symlink to /run (Alpine/Debian/Ubuntu).
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("run")).unwrap();
+        std::fs::create_dir_all(root.path().join("var")).unwrap();
+        std::os::unix::fs::symlink("/run", root.path().join("var/run")).unwrap();
+
+        // The SA-token destination must resolve through the symlink to the real
+        // /run/secrets/... path, not land inside the var/run symlink.
+        let resolved = resolve_mount_target_in_root(
+            root.path(),
+            std::path::Path::new("/var/run/secrets/kubernetes.io/serviceaccount"),
+        );
+        assert_eq!(
+            resolved,
+            root.path().join("run/secrets/kubernetes.io/serviceaccount")
+        );
+    }
+
+    #[test]
+    fn test_resolve_mount_target_relative_symlink() {
+        // A relative symlink resolves against its own parent directory.
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("real")).unwrap();
+        std::os::unix::fs::symlink("real", root.path().join("link")).unwrap();
+
+        let resolved =
+            resolve_mount_target_in_root(root.path(), std::path::Path::new("/link/data"));
+        assert_eq!(resolved, root.path().join("real/data"));
+    }
+
+    #[test]
+    fn test_resolve_mount_target_no_symlink_passthrough() {
+        // Plain directory destinations are unchanged (leading slash stripped).
+        let root = tempfile::tempdir().unwrap();
+        let resolved = resolve_mount_target_in_root(root.path(), std::path::Path::new("/data/sub"));
+        assert_eq!(resolved, root.path().join("data/sub"));
+    }
+
+    #[test]
+    fn test_resolve_mount_target_parent_clamped_at_root() {
+        // `..` components cannot escape the rootfs.
+        let root = tempfile::tempdir().unwrap();
+        let resolved =
+            resolve_mount_target_in_root(root.path(), std::path::Path::new("/../../etc/passwd"));
+        assert_eq!(resolved, root.path().join("etc/passwd"));
+    }
+
+    #[test]
+    fn test_resolve_mount_target_symlink_loop_terminates() {
+        // A symlink cycle must not hang; resolution gives up via the link budget.
+        let root = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink("/b", root.path().join("a")).unwrap();
+        std::os::unix::fs::symlink("/a", root.path().join("b")).unwrap();
+        // Should return without looping forever (exact value unimportant).
+        let _ = resolve_mount_target_in_root(root.path(), std::path::Path::new("/a/x"));
+    }
 
     #[test]
     fn test_namespace_bitflags_combination() {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -27853,3 +27853,92 @@ mod exec_netns_and_loopback {
         cleanup(name);
     }
 }
+
+/// Issue #334: a volume whose container destination sits under a directory the
+/// image ships as a symlink (e.g. `/var/run -> /run` on Alpine/Debian/Ubuntu)
+/// must still be mounted at the real, container-visible path. Before the fix the
+/// bind target was computed as a naive `root.join("var/run/...")`; because the
+/// kernel resolves the mount destination *before* pivot_root, an absolute
+/// `/var/run -> /run` symlink resolved against the host root and the bind either
+/// escaped the rootfs or was dropped — silently losing the projected Kubernetes
+/// ServiceAccount token and breaking `rest.InClusterConfig()`.
+mod issue_334_symlinked_mount_dest {
+    use super::*;
+
+    /// Requires root and the alpine-rootfs.
+    ///
+    /// Builds an isolated rootfs copy whose `/var/run` is an
+    /// **absolute** symlink to `/run` — exactly how mainstream OCI base images
+    /// ship it, and the case that genuinely reproduced the bug (a relative
+    /// `../run` symlink happens to stay inside the rootfs and masks it).
+    ///
+    /// A host directory simulating the projected SA-token volume is bind-mounted
+    /// at `/var/run/secrets/kubernetes.io/serviceaccount`, then the container
+    /// reads the token back through that path. Failure (empty stdout / cat error)
+    /// would indicate the mount was dropped or escaped the rootfs — i.e. the
+    /// regression has returned.
+    #[test]
+    fn test_bind_mount_resolves_symlinked_parent() {
+        if !is_root() {
+            eprintln!("Skipping test_bind_mount_resolves_symlinked_parent: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!(
+                "Skipping test_bind_mount_resolves_symlinked_parent: alpine-rootfs not found"
+            );
+            return;
+        };
+
+        // Isolated rootfs copy so we can rewrite /var/run without touching the
+        // shared alpine-rootfs. (`cp -a`, not `-al`: the tempdir is typically on
+        // tmpfs — a different device — so hardlinks would fail cross-device.)
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let test_root = tmp.path().join("root");
+        let cp = std::process::Command::new("cp")
+            .arg("-a")
+            .arg(&rootfs)
+            .arg(&test_root)
+            .status()
+            .expect("cp -a rootfs");
+        assert!(cp.success(), "failed to copy rootfs");
+
+        // Replace /var/run with an absolute symlink to /run (OCI image layout).
+        let var_run = test_root.join("var/run");
+        let _ = std::fs::remove_file(&var_run);
+        std::fs::create_dir_all(test_root.join("run")).expect("mkdir run");
+        std::os::unix::fs::symlink("/run", &var_run).expect("symlink var/run -> /run");
+
+        // Host directory standing in for the projected SA-token volume.
+        let secret = tempfile::tempdir().expect("secret tempdir");
+        std::fs::write(secret.path().join("token"), b"sa-token-issue-334").expect("write token");
+
+        let dest = "/var/run/secrets/kubernetes.io/serviceaccount";
+        let mut child = Command::new("/bin/cat")
+            .args([format!("{dest}/token")])
+            .with_chroot(&test_root)
+            .with_namespaces(Namespace::UTS | Namespace::MOUNT)
+            .with_proc_mount()
+            .with_bind_mount_ro(secret.path(), dest)
+            .env("PATH", ALPINE_PATH)
+            .stdout(Stdio::Piped)
+            .stderr(Stdio::Piped)
+            .spawn()
+            .expect("Failed to spawn container");
+
+        let (status, stdout, stderr) = child.wait_with_output().expect("wait failed");
+        let out = String::from_utf8_lossy(&stdout);
+        let err = String::from_utf8_lossy(&stderr);
+
+        assert!(
+            status.success(),
+            "cat of SA token through symlinked /var/run failed (exit {:?}).\nstdout: {out}\nstderr: {err}",
+            status.code()
+        );
+        assert_eq!(
+            out.trim(),
+            "sa-token-issue-334",
+            "SA token not readable through /var/run -> /run symlink — mount was dropped (issue #334).\nstderr: {err}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #334.

## Problem

Pelagos computed bind-mount destinations as a naive `root.join(target)` that never followed symlinks in the image rootfs. Mainstream base images (Alpine, Debian, Ubuntu) ship `/var/run` as a symlink to `/run`. Because the kernel resolves a mount destination **before** `pivot_root`, an absolute `/var/run -> /run` symlink resolved against the *host* root, so a volume targeting `/var/run/secrets/...` either escaped the rootfs or was silently dropped.

Most visibly this lost the projected Kubernetes ServiceAccount token (`kube-api-access-*`), breaking `rest.InClusterConfig()` for any controller built on such a base image — e.g. `rancher/local-path-provisioner` crashlooping, and the reason the k3s built-in local-path provisioner never worked on our cluster.

A relative `../run` symlink (as our local `alpine-rootfs` happens to use) stays inside the rootfs and masks the bug, which is why it surfaced only against real OCI images.

## Fix

Add `resolve_mount_target_in_root()` — a securejoin-style resolver that walks the destination component-by-component within the rootfs, following symlinks (absolute targets reinterpreted relative to root, `..` clamped to root, finite link budget against loops) and stopping at the first non-existent component so leaf directories are still created for binding. Applied at both bind-mount sites (`spawn` and `spawn_interactive`).

This mirrors how containerd/CRI-O realize mounts and fixes **any** volume mounted under a symlinked parent, not just the SA token. Kernel mounts (`/proc`, `/sys`, `/dev`) target non-symlinked paths and are unchanged.

## Tests

- **5 unit tests** (`container::tests::resolve_mount_target_*`, no root) pin the resolver: `/var/run` symlink following, relative symlink resolution against the parent, plain passthrough, `..` clamping at root, and symlink-loop termination.
- **Integration test** `issue_334_symlinked_mount_dest::test_bind_mount_resolves_symlinked_parent` builds an isolated rootfs whose `/var/run` is an **absolute** symlink to `/run` (the case that genuinely reproduces the bug), bind-mounts a host dir as a stand-in SA token volume at `/var/run/secrets/kubernetes.io/serviceaccount`, and reads the token back through the symlinked path. Documented in `docs/INTEGRATION_TESTS.md`.

### Verification
- `cargo test --lib` — 373 passed (368 + 5 new)
- Mount-related integration regression: `filesystem` (12), `oci_lifecycle` (28), `issue_112` ca-cert bind (1), `cri_phase2` (5), `supplemental_groups` (2), and the new `issue_334` test — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)