### PR TITLE
fix(cri): keep container supervisors alive across pelagos-cri restart (#336)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -5121,3 +5121,24 @@ absolute symlink is used deliberately: a relative `../run` symlink happens to st
 the rootfs and would mask the bug. Complemented by the `container::tests::resolve_mount_target_*`
 unit tests, which pin the path-resolution logic (symlink following, relative targets,
 `..` clamping, loop termination) without requiring root.
+
+## `issue_336_cri_restart_readopt::test_scoped_supervisor_survives_service_kill`
+**Requires root and systemd** (skips gracefully when `/run/systemd/system`,
+`systemd-run`, or `systemctl` are absent).
+Validates the mechanism behind the #336 fix: per-container supervisors must outlive a
+`pelagos-cri` restart. A parent transient service stands in for `pelagos-cri.service`
+and launches two children — a "supervisor" `sleep` placed in its own
+`systemd-run --scope` under a dedicated slice (mirroring how pelagos-cri now launches
+the `pelagos run --detach` watcher and the pause), and a "control" `sleep` left directly
+in the parent service's cgroup. The test then `systemctl stop`s the parent service and
+asserts the control child is **killed** (proving systemd's default
+`KillMode=control-group` reaps everything in the service cgroup — the original bug) while
+the scoped supervisor **survives** (proving the fix moves supervisors outside the runtime's
+cgroup). Failure of the control assertion means the test is not exercising the real cgroup
+kill; failure of the supervisor assertion means the #336 regression has returned and a
+runtime restart would again kill/orphan running pods. Sentinels are carried in each sleep's
+argv0 (via symlinks) so `pgrep -f` matches uniquely, and all transient units/processes are
+torn down on every exit path. Complemented by the in-crate `pelagos-cri` unit tests
+(`scope::tests::*` for the systemd-run argv construction and `state::tests::*` for the
+startup re-adoption policy — live pause → re-adopt, dead pause → purge, native sandbox →
+never stale).

--- a/pelagos-cri/pelagos.slice
+++ b/pelagos-cri/pelagos.slice
@@ -1,0 +1,11 @@
+[Unit]
+Description=Pelagos CRI container supervisors
+Documentation=https://github.com/pelagos-containers/pelagos
+Before=slices.target
+# Supervisors (the per-container `pelagos run` watcher and per-pod pause process)
+# are placed in transient scope/service units under this slice by pelagos-cri, so
+# they live outside the pelagos-cri.service cgroup and survive a runtime restart
+# (issue #336). systemd auto-creates this slice if it is not installed; shipping it
+# lets operators tune resource accounting for all pelagos workloads in one place.
+
+[Slice]

--- a/pelagos-cri/src/main.rs
+++ b/pelagos-cri/src/main.rs
@@ -9,6 +9,7 @@ mod cni;
 mod image;
 mod invoke;
 mod runtime;
+mod scope;
 mod state;
 mod streaming;
 

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -31,6 +31,7 @@ use crate::cri::{
     UpdateRuntimeConfigRequest, UpdateRuntimeConfigResponse, VersionRequest, VersionResponse,
 };
 use crate::invoke::run_pelagos;
+use crate::scope;
 use crate::state::{
     self, AppState, ContainerState as MyContainerState, CriContainer, CriMount, CriSandbox,
     SandboxState,
@@ -176,9 +177,9 @@ fn read_proc_mem_bytes(pid: i32) -> u64 {
 /// Read cgroup memory stats for a container.
 ///
 /// Returns `(usage_bytes, working_set_bytes)` where:
-/// - `usage_bytes`       = total cgroup memory (all processes, including page cache)
-/// - `working_set_bytes` = usage minus reclaimable page cache (inactive_file),
-///                         the value metrics-server uses for HPA
+/// - `usage_bytes` = total cgroup memory (all processes, including page cache)
+/// - `working_set_bytes` = usage minus reclaimable page cache (inactive_file), the
+///   value metrics-server uses for HPA
 ///
 /// Priority:
 ///  1. cgroup v2: memory.current minus memory.stat[inactive_file]
@@ -666,19 +667,63 @@ impl RuntimeService for RuntimeSvc {
 
             // Spawn pause process: joins the CNI-configured netns, unshares IPC+UTS.
             // We re-use pelagos's own `sandbox __pause__ <ns_name>` subcommand.
-            let pause = std::process::Command::new(&bin)
-                .args(["sandbox", "__pause__", &ns_name])
-                .stdin(std::process::Stdio::null())
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .spawn()
-                .map_err(|e| Status::internal(format!("spawn pause process: {}", e)))?;
-            let pause_pid = pause.id() as i32;
-            // Intentionally leaked — killed explicitly on StopPodSandbox.
-            std::mem::forget(pause);
-
-            // Brief pause for the process to enter namespaces before containers join.
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            //
+            // Under systemd the pause runs as a transient service under
+            // `pelagos.slice` (created by PID 1) so it survives a `pelagos-cri`
+            // restart and the sandbox is re-adopted rather than torn down (#336).
+            // The pause blocks forever, so it must be a backgrounded *service*
+            // (not a `--scope`, which would block); its real PID is the unit's
+            // MainPID. Off systemd we fall back to a plain leaked child.
+            let pause_pid = if scope::systemd_available() {
+                let unit = scope::sandbox_unit(&id);
+                // A re-run for the same sandbox id would collide with a lingering
+                // unit; clear any stale one first (best effort).
+                scope::stop_unit(&unit).await;
+                let argv =
+                    scope::build_service_argv(&unit, &bin, &["sandbox", "__pause__", &ns_name]);
+                let out = tokio::process::Command::new(&argv[0])
+                    .args(&argv[1..])
+                    .output()
+                    .await
+                    .map_err(|e| Status::internal(format!("systemd-run pause: {}", e)))?;
+                if !out.status.success() {
+                    return Err(Status::internal(format!(
+                        "systemd-run pause failed: {}",
+                        String::from_utf8_lossy(&out.stderr).trim()
+                    )));
+                }
+                // MainPID is populated asynchronously once systemd forks the unit.
+                let mut pid = 0;
+                for _ in 0..40 {
+                    if let Some(p) = scope::service_main_pid(&unit).await {
+                        pid = p;
+                        break;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+                }
+                if pid <= 0 {
+                    scope::stop_unit(&unit).await;
+                    return Err(Status::internal(format!(
+                        "pause unit {} did not report a MainPID",
+                        unit
+                    )));
+                }
+                pid
+            } else {
+                let pause = std::process::Command::new(&bin)
+                    .args(["sandbox", "__pause__", &ns_name])
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .spawn()
+                    .map_err(|e| Status::internal(format!("spawn pause process: {}", e)))?;
+                let pid = pause.id() as i32;
+                // Intentionally leaked — killed explicitly on StopPodSandbox.
+                std::mem::forget(pause);
+                // Brief pause for the process to enter namespaces before containers join.
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                pid
+            };
 
             // Write pelagos-format sandbox state so `pelagos run --sandbox` works.
             state::write_pelagos_sandbox_state(&id, Some(&meta.name), pause_pid, &ns_name, &ip)
@@ -823,6 +868,11 @@ impl RuntimeService for RuntimeSvc {
                     let _ = std::process::Command::new("kill")
                         .args(["-TERM", &sb.pause_pid.to_string()])
                         .output();
+                }
+                // Tear down the transient pause service (#336); harmless if the
+                // pause was launched as a plain child on a non-systemd host.
+                if scope::systemd_available() {
+                    scope::stop_unit(&scope::sandbox_unit(&sandbox_id)).await;
                 }
                 cni::delete_netns(&sb.netns);
                 state::remove_pelagos_sandbox_state(&sandbox_id);
@@ -1532,9 +1582,25 @@ impl RuntimeService for RuntimeSvc {
         args.extend(effective_cmd);
 
         let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-        let out = run_pelagos(&bin, &args_ref)
-            .await
-            .map_err(|e| Status::internal(format!("exec error: {}", e)))?;
+        // Under systemd, wrap `pelagos run --detach` in a transient scope under
+        // `pelagos.slice` so the watcher it forks lives outside the
+        // `pelagos-cri.service` cgroup and survives a runtime restart (#336). The
+        // foreground `pelagos run` returns promptly after forking the watcher, so
+        // the scope (kept alive by the watcher) outlives this call. Off systemd we
+        // invoke pelagos directly, preserving prior behavior.
+        let out = if scope::systemd_available() {
+            let unit = scope::container_unit(&container.pelagos_name);
+            scope::stop_unit(&unit).await; // clear any stale unit for this name
+            let argv = scope::build_scope_argv(&unit, &bin, &args_ref);
+            let argv_ref: Vec<&str> = argv.iter().map(|s| s.as_str()).collect();
+            run_pelagos(argv_ref[0], &argv_ref[1..])
+                .await
+                .map_err(|e| Status::internal(format!("exec error: {}", e)))?
+        } else {
+            run_pelagos(&bin, &args_ref)
+                .await
+                .map_err(|e| Status::internal(format!("exec error: {}", e)))?
+        };
 
         if !out.success {
             log::error!(
@@ -1597,6 +1663,11 @@ impl RuntimeService for RuntimeSvc {
         };
 
         let _ = run_pelagos(&bin, &["stop", &pelagos_name]).await;
+        // The watcher has exited, so the transient scope is now empty; --collect
+        // reaps it, but stop it explicitly for determinism (#336).
+        if scope::systemd_available() {
+            scope::stop_unit(&scope::container_unit(&pelagos_name)).await;
+        }
 
         let mut st = self.state.inner.lock().await;
         if let Some(c) = st.containers.get_mut(&container_id) {
@@ -1624,6 +1695,9 @@ impl RuntimeService for RuntimeSvc {
 
         if let Some(name) = pelagos_name {
             let _ = run_pelagos(&bin, &["rm", &name]).await;
+            if scope::systemd_available() {
+                scope::stop_unit(&scope::container_unit(&name)).await;
+            }
         }
 
         let mut st = self.state.inner.lock().await;

--- a/pelagos-cri/src/scope.rs
+++ b/pelagos-cri/src/scope.rs
@@ -1,0 +1,215 @@
+//! Transient systemd-unit supervision for container/pause processes.
+//!
+//! Issue #336: per-container supervisors (the detached `pelagos run` watcher and
+//! the sandbox pause process) were launched as plain children of pelagos-cri and
+//! therefore lived in the `pelagos-cri.service` cgroup. systemd's default
+//! `KillMode=control-group` means a `systemctl restart pelagos-cri` SIGTERMs (then
+//! SIGKILLs) every process in that cgroup — taking the supervisors, and with them
+//! the running workloads, down with the runtime. Compliant CRIs (containerd,
+//! CRI-O) keep each container's supervisor in its own transient scope/service so a
+//! runtime restart is transparent.
+//!
+//! This module launches supervisors via `systemd-run`, which asks systemd (PID 1)
+//! to create the unit. The resulting processes are children of systemd under
+//! `pelagos.slice`, fully outside `pelagos-cri.service`, so they survive a runtime
+//! restart and are re-adopted on startup.
+//!
+//! Two unit kinds are used because the two supervisors have different lifecycles:
+//!
+//! * **scope** for `pelagos run --detach`: the foreground process forks the
+//!   watcher and returns quickly, so `systemd-run --scope` returns promptly while
+//!   the watcher persists in the (non-empty) scope.
+//! * **service** for the pause process: it blocks forever, so it is run as a
+//!   backgrounded transient service whose `MainPID` is the real pause PID.
+//!
+//! When systemd is unavailable (unit tests, non-systemd hosts) callers fall back to
+//! launching the process directly, preserving the previous behavior.
+
+use std::sync::OnceLock;
+
+/// Slice that groups all pelagos supervisor units. systemd auto-creates it when
+/// first referenced; an optional shipped `pelagos.slice` may set properties.
+pub const SLICE: &str = "pelagos.slice";
+
+/// Whether this host is running under systemd and `systemd-run` is usable.
+///
+/// Requires both a live systemd (`/run/systemd/system`) and `systemd-run` on PATH.
+/// Cached after the first probe.
+pub fn systemd_available() -> bool {
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        std::path::Path::new("/run/systemd/system").is_dir() && which_systemd_run().is_some()
+    })
+}
+
+fn which_systemd_run() -> Option<String> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let cand = dir.join("systemd-run");
+        if cand.is_file() {
+            return Some(cand.to_string_lossy().into_owned());
+        }
+    }
+    None
+}
+
+/// Sanitize an arbitrary id into a valid systemd unit-name component.
+///
+/// systemd unit names allow `[A-Za-z0-9:_.\\-]`; anything else is replaced with
+/// `-`. The id is truncated so the final unit name stays well within systemd's
+/// 256-byte limit while remaining collision-free for our hex/`pcri-` ids.
+fn sanitize(id: &str) -> String {
+    let mut s: String = id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, ':' | '_' | '.' | '-') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if s.len() > 64 {
+        s.truncate(64);
+    }
+    s
+}
+
+/// Unit name for a container watcher scope, e.g. `pelagos-ctr-pcri-abc123.scope`.
+pub fn container_unit(pelagos_name: &str) -> String {
+    format!("pelagos-ctr-{}.scope", sanitize(pelagos_name))
+}
+
+/// Unit name for a sandbox pause service, e.g. `pelagos-sbx-<id>.service`.
+pub fn sandbox_unit(sandbox_id: &str) -> String {
+    format!("pelagos-sbx-{}.service", sanitize(sandbox_id))
+}
+
+/// Build the `systemd-run --scope` argv that wraps a quick-returning command
+/// whose forked descendants must outlive the runtime (the `pelagos run --detach`
+/// watcher). Returns the full argv beginning with `systemd-run`.
+pub fn build_scope_argv(unit: &str, bin: &str, args: &[&str]) -> Vec<String> {
+    let mut v = vec![
+        "systemd-run".to_string(),
+        "--scope".to_string(),
+        "--collect".to_string(),
+        format!("--slice={}", SLICE),
+        format!("--unit={}", unit),
+        "--quiet".to_string(),
+        "--".to_string(),
+        bin.to_string(),
+    ];
+    v.extend(args.iter().map(|s| s.to_string()));
+    v
+}
+
+/// Build the `systemd-run` transient-service argv for a long-running, blocking
+/// command (the pause process). The service is backgrounded; `systemd-run`
+/// returns immediately and the real process is the unit's `MainPID`.
+///
+/// `KillMode=mixed` so that stopping the unit signals the main process directly,
+/// and `--collect` so a failed unit is garbage-collected rather than lingering.
+pub fn build_service_argv(unit: &str, bin: &str, args: &[&str]) -> Vec<String> {
+    let mut v = vec![
+        "systemd-run".to_string(),
+        "--collect".to_string(),
+        format!("--slice={}", SLICE),
+        format!("--unit={}", unit),
+        "--property=KillMode=mixed".to_string(),
+        "--quiet".to_string(),
+        "--".to_string(),
+        bin.to_string(),
+    ];
+    v.extend(args.iter().map(|s| s.to_string()));
+    v
+}
+
+/// Query the `MainPID` of a transient service unit. Returns `None` if the unit is
+/// unknown, inactive, or systemd reports PID 0 (not yet started / already gone).
+pub async fn service_main_pid(unit: &str) -> Option<i32> {
+    let out = tokio::process::Command::new("systemctl")
+        .args(["show", "-p", "MainPID", "--value", unit])
+        .output()
+        .await
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let pid: i32 = String::from_utf8_lossy(&out.stdout).trim().parse().ok()?;
+    if pid > 0 {
+        Some(pid)
+    } else {
+        None
+    }
+}
+
+/// Best-effort stop of a transient unit (scope or service). Errors are ignored:
+/// scopes auto-collect when empty, and a missing unit is already gone.
+pub async fn stop_unit(unit: &str) {
+    let _ = tokio::process::Command::new("systemctl")
+        .args(["stop", unit])
+        .output()
+        .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scope_argv_wraps_command_under_slice_and_unit() {
+        let argv = build_scope_argv(
+            "pelagos-ctr-pcri-abc123.scope",
+            "/usr/local/bin/pelagos",
+            &["run", "--detach", "--name", "pcri-abc123"],
+        );
+        assert_eq!(argv[0], "systemd-run");
+        assert!(argv.contains(&"--scope".to_string()));
+        assert!(argv.contains(&"--collect".to_string()));
+        assert!(argv.contains(&"--slice=pelagos.slice".to_string()));
+        assert!(argv.contains(&"--unit=pelagos-ctr-pcri-abc123.scope".to_string()));
+        // The `--` separator must precede the wrapped binary so its flags are not
+        // parsed by systemd-run.
+        let sep = argv.iter().position(|s| s == "--").unwrap();
+        assert_eq!(argv[sep + 1], "/usr/local/bin/pelagos");
+        assert_eq!(argv[sep + 2], "run");
+        assert_eq!(argv.last().unwrap(), "pcri-abc123");
+    }
+
+    #[test]
+    fn service_argv_is_backgrounded_with_killmode() {
+        let argv = build_service_argv(
+            "pelagos-sbx-deadbeef.service",
+            "/usr/local/bin/pelagos",
+            &["sandbox", "__pause__", "pcri-deadbeef"],
+        );
+        assert_eq!(argv[0], "systemd-run");
+        // A transient *service* must NOT carry --scope (which would block).
+        assert!(!argv.contains(&"--scope".to_string()));
+        assert!(argv.contains(&"--property=KillMode=mixed".to_string()));
+        assert!(argv.contains(&"--unit=pelagos-sbx-deadbeef.service".to_string()));
+        let sep = argv.iter().position(|s| s == "--").unwrap();
+        assert_eq!(argv[sep + 1], "/usr/local/bin/pelagos");
+        assert_eq!(argv[sep + 2], "sandbox");
+    }
+
+    #[test]
+    fn unit_names_are_sanitized_and_bounded() {
+        // Hex/`pcri-` ids pass through unchanged.
+        assert_eq!(
+            container_unit("pcri-abc123def456"),
+            "pelagos-ctr-pcri-abc123def456.scope"
+        );
+        assert_eq!(
+            sandbox_unit("0123456789abcdef"),
+            "pelagos-sbx-0123456789abcdef.service"
+        );
+        // Disallowed characters are replaced; length is bounded.
+        let dirty = sanitize("a/b c*d\u{00e9}");
+        assert!(dirty
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, ':' | '_' | '.' | '-')));
+        let long = sanitize(&"x".repeat(200));
+        assert!(long.len() <= 64);
+    }
+}

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -230,27 +230,28 @@ impl AppState {
         let mut inner = StateInner::load();
         inner.pelagos_bin = pelagos_bin;
 
-        // Purge stale sandboxes whose pause process no longer exists.
-        // This happens when pelagos-cri restarts (e.g. after a system reboot or
-        // RuntimeDirectory wipe) and the in-memory /run/pelagos/ state is gone.
-        // k3s persists container IDs across its own restarts and will call
-        // StartContainer on those old IDs, hitting "sandbox not found".
-        // Removing the records here gives k3s a clean slate and causes it to
-        // recreate the pods from scratch.
-        let stale_sandbox_ids: Vec<String> = inner
-            .sandboxes
-            .values()
-            .filter(|s| {
-                if s.pause_pid <= 0 {
-                    return false;
-                }
-                // Process is alive iff /proc/<pid> exists.
-                !std::path::Path::new(&format!("/proc/{}", s.pause_pid)).exists()
-            })
-            .map(|s| s.id.clone())
-            .collect();
+        // Re-adopt running pods across a `pelagos-cri` restart (#336).
+        //
+        // CRI metadata under /run/pelagos-cri/ persists across restarts, and —
+        // because each pod's pause process now runs in its own transient systemd
+        // unit under `pelagos.slice` (see `scope`) — the pause survives the
+        // runtime restart too. So a sandbox whose pause is still alive is simply
+        // re-adopted: its metadata is kept and the kubelet's view is unchanged.
+        //
+        // Only sandboxes whose pause is genuinely gone (crash, reboot before the
+        // unit came back, or a legacy non-scoped pause killed with the old
+        // runtime) are purged, taking their containers with them, so the kubelet
+        // recreates just those pods rather than every pod on the node.
+        let stale = stale_sandbox_ids(&inner.sandboxes, |pid| {
+            std::path::Path::new(&format!("/proc/{}", pid)).exists()
+        });
 
-        for sid in &stale_sandbox_ids {
+        let adopted = inner.sandboxes.len() - stale.len();
+        if adopted > 0 {
+            log::info!("startup: re-adopting {adopted} running sandbox(es) across restart");
+        }
+
+        for sid in &stale {
             log::info!("startup: removing stale sandbox {sid} (pause process gone)");
             // Remove all containers that belonged to this sandbox.
             let stale_ctrs: Vec<String> = inner
@@ -272,6 +273,24 @@ impl AppState {
             inner: Arc::new(Mutex::new(inner)),
         }
     }
+}
+
+/// Identify sandboxes whose supervisor (pause process) is gone and must be purged
+/// on startup. `is_alive(pid)` reports whether a given pause PID is still running.
+///
+/// Sandboxes created on the native (non-CNI) path have `pause_pid <= 0` and no
+/// pause process to check, so they are never treated as stale here. Pulled out as
+/// a pure function so the re-adoption policy can be unit-tested without touching
+/// `/proc` (#336).
+pub(crate) fn stale_sandbox_ids<F: Fn(i32) -> bool>(
+    sandboxes: &HashMap<String, CriSandbox>,
+    is_alive: F,
+) -> Vec<String> {
+    sandboxes
+        .values()
+        .filter(|s| s.pause_pid > 0 && !is_alive(s.pause_pid))
+        .map(|s| s.id.clone())
+        .collect()
 }
 
 // ── Disk helpers ─────────────────────────────────────────────────────────────
@@ -372,4 +391,56 @@ fn load_all_containers() -> HashMap<String, CriContainer> {
         })
         .map(|c| (c.id.clone(), c))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a CriSandbox with the given id and pause_pid via JSON so we don't
+    /// have to spell out every (mostly `#[serde(default)]`) field.
+    fn sandbox(id: &str, pause_pid: i32) -> CriSandbox {
+        let json = format!(
+            r#"{{"id":"{id}","name":"n","namespace":"ns","uid":"u","attempt":0,
+                 "labels":{{}},"annotations":{{}},"created_at_ns":0,"state":"Running",
+                 "pause_pid":{pause_pid}}}"#
+        );
+        serde_json::from_str(&json).expect("valid sandbox json")
+    }
+
+    fn map(items: Vec<CriSandbox>) -> HashMap<String, CriSandbox> {
+        items.into_iter().map(|s| (s.id.clone(), s)).collect()
+    }
+
+    #[test]
+    fn live_pause_sandboxes_are_re_adopted_not_purged() {
+        // Two CNI sandboxes whose pause processes are still alive must survive a
+        // restart untouched (#336): stale set is empty.
+        let sandboxes = map(vec![sandbox("alive1", 1001), sandbox("alive2", 1002)]);
+        let stale = stale_sandbox_ids(&sandboxes, |_pid| true);
+        assert!(
+            stale.is_empty(),
+            "live sandboxes must be re-adopted: {stale:?}"
+        );
+    }
+
+    #[test]
+    fn dead_pause_sandboxes_are_purged() {
+        // Only the sandbox whose pause is gone is purged; the live one is kept.
+        let sandboxes = map(vec![sandbox("alive", 1001), sandbox("dead", 1002)]);
+        let stale = stale_sandbox_ids(&sandboxes, |pid| pid == 1001);
+        assert_eq!(stale, vec!["dead".to_string()]);
+    }
+
+    #[test]
+    fn native_sandboxes_without_pause_are_never_stale() {
+        // pause_pid <= 0 (native bridge path) has no pause to check; such a
+        // sandbox must not be purged even though `is_alive` would say "dead".
+        let sandboxes = map(vec![sandbox("native", 0), sandbox("native_neg", -1)]);
+        let stale = stale_sandbox_ids(&sandboxes, |_pid| false);
+        assert!(
+            stale.is_empty(),
+            "native sandboxes must never be stale: {stale:?}"
+        );
+    }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -27942,3 +27942,181 @@ mod issue_334_symlinked_mount_dest {
         );
     }
 }
+
+/// Issue #336: a `pelagos-cri` restart must be transparent to running pods. The
+/// fix launches each per-container supervisor (the `pelagos run --detach` watcher
+/// and the per-pod pause) in its own transient systemd scope/service under
+/// `pelagos.slice`, created by systemd (PID 1), so it lives OUTSIDE the
+/// `pelagos-cri.service` cgroup and is not taken down by systemd's default
+/// `KillMode=control-group` when the runtime restarts.
+///
+/// This module validates that exact mechanism end to end with systemd, without
+/// needing a full CNI/k8s stack: a process placed in a transient scope survives
+/// when its launching service's cgroup is killed, while a control child left in
+/// that cgroup is killed — i.e. the regression is reproduced and fixed.
+mod issue_336_cri_restart_readopt {
+    use super::*;
+    use std::process::Command as Proc;
+
+    /// systemd usable iff PID 1 is systemd and systemd-run/systemctl are present.
+    fn systemd_usable() -> bool {
+        if !std::path::Path::new("/run/systemd/system").is_dir() {
+            return false;
+        }
+        let have = |b: &str| {
+            Proc::new("sh")
+                .args(["-c", &format!("command -v {b}")])
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        };
+        have("systemd-run") && have("systemctl")
+    }
+
+    /// True iff at least one process whose command line matches `pat` is alive.
+    fn matches_alive(pat: &str) -> bool {
+        Proc::new("pgrep")
+            .args(["-f", pat])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    fn stop_unit(unit: &str) {
+        let _ = Proc::new("systemctl").args(["stop", unit]).output();
+        let _ = Proc::new("systemctl").args(["reset-failed", unit]).output();
+    }
+
+    /// Requires root and systemd.
+    ///
+    /// Reproduces the #336 mechanism: a parent transient service (standing in for
+    /// `pelagos-cri.service`) launches a "supervisor" sleep inside its own
+    /// `systemd-run --scope` (as the fix does for the watcher) plus a "control"
+    /// sleep left directly in the parent's cgroup. Stopping the parent service
+    /// must kill the control child (proving the cgroup kill is real) but leave the
+    /// scoped supervisor running (proving the fix makes supervisors survive a
+    /// runtime restart).
+    #[test]
+    fn test_scoped_supervisor_survives_service_kill() {
+        if !is_root() {
+            eprintln!("Skipping test_scoped_supervisor_survives_service_kill: requires root");
+            return;
+        }
+        if !systemd_usable() {
+            eprintln!("Skipping test_scoped_supervisor_survives_service_kill: systemd unavailable");
+            return;
+        }
+
+        // Unique sentinels so pgrep finds exactly our sleeps across the run.
+        let pid = std::process::id();
+        let sup_tag = format!("pelagos336sup{pid}"); // scoped supervisor marker
+        let ctrl_tag = format!("pelagos336ctl{pid}"); // control child marker
+        let parent_unit = format!("pelagos336-parent-{pid}.service");
+        let scope_unit = format!("pelagos336-sup-{pid}.scope");
+        // Flat slice name (no internal dash before the pid) so systemd does not
+        // auto-create a lingering parent slice; cleanup then removes it fully.
+        let slice = format!("pelagos336t{pid}.slice");
+
+        // Clean any stragglers from a prior aborted run.
+        stop_unit(&parent_unit);
+        stop_unit(&scope_unit);
+
+        // Carry the sentinels in the *binary name* (symlinks to sleep) rather than
+        // as args — `sleep 3600 <tag>` would be an invalid time interval. pgrep -f
+        // then matches each sleep's argv0 uniquely.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sleep_bin = ["/bin/sleep", "/usr/bin/sleep"]
+            .into_iter()
+            .find(|p| std::path::Path::new(p).exists())
+            .expect("a sleep binary");
+        let sup_bin = dir.path().join(&sup_tag);
+        let ctrl_bin = dir.path().join(&ctrl_tag);
+        std::os::unix::fs::symlink(sleep_bin, &sup_bin).expect("symlink sup sleep");
+        std::os::unix::fs::symlink(sleep_bin, &ctrl_bin).expect("symlink ctrl sleep");
+
+        // The parent service's body, written to a temp script so the parent's own
+        // command line does NOT contain the sentinels (keeping pgrep unambiguous).
+        let runner = dir.path().join("runner.sh");
+        let body = format!(
+            "#!/bin/sh\n\
+             # Supervisor: launched in its OWN scope under {slice} (the fix).\n\
+             systemd-run --scope --slice={slice} --unit={scope_unit} --quiet -- \
+                 {sup} 3600 &\n\
+             # Control: stays in THIS service's cgroup, must die on stop.\n\
+             {ctrl} 3600 &\n\
+             # Keep the service active until we stop it.\n\
+             exec {sleep_bin} 3600\n",
+            sup = sup_bin.to_str().unwrap(),
+            ctrl = ctrl_bin.to_str().unwrap(),
+        );
+        std::fs::write(&runner, body).expect("write runner");
+
+        // Launch the parent service (stand-in for pelagos-cri.service).
+        let start = Proc::new("systemd-run")
+            .args([
+                "--unit",
+                &parent_unit,
+                "--quiet",
+                "--",
+                "/bin/sh",
+                runner.to_str().unwrap(),
+            ])
+            .output()
+            .expect("systemd-run parent");
+        assert!(
+            start.status.success(),
+            "failed to start parent service: {}",
+            String::from_utf8_lossy(&start.stderr)
+        );
+
+        // Wait for both children to come up (the scope launch is async).
+        let mut both_up = false;
+        for _ in 0..50 {
+            if matches_alive(&sup_tag) && matches_alive(&ctrl_tag) {
+                both_up = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+
+        // Only act once both are up; otherwise leave the outcome flags false so the
+        // assert below reports the real problem. Cleanup runs unconditionally.
+        let mut ctrl_dead = false;
+        let mut sup_alive = false;
+        if both_up {
+            // Stop the parent service — control-group kill takes everything still
+            // in its cgroup, exactly like `systemctl restart pelagos-cri`.
+            let _ = Proc::new("systemctl").args(["stop", &parent_unit]).output();
+
+            // Observe outcomes, polling for the control child to die.
+            for _ in 0..50 {
+                if !matches_alive(&ctrl_tag) {
+                    ctrl_dead = true;
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            sup_alive = matches_alive(&sup_tag);
+        }
+
+        // Always clean up before asserting so no failure path leaks units/procs.
+        stop_unit(&scope_unit);
+        stop_unit(&parent_unit);
+        let _ = Proc::new("pkill").args(["-f", &sup_tag]).output();
+        let _ = Proc::new("pkill").args(["-f", &ctrl_tag]).output();
+        let _ = Proc::new("systemctl").args(["stop", &slice]).output();
+
+        assert!(
+            both_up,
+            "supervisor and control children did not both start"
+        );
+        assert!(
+            ctrl_dead,
+            "control child survived the service stop — the cgroup kill is not happening as assumed; test is not exercising #336"
+        );
+        assert!(
+            sup_alive,
+            "scoped supervisor was killed when the parent service stopped — #336 regression: supervisors must outlive a runtime restart"
+        );
+    }
+}


### PR DESCRIPTION
Closes #336.

## Problem

A `systemctl restart pelagos-cri` (including a routine package upgrade) disrupted **every pod on the node**:
- `restartPolicy: Never` → container process killed, pod `Failed`, `restartCount=1`.
- `restartPolicy: Always` → old process killed, kubelet recreates, `restartCount` desyncs.
- SIGTERM-ignoring workloads (node-exporter, Vault) → old process **orphaned**, one leaked per restart (a Vault Raft node kept its BoltDB lock and crashlooped the replacement).

## Root cause

The per-container **supervisor** — the detached `pelagos run` watcher, and the per-pod **pause** — was a plain child of pelagos-cri and lived in the `pelagos-cri.service` cgroup. systemd's default `KillMode=control-group` SIGTERMs (then SIGKILLs) that entire cgroup on restart, so the watcher was signalled and either forwarded SIGTERM to its workload (killing `Never` pods) or died and orphaned it. The workload itself **already** runs in its own kubepods cgroup (`cgroup.procs`); only the supervisor was exposed. CRI metadata under `/run/pelagos-cri/` already persists across restarts — the missing piece was **supervisor survival**.

## Fix

Launch each supervisor in its own transient systemd unit under a dedicated **`pelagos.slice`**, created by systemd (PID 1) and therefore fully outside `pelagos-cri.service`, exactly as containerd/CRI-O isolate their shims:

- **Container watcher** → `systemd-run --scope` wrapping `pelagos run --detach`. The foreground returns promptly after forking the watcher, which persists in the (non-empty) scope.
- **Pause** → backgrounded `systemd-run` transient **service** (it blocks forever, so a `--scope` would hang); the real pause PID is the unit `MainPID`.
- **Fallback**: off systemd (unit tests, non-systemd hosts) both fall back to the prior direct-spawn path.
- **Teardown**: Stop/Remove tear units down (`--collect` + explicit `systemctl stop`).

**Re-adoption:** with supervisors surviving, persisted CRI state is re-adopted rather than purged. The stale-sandbox detection is refactored into a pure, unit-tested function: live pause → re-adopt, dead pause → purge only that pod's containers, native sandbox (no pause) → never stale.

New module `pelagos-cri/src/scope.rs` (systemd detection, unit naming, argv builders, `MainPID` query, teardown) and a shipped `pelagos.slice`.

## Tests

- **pelagos-cri unit tests** (`scope::tests`, `state::tests`): systemd-run scope/service argv construction, unit-name sanitization, and the re-adoption policy.
- **Integration test** `issue_336_cri_restart_readopt::test_scoped_supervisor_survives_service_kill` (root + systemd; skips gracefully otherwise): a scoped supervisor **survives** a parent-service stop while a control child left in the service cgroup is **killed** — reproducing and fixing the bug. Documented in `docs/INTEGRATION_TESTS.md`.
- **Live end-to-end**: `scripts/test-cri.sh` **36/36 pass** through the real `systemd-run` scope/service path (RunPodSandbox/CreateContainer/StartContainer/ExecSync/stats/Stop/Remove); supervisor units are cleaned up on teardown.
- `cargo test --lib` 373 pass; `cargo test -p pelagos-cri --bins` 23 pass; `cri_phase2/3/4` + `cri_uid` integration tests green.

### Design note
The approach (systemd-run transient scope per supervisor) was chosen over the lighter `KillMode=process` unit tweak and an in-code cgroup escape, as the most correct, systemd-native, containerd/CRI-O-equivalent design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)