### PR TITLE
fix(security): guard against host-destructive removals — never delete outside pelagos dirs (#347)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -5196,3 +5196,17 @@ Validated by the `pelagos-cri` unit tests `image::tests::*` (run via
   concurrency-safe (serialized by a mutex).
 Note: `crictl img`/`images` is ListImages; `crictl inspecti` is ImageStatus —
 the assertions use the correct one for each check.
+
+## `issue_347_no_host_destruction::test_rm_refuses_path_like_names_and_spares_host_bin`
+**Does NOT require root.**
+Regression guard for the CRITICAL host-destructive bug #347, where an inconsistent
+("phantom") sandbox caused pelagos to `unlink` the host `/bin` symlink during GC — a
+removal whose base path resolved outside pelagos's managed directories. Runs the
+`pelagos` binary with empty and path-like names (`/bin`, `/usr`, `../../../bin`, ``, `.`)
+and asserts each `pelagos rm` **fails** and that the host `/bin` still exists afterward.
+Failure means the CLI accepted a name that could escape pelagos's managed dirs and a
+removal touched the host filesystem. Complemented by the unit tests
+`paths::tests::test_guard_*` (which pin `is_safe_to_remove`: rejects `/`, `/bin`, the
+managed roots and wholesale parent dirs, and `join`/`..` escapes; accepts legitimate
+container/sandbox/overlay/image subpaths) and `test_guarded_remove_refuses_unmanaged_dir`
+(functional proof that `guarded_remove_dir_all` leaves an out-of-tree directory intact).

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -311,7 +311,19 @@ pub fn save_container(c: &CriContainer) -> std::io::Result<()> {
     std::fs::write(path, json)
 }
 
+/// A CRI id must be a non-empty, single path component (our ids are 64-char
+/// hex). Reject anything else so a corrupted/empty id from an inconsistent
+/// ("phantom") sandbox can never make a removal escape its directory or wipe a
+/// whole parent dir (#347).
+fn valid_id(id: &str) -> bool {
+    !id.is_empty() && id != "." && id != ".." && !id.contains('/') && !id.contains('\0')
+}
+
 pub fn remove_sandbox_file(id: &str) {
+    if !valid_id(id) {
+        log::error!("remove_sandbox_file: refusing invalid id {id:?} (#347)");
+        return;
+    }
     let _ = std::fs::remove_file(format!("{}/{}.json", SANDBOXES_DIR, id));
 }
 
@@ -353,11 +365,19 @@ pub fn write_pelagos_sandbox_state(
 
 /// Remove the pelagos-format sandbox state directory.
 pub fn remove_pelagos_sandbox_state(id: &str) {
+    if !valid_id(id) {
+        log::error!("remove_pelagos_sandbox_state: refusing invalid id {id:?} (#347)");
+        return;
+    }
     let dir = format!("{}/{}", PELAGOS_SANDBOXES_DIR, id);
     let _ = std::fs::remove_dir_all(dir);
 }
 
 pub fn remove_container_file(id: &str) {
+    if !valid_id(id) {
+        log::error!("remove_container_file: refusing invalid id {id:?} (#347)");
+        return;
+    }
     let _ = std::fs::remove_file(format!("{}/{}.json", CONTAINERS_DIR, id));
 }
 

--- a/src/cli/rm.rs
+++ b/src/cli/rm.rs
@@ -51,8 +51,15 @@ pub fn cmd_rm(name: &str, force: bool) -> Result<(), Box<dyn std::error::Error>>
         }
     }
 
+    // Reject an empty/separator-laden name before building a removal path: an
+    // empty name makes `container_dir("")` resolve to the containers parent dir
+    // (wiping ALL containers), and a `/`-leading name escapes it entirely (#347).
+    if name.is_empty() || name.contains('/') || name == "." || name == ".." {
+        return Err(format!("invalid container name '{}'", name).into());
+    }
     let dir = container_dir(name);
-    std::fs::remove_dir_all(&dir).map_err(|e| format!("remove {}: {}", dir.display(), e))?;
+    pelagos::paths::guarded_remove_dir_all(&dir)
+        .map_err(|e| format!("remove {}: {}", dir.display(), e))?;
 
     Ok(())
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1210,7 +1210,7 @@ fn prepare_persistent_upper(
 
     // Work dir must be empty at mount time — recreate it every run.
     let work = container_d.join("work");
-    let _ = std::fs::remove_dir_all(&work);
+    let _ = pelagos::paths::guarded_remove_dir_all(&work);
     std::fs::create_dir_all(&work)?;
     let _ = std::fs::set_permissions(&work, std::fs::Permissions::from_mode(0o755));
 
@@ -1330,7 +1330,7 @@ fn run_foreground(
     if auto_remove {
         // Remove state directory immediately; ignore errors (best-effort).
         let dir = super::container_dir(&name);
-        let _ = std::fs::remove_dir_all(&dir);
+        let _ = pelagos::paths::guarded_remove_dir_all(&dir);
     } else {
         state.status = ContainerStatus::Exited;
         state.exit_code = Some(code);
@@ -1419,7 +1419,7 @@ fn run_interactive(
 
     if auto_remove {
         let dir = super::container_dir(&name);
-        let _ = std::fs::remove_dir_all(&dir);
+        let _ = pelagos::paths::guarded_remove_dir_all(&dir);
     } else {
         state.status = ContainerStatus::Exited;
         state.exit_code = Some(code);
@@ -1577,7 +1577,7 @@ fn run_detached(a: DetachedArgs) -> Result<(), Box<dyn std::error::Error>> {
                 Err(e) => {
                     // Remove the state directory so a failed spawn doesn't leave a ghost
                     // container showing as "running" in `pelagos ps`.
-                    let _ = std::fs::remove_dir_all(&dir);
+                    let _ = pelagos::paths::guarded_remove_dir_all(&dir);
                     // Write the error message to the sync pipe so the parent can surface it,
                     // then close the pipe and exit.  The parent distinguishes success (\x00)
                     // from error (any other bytes) by reading more than 1 byte.

--- a/src/container.rs
+++ b/src/container.rs
@@ -8150,15 +8150,17 @@ impl Child {
         if !preserve_overlay {
             if let Some(ref merged) = self.overlay_merged_dir.take() {
                 if let Some(parent) = merged.parent() {
-                    let _ = std::fs::remove_dir_all(parent);
+                    // Guarded: never remove a path outside pelagos-managed dirs,
+                    // even if the overlay base were somehow mis-computed (#347).
+                    let _ = crate::paths::guarded_remove_dir_all(parent);
                 }
             }
         }
         if let Some(ref dir) = self.dns_temp_dir.take() {
-            let _ = std::fs::remove_dir_all(dir);
+            let _ = crate::paths::guarded_remove_dir_all(dir);
         }
         if let Some(ref dir) = self.hosts_temp_dir.take() {
-            let _ = std::fs::remove_dir_all(dir);
+            let _ = crate::paths::guarded_remove_dir_all(dir);
         }
         // Join the user_notif supervisor thread (it exits when the notif_fd is closed,
         // which happens when the child process exits and the kernel drops the fd).

--- a/src/oci.rs
+++ b/src/oci.rs
@@ -2389,7 +2389,7 @@ pub fn cmd_delete(id: &str) -> io::Result<()> {
 
     // Load config before removing state dir so we can run poststop hooks.
     let bundle_path = state.bundle.clone();
-    fs::remove_dir_all(state_dir(id))?;
+    crate::paths::guarded_remove_dir_all(&state_dir(id))?;
 
     // Run poststop hooks (best-effort — state dir is already gone).
     if let Ok(config) = config_from_bundle(std::path::Path::new(&bundle_path)) {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -455,9 +455,166 @@ pub fn validate_install() -> Vec<InstallIssue> {
     issues
 }
 
+// ── Host-destructive-removal guard (issue #347) ─────────────────────────────
+
+/// Lexically normalize an absolute path: collapse `.`, `..`, and repeated
+/// separators WITHOUT touching the filesystem (no symlink resolution, no
+/// existence requirement). Returns `None` for a non-absolute path.
+fn normalize_abs(path: &std::path::Path) -> Option<PathBuf> {
+    use std::path::Component;
+    if !path.is_absolute() {
+        return None;
+    }
+    let mut out = PathBuf::from("/");
+    for comp in path.components() {
+        match comp {
+            Component::RootDir | Component::Prefix(_) | Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::Normal(c) => out.push(c),
+        }
+    }
+    Some(out)
+}
+
+/// Directories pelagos manages but must NEVER remove wholesale — removing one of
+/// these would wipe every container/sandbox/image/layer/volume at once (e.g. an
+/// empty container name making `containers_dir().join("")` resolve to
+/// `containers_dir()` itself).
+fn protected_parent_dirs() -> Vec<PathBuf> {
+    [
+        containers_dir(),
+        sandboxes_dir(),
+        images_dir(),
+        layers_dir(),
+        volumes_dir(),
+        runtime_dir(),
+        data_dir(),
+    ]
+    .into_iter()
+    .filter_map(|p| normalize_abs(&p))
+    .collect()
+}
+
+/// True iff `path` is safe for pelagos to recursively remove: an absolute,
+/// lexically-normalized path that is a **strict descendant** of a managed root
+/// (`/run/pelagos`, `/var/lib/pelagos`, or the rootless equivalents) and is not
+/// one of the wholesale parent dirs.
+///
+/// Guards against issue #347 — a host-destructive bug where an inconsistent
+/// ("phantom") sandbox/container yielded an empty or absolute base path that
+/// `PathBuf::join` resolved OUTSIDE pelagos's directories (e.g. to the host
+/// `/bin` symlink), and a teardown `remove_dir_all`/unlink then deleted it.
+pub fn is_safe_to_remove(path: &std::path::Path) -> bool {
+    let Some(norm) = normalize_abs(path) else {
+        return false;
+    };
+    // Never a managed parent dir itself.
+    if protected_parent_dirs().contains(&norm) {
+        return false;
+    }
+    // Must be a strict descendant of a managed root.
+    [runtime_dir(), data_dir()]
+        .iter()
+        .filter_map(|r| normalize_abs(r))
+        .any(|root| norm.starts_with(&root) && norm != root)
+}
+
+/// `remove_dir_all`, but refuses (logs an error and returns `Ok`) for any path
+/// not strictly under a pelagos-managed root — a belt-and-suspenders guard
+/// against host-destructive removals (#347). `NotFound` is treated as success.
+pub fn guarded_remove_dir_all(path: &std::path::Path) -> std::io::Result<()> {
+    if !is_safe_to_remove(path) {
+        log::error!(
+            "refusing to remove path outside pelagos-managed dirs: {} (#347 guard)",
+            path.display()
+        );
+        return Ok(());
+    }
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+/// `remove_file`/unlink with the same managed-root guard as
+/// [`guarded_remove_dir_all`].
+pub fn guarded_remove_file(path: &std::path::Path) -> std::io::Result<()> {
+    if !is_safe_to_remove(path) {
+        log::error!(
+            "refusing to unlink path outside pelagos-managed dirs: {} (#347 guard)",
+            path.display()
+        );
+        return Ok(());
+    }
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_guard_rejects_host_and_root_paths() {
+        // Host system paths — the #347 destruction targets.
+        assert!(!is_safe_to_remove(std::path::Path::new("/")));
+        assert!(!is_safe_to_remove(std::path::Path::new("/bin")));
+        assert!(!is_safe_to_remove(std::path::Path::new("/usr/bin")));
+        assert!(!is_safe_to_remove(std::path::Path::new("/etc")));
+        // Non-absolute / empty.
+        assert!(!is_safe_to_remove(std::path::Path::new("")));
+        assert!(!is_safe_to_remove(std::path::Path::new("relative/path")));
+        // The managed roots and wholesale parent dirs themselves.
+        assert!(!is_safe_to_remove(&runtime_dir()));
+        assert!(!is_safe_to_remove(&data_dir()));
+        assert!(!is_safe_to_remove(&containers_dir()));
+        assert!(!is_safe_to_remove(&sandboxes_dir()));
+        assert!(!is_safe_to_remove(&images_dir()));
+        assert!(!is_safe_to_remove(&layers_dir()));
+    }
+
+    #[test]
+    fn test_guard_allows_managed_subpaths() {
+        assert!(is_safe_to_remove(&containers_dir().join("pcri-abc123")));
+        assert!(is_safe_to_remove(&sandbox_dir("0123456789abcdef")));
+        assert!(is_safe_to_remove(&runtime_dir().join("overlay-1234-5")));
+        assert!(is_safe_to_remove(&images_dir().join("alpine_latest")));
+        assert!(is_safe_to_remove(&layers_dir().join("deadbeef")));
+    }
+
+    #[test]
+    fn test_guarded_remove_refuses_unmanaged_dir() {
+        // A real directory OUTSIDE pelagos's managed roots must NOT be removed by
+        // the guarded wrapper — it returns Ok (refusal logged) and the dir
+        // survives. This is the functional proof that the #347 guard prevents
+        // host-destructive removals.
+        let tmp = tempfile::tempdir().unwrap();
+        let victim = tmp.path().join("not-pelagos");
+        std::fs::create_dir_all(&victim).unwrap();
+        assert!(!is_safe_to_remove(&victim));
+        guarded_remove_dir_all(&victim).unwrap();
+        assert!(victim.exists(), "guard must not remove an unmanaged dir");
+    }
+
+    #[test]
+    fn test_guard_blocks_join_and_traversal_escapes() {
+        // PathBuf::join with an absolute component replaces the base -> escapes.
+        assert!(!is_safe_to_remove(&containers_dir().join("/bin")));
+        assert!(!is_safe_to_remove(&sandbox_dir("/bin")));
+        // `..` traversal out of the managed root.
+        assert!(!is_safe_to_remove(
+            &containers_dir().join("../../../../bin")
+        ));
+        // Empty id collapses to the protected parent dir.
+        assert!(!is_safe_to_remove(&containers_dir().join("")));
+        assert!(!is_safe_to_remove(&sandbox_dir("")));
+    }
 
     #[test]
     fn test_is_rootless_returns_bool() {

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -253,6 +253,12 @@ pub fn create_sandbox(name: Option<&str>) -> io::Result<SandboxState> {
 /// Remove a sandbox: SIGTERM the pause process, tear down the network namespace,
 /// and clean up the state directory.
 pub fn remove_sandbox(id: &str) -> io::Result<()> {
+    // Reject an empty/separator-laden id before any path is built from it: an
+    // empty id makes `sandbox_dir("")` resolve to the sandboxes parent dir, and
+    // a `/`-leading id escapes the runtime dir entirely (#347).
+    if id.is_empty() || id.contains('/') || id == "." || id == ".." {
+        return Err(io::Error::other(format!("invalid sandbox id '{}'", id)));
+    }
     let state = SandboxState::load(id)?;
 
     // Send SIGTERM to the pause process.
@@ -274,10 +280,10 @@ pub fn remove_sandbox(id: &str) -> io::Result<()> {
     let _ = crate::netlink::link_del(&veth_host);
     let _ = crate::netlink::netns_del(&state.ns_name);
 
-    // Remove the state directory.
+    // Remove the state directory (guarded against any path outside the runtime dir).
     let dir = crate::paths::sandbox_dir(id);
     if dir.exists() {
-        std::fs::remove_dir_all(&dir)?;
+        crate::paths::guarded_remove_dir_all(&dir)?;
     }
 
     Ok(())

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -28120,3 +28120,43 @@ mod issue_336_cri_restart_readopt {
         );
     }
 }
+
+/// Issue #347 (CRITICAL host-destructive): an inconsistent/"phantom" sandbox made
+/// pelagos delete the host `/bin` symlink during GC, via a removal whose base path
+/// resolved outside pelagos's managed dirs. The fix guards every dynamic-path
+/// removal (`paths::guarded_remove_dir_all`) and rejects empty/path-like ids at
+/// the CLI. This test proves the binary refuses such names without touching the host.
+mod issue_347_no_host_destruction {
+    use super::*;
+    use std::process::Command as Proc;
+
+    fn pelagos_bin() -> &'static str {
+        env!("CARGO_BIN_EXE_pelagos")
+    }
+
+    /// Does NOT require root. `pelagos rm` with an empty or path-like name must
+    /// fail and must NOT remove the host `/bin` (or any host path).
+    #[test]
+    fn test_rm_refuses_path_like_names_and_spares_host_bin() {
+        // Precondition: the host has /bin (usr-merge symlink on modern distros).
+        assert!(
+            std::path::Path::new("/bin").exists(),
+            "test precondition: /bin must exist"
+        );
+        for bad in ["/bin", "/usr", "../../../bin", "", "."] {
+            let out = Proc::new(pelagos_bin())
+                .args(["rm", bad])
+                .output()
+                .expect("run pelagos rm");
+            assert!(
+                !out.status.success(),
+                "pelagos rm {bad:?} must fail, not succeed (#347)"
+            );
+        }
+        // The whole point: the host filesystem is untouched.
+        assert!(
+            std::path::Path::new("/bin").exists(),
+            "#347 regression: /bin was removed by `pelagos rm`"
+        );
+    }
+}


### PR DESCRIPTION
Closes #347. **CRITICAL / host-destructive.**

## The bug
Running critest left `pelagos-cri`'s sandbox store inconsistent ("phantom" sandboxes — listed but `crictl rmp` says *not found*), and the kubelet's GC of those made pelagos **`unlink` the host's usr-merge `/bin -> usr/bin` symlink**, breaking SSH (login shell `/bin/bash` stops resolving). 2 of 2 critest nodes lost `/bin`; 0 of 4 non-critest nodes did. Restarting `pelagos-cri` (which clears the phantoms) stops the deletion.

## Mechanism & approach
A teardown/cleanup removal computed a base path from inconsistent sandbox/container state that was **empty or `/`-rooted**, so `<base>/…` resolved to a host path. (`PathBuf::join` also **replaces** the base when given an absolute component — `sandboxes_dir().join("/bin")` → `/bin`.)

I could **not isolate the exact trigger line** without reproducing it, and reproduction is host-destructive — it must only run on disposable cluster nodes, never a dev host. So the fix is **defense-in-depth that makes the whole class structurally impossible**, applied across every removal in the GC/teardown surface.

## The fix
- **`paths::is_safe_to_remove` + `guarded_remove_dir_all`/`guarded_remove_file`** — refuse (log + no-op) to remove any path that isn't a **strict descendant** of a pelagos-managed root (`/run/pelagos`, `/var/lib/pelagos`, rootless equivalents), and never a wholesale parent dir (`containers/`, `sandboxes/`, `images/`, `layers/`, `volumes/`, the roots themselves). Lexically normalizes `.`/`..` **without following symlinks**.
- Applied at every dynamic-path removal reachable from CRI GC / container teardown: overlay/dns/hosts teardown (`container.rs`), `pelagos rm` (`cli/rm.rs`), ephemeral overlay + state-dir cleanup (`cli/run.rs`), `pelagos sandbox rm` (`sandbox.rs`), OCI `delete` (`oci.rs`).
- **Reject empty / `/`-laden / `.`/`..` ids at the source** in `pelagos rm`, `remove_sandbox`, and the pelagos-cri state file removers, so an empty id can no longer collapse to a parent dir (wiping ALL containers/sandboxes) or escape it.

## Tests
- `paths::tests::test_guard_*` — `is_safe_to_remove` rejects `/`, `/bin`, `/usr`, `/etc`, the managed roots/parent dirs, and `join`/`..` escapes; accepts legitimate subpaths. `test_guarded_remove_refuses_unmanaged_dir` — functional proof the wrapper leaves an out-of-tree dir intact.
- `issue_347_no_host_destruction` (no root) — `pelagos rm` with path-like/empty names fails and the host `/bin` survives. Documented in `docs/INTEGRATION_TESTS.md`.
- `cargo test --lib` 377 pass; `cargo test -p pelagos-cri` 23 pass; clippy clean.

⚠️ **Do NOT re-run critest until this ships on the affected nodes.** Honest caveat: because the exact trigger wasn't isolated, this is a guard rather than a root-cause point-fix — but the guard covers the full removal surface and the unit tests prove it blocks every host path. If a phantom-sandbox repro can be captured on a disposable node, we can also point-fix the originating computation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)