### PR TITLE
fix(cri): stop host /bin deletion — reap phantom sandboxes + never emit empty LogPath (#347, #351)

### DIFF
--- a/pelagos-cri/src/main.rs
+++ b/pelagos-cri/src/main.rs
@@ -69,6 +69,21 @@ async fn async_run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
 
     let app_state = AppState::new(args.pelagos_bin.clone());
 
+    // Periodically reap dead-pause ("phantom") sandboxes so we never keep
+    // presenting the kubelet an orphaned, un-operable sandbox to garbage-collect
+    // — the path that deleted the host /bin (#347). Without this, a phantom
+    // lingers in the live listing until the next restart's reconciliation.
+    {
+        let reaper_state = app_state.clone();
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(std::time::Duration::from_secs(30));
+            loop {
+                tick.tick().await;
+                reaper_state.reconcile_stale_sandboxes().await;
+            }
+        });
+    }
+
     let runtime_svc = RuntimeSvc {
         state: app_state.clone(),
         streaming_base_url: streaming_base_url.clone(),

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -1094,7 +1094,19 @@ impl RuntimeService for RuntimeSvc {
         request: Request<ListPodSandboxRequest>,
     ) -> Result<Response<ListPodSandboxResponse>, Status> {
         let filter = request.into_inner().filter;
-        let st = self.state.inner.lock().await;
+        let mut st = self.state.inner.lock().await;
+
+        // Self-heal at the point of observation: never return a dead-pause
+        // ("phantom") sandbox. The kubelet discovers GC targets via this list, so
+        // reaping dead sandboxes here — synchronously, under the same lock that
+        // builds the response — means it can never see one to garbage-collect.
+        // The periodic reaper (see `main`) only *bounds* that window; doing it on
+        // read *closes* it (the path that deleted the host /bin, #347/#351).
+        let reaped =
+            st.reap_stale_sandboxes(|pid| std::path::Path::new(&format!("/proc/{}", pid)).exists());
+        for sid in &reaped {
+            log::info!("list_pod_sandbox: reaped stale sandbox {sid} (pause process gone)");
+        }
 
         let items: Vec<PodSandbox> = st
             .sandboxes

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -86,6 +86,36 @@ struct PelagosContainerState {
 /// 32 bytes from the OS CSPRNG encoded as hex — identical to the format used
 /// by containerd and CRI-O.  The 64-char length is a de facto standard
 /// hardcoded in SPIRE, Fluentd, Fluent Bit, OTel, Datadog, Falco, and cAdvisor.
+/// The absolute filesystem path where a container's CRI-format log is written AND
+/// that `ContainerStatus.log_path` reports back to the kubelet. The log relay
+/// (writer) and ContainerStatus (reporter) both call this, so the reported path
+/// always has a real log file behind it — it is never a dangling placeholder.
+///
+/// Every container gets a real, absolute path — never empty, never relative:
+///   * the client supplied a log directory + path (the kubelet always does) →
+///     honor `<log_directory>/<log_path>`;
+///   * the client supplied neither (e.g. a direct CRI client such as critest) →
+///     synthesize one inside pelagos's own runtime dir and relay the container's
+///     stdout/stderr there anyway, so `crictl logs` still works and the path is
+///     both meaningful and contained.
+///
+/// Why never empty/relative (issue #347): the kubelet derives its container-log
+/// cleanup path from this value. An empty or relative LogPath collapses on the
+/// kubelet side — `filepath.Dir("")` is `"."`, and with the kubelet's working
+/// directory at `/` a subsequent `os.RemoveAll` walks the HOST ROOT and unlinks
+/// entries like the usr-merge `/bin` symlink, breaking the node. Proven on a
+/// disposable cluster node: the k3s kubelet does `unlinkat(AT_FDCWD</>, "bin")`
+/// when GC'ing an orphaned sandbox whose container reported an empty log path.
+fn effective_cri_log_path(log_directory: &str, log_path: &str, pelagos_name: &str) -> String {
+    if !log_directory.is_empty() && !log_path.is_empty() {
+        let joined = format!("{}/{}", log_directory, log_path);
+        if joined.starts_with('/') {
+            return joined;
+        }
+    }
+    format!("/run/pelagos/containers/{}/cri.log", pelagos_name)
+}
+
 fn generate_id() -> String {
     use std::io::Read;
     let mut bytes = [0u8; 32];
@@ -1721,11 +1751,16 @@ impl RuntimeService for RuntimeSvc {
         }
         drop(st);
 
-        if !log_directory.is_empty() && !log_path_rel.is_empty() {
-            let cri_log_path = format!("{}/{}", log_directory, log_path_rel);
-            let pelagos_name = container.pelagos_name.clone();
-            tokio::spawn(relay_container_logs(pelagos_name, cri_log_path));
-        }
+        // Always relay logs to an absolute, pelagos-reported path — even when the
+        // CRI client supplied no log dir/path — so the container has a real CRI
+        // log and ContainerStatus.LogPath never points at a missing file or
+        // collapses to the host root (#347).
+        let log_dest =
+            effective_cri_log_path(&log_directory, &log_path_rel, &container.pelagos_name);
+        tokio::spawn(relay_container_logs(
+            container.pelagos_name.clone(),
+            log_dest,
+        ));
 
         Ok(Response::new(StartContainerResponse {}))
     }
@@ -1883,15 +1918,19 @@ impl RuntimeService for RuntimeSvc {
 
         let cstate = cri_container_state_val(&container.state);
 
-        let full_log_path = if !container.log_path.is_empty() {
-            st.sandboxes
-                .get(&container.sandbox_id)
-                .filter(|s| !s.log_directory.is_empty())
-                .map(|s| format!("{}/{}", s.log_directory, container.log_path))
-                .unwrap_or_default()
-        } else {
-            String::new()
-        };
+        // Report the SAME absolute path the log relay writes to (see
+        // effective_cri_log_path / StartContainer), so the reported LogPath always
+        // has a real file behind it and never collapses to the host root (#347).
+        let sandbox_log_dir = st
+            .sandboxes
+            .get(&container.sandbox_id)
+            .map(|s| s.log_directory.clone())
+            .unwrap_or_default();
+        let full_log_path = effective_cri_log_path(
+            &sandbox_log_dir,
+            &container.log_path,
+            &container.pelagos_name,
+        );
 
         // Read termination message (up to 4096 bytes per CRI convention).
         let message = if !container.termination_log_host_path.is_empty() {
@@ -2561,6 +2600,46 @@ mod tests {
             "session grandchild {sleep_pid} survived kill_exec_wrapper (#339 leak)"
         );
         assert!(!is_alive(root), "wrapper {root} survived kill_exec_wrapper");
+    }
+
+    /// #347: the path the relay writes AND ContainerStatus.log_path reports must
+    /// never be empty or relative — an empty LogPath makes the kubelet RemoveAll
+    /// the host root (deleting /bin). Proven on a disposable node; this pins the
+    /// contract. Because the relay and the reporter call the same function, the
+    /// reported path always has a real log file behind it.
+    #[test]
+    fn test_effective_cri_log_path_never_empty_or_relative() {
+        // No client-supplied log dir/path -> synthesized absolute path under pelagos's
+        // runtime dir, where the relay will actually write the log.
+        assert_eq!(
+            effective_cri_log_path("", "", "pcri-abc123"),
+            "/run/pelagos/containers/pcri-abc123/cri.log"
+        );
+        // log_path present but no log_directory -> can't honor a bare relative path
+        // (would collapse to "." with cwd "/") -> fall back.
+        assert_eq!(
+            effective_cri_log_path("", "node-exporter/0.log", "pcri-xyz"),
+            "/run/pelagos/containers/pcri-xyz/cri.log"
+        );
+        // Kubelet-supplied absolute dir + path -> honored verbatim.
+        assert_eq!(
+            effective_cri_log_path("/var/log/pods/ns_name_uid/ctr", "0.log", "pcri-abc"),
+            "/var/log/pods/ns_name_uid/ctr/0.log"
+        );
+        // A (defensive) relative log_directory must never be honored -> fall back.
+        assert_eq!(
+            effective_cri_log_path("var/log/pods/x", "0.log", "pcri-def"),
+            "/run/pelagos/containers/pcri-def/cri.log"
+        );
+        // The result is ALWAYS absolute, for every combination (the safety invariant).
+        for (dir, path) in [
+            ("", ""),
+            ("", "a/b.log"),
+            ("rel/dir", "0.log"),
+            ("/abs", "0.log"),
+        ] {
+            assert!(effective_cri_log_path(dir, path, "pcri-x").starts_with('/'));
+        }
     }
 
     #[test]

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -214,6 +214,39 @@ impl StateInner {
             pelagos_bin: String::new(),
         }
     }
+
+    /// Reap sandboxes whose pause process is gone, taking their containers with
+    /// them; returns the reaped sandbox ids. `is_alive(pid)` reports whether a
+    /// pause pid is still live.
+    ///
+    /// A sandbox with a dead pause is unusable — its network namespace and
+    /// processes are gone. Pelagos has always reaped these at startup; the same
+    /// pass runs periodically (see [`AppState::reconcile_stale_sandboxes`]) so a
+    /// dead "phantom" sandbox is removed within one interval instead of lingering
+    /// in the live listing until the next restart. A lingering phantom is exactly
+    /// what the kubelet discovers as an orphan and garbage-collects — the path
+    /// that deleted the host `/bin` (#347). Keys on pause-liveness, not the
+    /// recorded `state`, so it reaps both Ready-but-dead and NotReady-but-dead.
+    pub(crate) fn reap_stale_sandboxes<F: Fn(i32) -> bool>(&mut self, is_alive: F) -> Vec<String> {
+        let stale = stale_sandbox_ids(&self.sandboxes, is_alive);
+        for sid in &stale {
+            // Remove all containers that belonged to this sandbox.
+            let stale_ctrs: Vec<String> = self
+                .containers
+                .values()
+                .filter(|c| &c.sandbox_id == sid)
+                .map(|c| c.id.clone())
+                .collect();
+            for cid in stale_ctrs {
+                self.containers.remove(&cid);
+                remove_container_file(&cid);
+            }
+            self.sandboxes.remove(sid);
+            remove_sandbox_file(sid);
+            remove_pelagos_sandbox_state(sid);
+        }
+        stale
+    }
 }
 
 // ── AppState ─────────────────────────────────────────────────────────────────
@@ -242,35 +275,35 @@ impl AppState {
         // unit came back, or a legacy non-scoped pause killed with the old
         // runtime) are purged, taking their containers with them, so the kubelet
         // recreates just those pods rather than every pod on the node.
-        let stale = stale_sandbox_ids(&inner.sandboxes, |pid| {
-            std::path::Path::new(&format!("/proc/{}", pid)).exists()
-        });
+        let total_before = inner.sandboxes.len();
+        let stale = inner
+            .reap_stale_sandboxes(|pid| std::path::Path::new(&format!("/proc/{}", pid)).exists());
 
-        let adopted = inner.sandboxes.len() - stale.len();
+        let adopted = total_before - stale.len();
         if adopted > 0 {
             log::info!("startup: re-adopting {adopted} running sandbox(es) across restart");
         }
-
         for sid in &stale {
             log::info!("startup: removing stale sandbox {sid} (pause process gone)");
-            // Remove all containers that belonged to this sandbox.
-            let stale_ctrs: Vec<String> = inner
-                .containers
-                .values()
-                .filter(|c| &c.sandbox_id == sid)
-                .map(|c| c.id.clone())
-                .collect();
-            for cid in stale_ctrs {
-                inner.containers.remove(&cid);
-                remove_container_file(&cid);
-            }
-            inner.sandboxes.remove(sid);
-            remove_sandbox_file(sid);
-            remove_pelagos_sandbox_state(sid);
         }
 
         AppState {
             inner: Arc::new(Mutex::new(inner)),
+        }
+    }
+
+    /// Reap dead-pause ("phantom") sandboxes from the live state. Intended to run
+    /// on a timer (see `main`) so a phantom is removed within one interval rather
+    /// than lingering in `list_pod_sandbox` until the next restart — otherwise the
+    /// kubelet discovers it as an orphan and garbage-collects it, the path that
+    /// deleted the host `/bin` (#347). Mirrors the startup reconciliation.
+    pub async fn reconcile_stale_sandboxes(&self) {
+        let reaped = {
+            let mut st = self.inner.lock().await;
+            st.reap_stale_sandboxes(|pid| std::path::Path::new(&format!("/proc/{}", pid)).exists())
+        };
+        for sid in &reaped {
+            log::info!("reconcile: removed stale sandbox {sid} (pause process gone)");
         }
     }
 }
@@ -461,6 +494,60 @@ mod tests {
         assert!(
             stale.is_empty(),
             "native sandboxes must never be stale: {stale:?}"
+        );
+    }
+
+    /// Build a minimal CriContainer attached to a sandbox via JSON.
+    fn container(id: &str, sandbox_id: &str) -> CriContainer {
+        let json = format!(
+            r#"{{"id":"{id}","sandbox_id":"{sandbox_id}","pelagos_name":"pcri-{id}",
+                 "name":"c","image":"img","entrypoint":[],"args":[],"envs":[],
+                 "working_dir":"","mounts":[],"labels":{{}},"annotations":{{}},
+                 "created_at_ns":0,"started_at_ns":0,"finished_at_ns":0,
+                 "state":"Running","exit_code":0}}"#
+        );
+        serde_json::from_str(&json).expect("valid container json")
+    }
+
+    /// #347 follow-up: reaping a dead-pause "phantom" sandbox must drop it from the
+    /// live state AND take its containers with it, while leaving live sandboxes (and
+    /// their containers) untouched. This is what stops us from continuing to present
+    /// the kubelet an orphan to GC between restarts.
+    #[test]
+    fn reap_removes_dead_phantom_sandbox_and_its_containers() {
+        let mut inner = StateInner {
+            sandboxes: map(vec![sandbox("alive", 1001), sandbox("dead", 1002)]),
+            containers: vec![
+                container("c-alive", "alive"),
+                container("c-dead1", "dead"),
+                container("c-dead2", "dead"),
+            ]
+            .into_iter()
+            .map(|c| (c.id.clone(), c))
+            .collect(),
+            pelagos_bin: String::new(),
+        };
+
+        // pid 1001 (alive) is live; 1002 (dead) is gone.
+        let reaped = inner.reap_stale_sandboxes(|pid| pid == 1001);
+
+        assert_eq!(
+            reaped,
+            vec!["dead".to_string()],
+            "only the dead sandbox reaped"
+        );
+        assert!(inner.sandboxes.contains_key("alive"), "live sandbox kept");
+        assert!(
+            !inner.sandboxes.contains_key("dead"),
+            "dead sandbox removed"
+        );
+        assert!(
+            inner.containers.contains_key("c-alive"),
+            "live container kept"
+        );
+        assert!(
+            !inner.containers.contains_key("c-dead1") && !inner.containers.contains_key("c-dead2"),
+            "the phantom's containers must be removed with it"
         );
     }
 }


### PR DESCRIPTION
Closes #347. Closes #351. The two compounding pelagos defects behind the host-`/bin` deletion, fixed together. Root cause confirmed by reproducing on a disposable node (ipc2).

## What actually happened
On a k3s node, critest and the kubelet share one pelagos-cri socket.
1. **We leaked phantoms** (#351): a sandbox whose pause process died lingered in `ListPodSandbox` because we only reconcile dead-pause sandboxes **at startup**, never while running.
2. **The kubelet GC'd the phantom** as an orphan — normal, expected behavior.
3. **We handed it an empty `LogPath`** (#347): the kubelet derives a log-cleanup path from it; empty collapses (`filepath.Dir("")`==`"."`, cwd `/`) → `os.RemoveAll("/")` → unlinks the usr-merge `/bin` symlink, breaking SSH.

```
comm=k3s-agent  cwd=/
unlinkat(AT_FDCWD</>, "bin", 0)  = 0          ← /bin deleted
unlinkat(AT_FDCWD</>, "boot", 0) = -1 EISDIR   ← then /boot, /dev, …
```

#1 is *why it happens at all*; #2 is *why it's catastrophic instead of harmless*. Both are ours.

## Fix A — never emit an empty/relative LogPath (#347)
`effective_cri_log_path()` is the single source of truth for both the log **writer** (StartContainer relay) and the **reporter** (ContainerStatus). The relay now **always** writes a CRI-format log (kubelet-supplied path when given, else `/run/pelagos/containers/<name>/cri.log`), so the reported `LogPath` is always absolute and always has a real file behind it — `crictl logs` works for these containers too, and the kubelet can never collapse it to `/`.

## Fix B — reap phantom sandboxes while live (#351)
Extracted the startup reconciliation into `StateInner::reap_stale_sandboxes` and added `AppState::reconcile_stale_sandboxes`, spawned on a **30s timer** in `main`. A dead-pause sandbox is now removed within one interval instead of lingering until the next restart — so we stop presenting the kubelet orphans to GC. (Keys on pause-liveness, mirroring the existing startup pass.)

## Proven on ipc2
- **Before**: k3s `unlinkat("bin")` deleted `/bin` every ~60s GC cycle; journal showed two dead-pause CNI phantoms (`10.42.1.43/.52`) reaped only on restart.
- **After**: two full GC cycles + a 130s bpftrace window — **0** `/bin` deletions, **0** `unlinkat("bin")` by k3s-agent, `/bin`/`/sbin`/`/boot` intact, phantoms GC'd cleanly. Host confirmed intact (`/bin -> usr/bin`).

## Upstream
The `RemoveAll("/")` is ultimately a **kubelet (k3s) bug** — no CRI response should let it delete the host root — to be reported separately. This PR stops pelagos from triggering it; the #348/v0.65.36 removal guard does **not** fix this (the kubelet, not pelagos, does the deletion).

Tests: `effective_cri_log_path_never_empty_or_relative`, `reap_removes_dead_phantom_sandbox_and_its_containers`, existing `relay_logs_from_dir` e2e (25 pelagos-cri unit tests pass; clippy clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)