### PR TITLE
fix(cri): drop image CMD when container sets command — keystone for verify-by-exec conformance (#358)

### DIFF
--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -1432,22 +1432,14 @@ impl RuntimeService for RuntimeSvc {
         // Kubelet may pass the sha256 digest form rather than the tag; resolve to a known tag.
         let image = Self::resolve_image_ref(&container.image).await;
 
-        // CRI entrypoint semantics:
-        //   container.entrypoint (CRI "command") overrides the image ENTRYPOINT when non-empty.
-        //   container.args (CRI "args") overrides the image CMD when non-empty.
-        //   When entrypoint is empty the image's default ENTRYPOINT must be used — omitting it
-        //   would cause `pelagos run` to exec the first arg as the binary, which is wrong.
+        // CRI entrypoint/cmd resolution — see `resolve_container_argv` (#358).
         let (image_entrypoint, image_cmd) = Self::load_image_defaults(&image).await;
-        let effective_entrypoint: Vec<String> = if !container.entrypoint.is_empty() {
-            container.entrypoint.clone()
-        } else {
-            image_entrypoint
-        };
-        let effective_cmd: Vec<String> = if !container.args.is_empty() {
-            container.args.clone()
-        } else {
-            image_cmd
-        };
+        let (effective_entrypoint, effective_cmd) = resolve_container_argv(
+            &container.entrypoint,
+            &container.args,
+            image_entrypoint,
+            image_cmd,
+        );
 
         // B″ — Effective-UID-is-zero audit log.
         // If the container will run as root and is not explicitly privileged, warn.
@@ -2422,6 +2414,43 @@ impl RuntimeService for RuntimeSvc {
     }
 }
 
+/// Resolve the container's effective `(entrypoint, cmd)` from the CRI request and
+/// the image defaults, per Kubernetes/CRI/OCI semantics (#358):
+///
+/// | CRI command | CRI args | entrypoint | cmd          |
+/// |-------------|----------|------------|--------------|
+/// | empty       | empty    | image EP   | image CMD    |
+/// | empty       | [args]   | image EP   | args         |
+/// | [cmd]       | empty    | cmd        | (none)       |  ← image CMD DROPPED
+/// | [cmd]       | [args]   | cmd        | args         |
+///
+/// The critical rule: a CRI `command` overrides the entrypoint AND drops the image
+/// CMD. The old code appended the image CMD whenever `args` was empty — even when
+/// `command` was set — producing e.g. `sleep 3600 sh` (image CMD `sh` appended),
+/// which exits immediately and breaks every verify-by-exec conformance spec.
+fn resolve_container_argv(
+    cri_command: &[String],
+    cri_args: &[String],
+    image_entrypoint: Vec<String>,
+    image_cmd: Vec<String>,
+) -> (Vec<String>, Vec<String>) {
+    let entrypoint = if cri_command.is_empty() {
+        image_entrypoint
+    } else {
+        cri_command.to_vec()
+    };
+    let cmd = if !cri_args.is_empty() {
+        cri_args.to_vec()
+    } else if cri_command.is_empty() {
+        // Only inherit the image CMD when the CRI command did NOT override the
+        // entrypoint; otherwise the CRI command is the full argv.
+        image_cmd
+    } else {
+        Vec::new()
+    };
+    (entrypoint, cmd)
+}
+
 // ── CRI log relay ─────────────────────────────────────────────────────────────
 
 /// Format current time as RFC3339 with nanosecond precision for the CRI log format.
@@ -2652,6 +2681,36 @@ mod tests {
         ] {
             assert!(effective_cri_log_path(dir, path, "pcri-x").starts_with('/'));
         }
+    }
+
+    /// #358: the four-cell entrypoint/cmd table. The keystone case is row 3 —
+    /// CRI command set + no args must DROP the image CMD (not append it), which is
+    /// what broke critest containers (`sleep 3600` → `sleep 3600 sh` → exit 1).
+    #[test]
+    fn test_resolve_container_argv() {
+        let ep = || vec!["/img-ep".to_string()];
+        let cmd = || vec!["img-cmd".to_string()];
+
+        // command empty, args empty → image EP + image CMD.
+        assert_eq!(
+            resolve_container_argv(&[], &[], ep(), cmd()),
+            (vec!["/img-ep".into()], vec!["img-cmd".into()])
+        );
+        // command empty, args set → image EP + args (image CMD dropped).
+        assert_eq!(
+            resolve_container_argv(&[], &["a".into()], ep(), cmd()),
+            (vec!["/img-ep".into()], vec!["a".into()])
+        );
+        // command set, args empty → command only; IMAGE CMD DROPPED (the bug).
+        assert_eq!(
+            resolve_container_argv(&["sleep".into(), "3600".into()], &[], ep(), cmd()),
+            (vec!["sleep".into(), "3600".into()], vec![])
+        );
+        // command set, args set → command + args.
+        assert_eq!(
+            resolve_container_argv(&["sleep".into()], &["3600".into()], ep(), cmd()),
+            (vec!["sleep".into()], vec!["3600".into()])
+        );
     }
 
     #[test]

--- a/scripts/cri-conformance-354-355.sh
+++ b/scripts/cri-conformance-354-355.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Focused critest conformance run for the Phase-1 CRI fixes (#354, #355).
+#
+# Runs ONLY the specs targeted by the hostname / host-port / DNS / sysctls
+# wire-ups against the live pelagos-cri socket, and writes a result file the
+# caller can read separately (critest is long-running; do not pipe it to tail).
+#
+# Usage (on an IPC test node, never omen):
+#   sudo bash scripts/cri-conformance-354-355.sh /tmp/cri-354-355.result
+set -u
+
+SOCK="unix:///run/pelagos/cri.sock"
+OUT="${1:-/tmp/cri-354-355.result}"
+
+# The four Phase-1 specs (Ginkgo regex). Keep in sync with #354/#355.
+FOCUS='should support set hostname|port mapping with host port and container port|should support DNS config|should support (safe|unsafe) sysctls|runtime should support sysctls'
+
+: > "$OUT"
+echo "# critest focus: $FOCUS" >> "$OUT"
+echo "# endpoint: $SOCK" >> "$OUT"
+echo "# pelagos-cri: $(systemctl is-active pelagos-cri 2>/dev/null)" >> "$OUT"
+echo "# started: $(date -u +%FT%TZ)" >> "$OUT"
+echo "----------------------------------------" >> "$OUT"
+
+critest --runtime-endpoint "$SOCK" --ginkgo.focus="$FOCUS" >> "$OUT" 2>&1
+rc=$?
+
+echo "----------------------------------------" >> "$OUT"
+echo "# critest exit: $rc" >> "$OUT"
+echo "# finished: $(date -u +%FT%TZ)" >> "$OUT"
+exit "$rc"

--- a/scripts/cri-diag-sandbox.sh
+++ b/scripts/cri-diag-sandbox.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Controlled CRI diagnostic for the Phase-1 conformance work (#354/#355) — isolates
+# each failing dimension with a LONG-LIVED container (sleep), so namespace-sharing /
+# sysctl / hostname / DNS questions are separated from any start/exit race.
+#
+# Writes everything to a result file (critest-style); read it separately.
+# Usage (on an IPC test node, never omen):
+#   sudo bash scripts/cri-diag-sandbox.sh /tmp/cri-diag.result
+set -u
+OUT="${1:-/tmp/cri-diag.result}"
+SOCK="unix:///run/pelagos/cri.sock"
+CR="crictl --runtime-endpoint $SOCK --image-endpoint $SOCK"
+IMG="registry.k8s.io/e2e-test-images/busybox:1.29-2"
+WORK="$(mktemp -d)"
+
+cat > "$WORK/pod.json" <<JSON
+{ "metadata": {"name":"diag-pod","namespace":"default","uid":"diag-uid-1","attempt":1},
+  "hostname": "diag-hostname",
+  "log_directory": "$WORK",
+  "linux": { "sysctls": {"kernel.shm_rmid_forced": "1"} } }
+JSON
+cat > "$WORK/ctr.json" <<JSON
+{ "metadata": {"name":"diag-ctr","attempt":1},
+  "image": {"image":"$IMG"},
+  "command": ["sleep","3600"],
+  "log_path": "diag-ctr.0.log",
+  "linux": {} }
+JSON
+
+exec > "$OUT" 2>&1
+echo "# cri-diag @ $(date -u +%FT%TZ)  cri=$(systemctl is-active pelagos-cri)"
+$CR pull "$IMG" >/dev/null 2>&1 || echo "WARN: image pull failed"
+
+POD=$($CR runp "$WORK/pod.json"); echo "POD=$POD"
+CID=$($CR create "$POD" "$WORK/ctr.json" "$WORK/pod.json"); echo "CID=$CID"
+$CR start "$CID"; sleep 1
+
+echo "=== [running?] crictl ps ==="
+$CR ps -a | grep -E "diag-ctr|CONTAINER" || true
+
+echo "=== [exit reason] crictl inspect ==="
+$CR inspect "$CID" 2>/dev/null | grep -iE '"state"|exitCode|"reason"|"message"|finishedAt|startedAt' | head
+echo "=== [container log] crictl logs ==="
+$CR logs "$CID" 2>&1 | head -15
+PN="pcri-${CID:0:12}"
+echo "=== [pelagos stderr/stdout for $PN] ==="
+sudo sh -c "cat /run/pelagos/containers/$PN/stderr.log 2>&1 | head -15; echo '--- stdout ---'; cat /run/pelagos/containers/$PN/stdout.log 2>&1 | head -8"
+echo "=== [pelagos-cri journal: run line] ==="
+sudo journalctl -u pelagos-cri --since '40 sec ago' --no-pager 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' | grep -iE "$PN|run failed|--hostname|--publish|sysctl|error|exited" | tail -12
+
+echo "=== [hostname] exec hostname ==="
+$CR exec "$CID" hostname 2>&1 || true
+
+echo "=== [sysctl] exec cat /proc/sys/kernel/shm_rmid_forced (want 1) ==="
+$CR exec "$CID" cat /proc/sys/kernel/shm_rmid_forced 2>&1 || true
+
+echo "=== [dns] exec cat /etc/resolv.conf ==="
+$CR exec "$CID" cat /etc/resolv.conf 2>&1 || true
+
+echo "=== [ns sharing] container vs pause IPC/UTS/NET inodes ==="
+CPID=$($CR inspect "$CID" 2>/dev/null | grep -oE '"pid": *[0-9]+' | head -1 | grep -oE '[0-9]+')
+PAUSE=$(pgrep -f "sandbox __pause__" | head -1)
+echo "container pid=$CPID  pause pid=$PAUSE"
+for ns in ipc uts net; do
+  c=$(sudo readlink "/proc/$CPID/ns/$ns" 2>/dev/null)
+  p=$(sudo readlink "/proc/$PAUSE/ns/$ns" 2>/dev/null)
+  echo "  $ns: container=$c pause=$p  $([ "$c" = "$p" ] && echo SHARED || echo SEPARATE)"
+done
+
+echo "=== [pause ns sysctl] value as seen inside the pause IPC ns (want 1) ==="
+sudo nsenter --ipc="/proc/$PAUSE/ns/ipc" -- cat /proc/sys/kernel/shm_rmid_forced 2>&1 || true
+
+echo "=== cleanup ==="
+$CR stop "$CID" >/dev/null 2>&1; $CR rm "$CID" >/dev/null 2>&1
+$CR stopp "$POD" >/dev/null 2>&1; $CR rmp "$POD" >/dev/null 2>&1
+rm -rf "$WORK"
+echo "# done @ $(date -u +%FT%TZ)"


### PR DESCRIPTION
Closes #358.

## The bug
A CRI container that sets `command` (OCI entrypoint override) with empty `args`, on an image that has a CMD, got the image CMD **wrongly appended**. On busybox (`CMD ["sh"]`) with `command: ["sleep","3600"]`, pelagos ran `sleep 3600 sh` → `sleep: invalid number 'sh'` → **exit 1, container dies immediately**.

## Why it matters
This is the **common cause** behind the critest verify-by-exec conformance cluster (#352 security context, #354 networking, #355 sysctls, #357 basic ops): critest creates containers with `command` set and no `args`; they exec a broken argv and exit, so every spec that exec's in to verify state failed with "container is not running." Also hits real pods that set `command` without `args` on an image with a CMD.

## Fix
`resolve_container_argv` implements the Kubernetes/CRI/OCI four-cell table — a CRI `command` overrides the entrypoint **and drops the image CMD**; only CRI `args` (if present) follow.

## Proven on ipc2
- Before: `sleep 3600` container → `Exited` (exit 1, `sleep 3600 sh`).
- After: `sleep 3600` container → **Running**, exec works, and the focused conformance set went **0/5 → 1/5** (DNS config now passes — it just needed the container to survive).

Found via ipc2 conformance testing (`scripts/cri-diag-sandbox.sh`). Test: `resolve_container_argv` (four-cell table); 28 pelagos-cri unit tests pass, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)