### PR TITLE
feat(cri): apply pod hostname + sysctls to pause namespaces, guarded against unshare race (#355)

### DIFF
--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -713,6 +713,15 @@ impl RuntimeService for RuntimeSvc {
         let uid = meta.uid.clone();
         let bin = self.bin().await;
 
+        // Pod-level settings applied to the pause's (container-shared) namespaces
+        // once the pause exists: hostname → UTS ns, sysctls → net/ipc/uts ns (#354/#355).
+        let sandbox_hostname = config.hostname.clone();
+        let sandbox_sysctls = config
+            .linux
+            .as_ref()
+            .map(|l| l.sysctls.clone())
+            .unwrap_or_default();
+
         // Try CNI networking first; fall back to pelagos native if no config is present.
         let (sandbox_id, netns, ip, cni_conf, pause_pid) = if let Some(conf_path) =
             cni::find_cni_conf()
@@ -841,6 +850,23 @@ impl RuntimeService for RuntimeSvc {
             // Write pelagos-format sandbox state so `pelagos run --sandbox` works.
             state::write_pelagos_sandbox_state(&id, Some(&meta.name), pause_pid, &ns_name, &ip)
                 .map_err(|e| Status::internal(format!("write sandbox state: {}", e)))?;
+
+            // Apply pod hostname + sysctls into the pause namespaces — but ONLY after
+            // confirming the pause has unshared UTS/IPC, so nsenter targets the POD
+            // namespaces and never the host (containers join these namespaces and
+            // inherit the values: #354 set-hostname, #355 sysctls).
+            if (!sandbox_hostname.is_empty() || !sandbox_sysctls.is_empty())
+                && wait_for_pause_ns_unshare(pause_pid).await
+            {
+                apply_pod_hostname(pause_pid, &sandbox_hostname).await;
+                apply_sandbox_sysctls(&netns_path, pause_pid, &sandbox_sysctls).await;
+            } else if !sandbox_hostname.is_empty() || !sandbox_sysctls.is_empty() {
+                log::warn!(
+                    "pause {} did not unshare UTS/IPC in time; skipping pod hostname/sysctls \
+                     to avoid mutating the host",
+                    pause_pid
+                );
+            }
 
             log::info!(
                 "CNI sandbox {} created: netns={} ip={} conf={}",
@@ -2451,6 +2477,100 @@ fn resolve_container_argv(
     (entrypoint, cmd)
 }
 
+// ── Pod-level settings applied to the pause namespaces (#354/#355) ─────────────
+
+/// Wait until the pause process has actually unshared its UTS **and** IPC
+/// namespaces — i.e. they differ from this (host) process's namespaces. Returns
+/// false on timeout.
+///
+/// CRITICAL: pod hostname/sysctls are applied via `nsenter /proc/<pause>/ns/*`.
+/// If applied before the pause finishes unsharing, `/proc/<pause>/ns/uts` still
+/// resolves to the HOST UTS namespace and `hostname <pod>` renames the HOST
+/// (observed: node hostname changed to the pod's). Likewise a sysctl set pre-unshare
+/// lands on a namespace the pause then discards, so the value never reaches the pod.
+/// Gating on this both fixes the apply and guarantees we never mutate the host: if
+/// the pause never unshares (e.g. a host-namespace pod), we skip the apply.
+async fn wait_for_pause_ns_unshare(pause_pid: i32) -> bool {
+    let host_uts = std::fs::read_link("/proc/self/ns/uts").ok();
+    let host_ipc = std::fs::read_link("/proc/self/ns/ipc").ok();
+    for _ in 0..40 {
+        let p_uts = std::fs::read_link(format!("/proc/{}/ns/uts", pause_pid)).ok();
+        let p_ipc = std::fs::read_link(format!("/proc/{}/ns/ipc", pause_pid)).ok();
+        if p_uts.is_some() && p_uts != host_uts && p_ipc.is_some() && p_ipc != host_ipc {
+            return true;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    false
+}
+
+/// Set the pod hostname inside the pause's UTS namespace (which containers join),
+/// so `hostname` resolves to the pod name (#354 set-hostname). Best-effort; no-op
+/// when empty.
+async fn apply_pod_hostname(pause_pid: i32, hostname: &str) {
+    if hostname.is_empty() {
+        return;
+    }
+    let uts = format!("--uts=/proc/{}/ns/uts", pause_pid);
+    match tokio::process::Command::new("nsenter")
+        .args([uts.as_str(), "--", "hostname", hostname])
+        .output()
+        .await
+    {
+        Ok(out) if out.status.success() => log::info!("pod hostname set to {}", hostname),
+        Ok(out) => log::warn!(
+            "set pod hostname {}: {}",
+            hostname,
+            String::from_utf8_lossy(&out.stderr).trim()
+        ),
+        Err(e) => log::warn!("nsenter hostname {}: {}", hostname, e),
+    }
+}
+
+/// Build the `nsenter` argv that applies one pod-level sysctl inside a sandbox's
+/// namespaces. `net.*` keys live in the network namespace; `kernel.*`/`fs.*` live
+/// in the IPC/UTS namespaces held by the pause — so we enter all three and let
+/// `sysctl -w` write to whichever `/proc/sys` the key belongs to.
+fn sandbox_sysctl_argv(netns_path: &str, pause_pid: i32, key: &str, value: &str) -> Vec<String> {
+    vec![
+        format!("--net={}", netns_path),
+        format!("--ipc=/proc/{}/ns/ipc", pause_pid),
+        format!("--uts=/proc/{}/ns/uts", pause_pid),
+        "--".to_string(),
+        "sysctl".to_string(),
+        "-w".to_string(),
+        format!("{}={}", key, value),
+    ]
+}
+
+/// Apply the sandbox's configured sysctls (safe + unsafe; the kubelet has already
+/// gate-kept which are permitted) to its pod namespaces. Best-effort per key.
+async fn apply_sandbox_sysctls(
+    netns_path: &str,
+    pause_pid: i32,
+    sysctls: &HashMap<String, String>,
+) {
+    for (key, value) in sysctls {
+        let argv = sandbox_sysctl_argv(netns_path, pause_pid, key, value);
+        match tokio::process::Command::new("nsenter")
+            .args(&argv)
+            .output()
+            .await
+        {
+            Ok(out) if out.status.success() => {
+                log::info!("sandbox sysctl {}={} applied", key, value)
+            }
+            Ok(out) => log::warn!(
+                "sandbox sysctl {}={}: {}",
+                key,
+                value,
+                String::from_utf8_lossy(&out.stderr).trim()
+            ),
+            Err(e) => log::warn!("nsenter sysctl {}={}: {}", key, value, e),
+        }
+    }
+}
+
 // ── CRI log relay ─────────────────────────────────────────────────────────────
 
 /// Format current time as RFC3339 with nanosecond precision for the CRI log format.
@@ -2710,6 +2830,30 @@ mod tests {
         assert_eq!(
             resolve_container_argv(&["sleep".into()], &["3600".into()], ep(), cmd()),
             (vec!["sleep".into()], vec!["3600".into()])
+        );
+    }
+
+    /// #355: a pod-level sysctl is applied inside ALL THREE pod namespaces — net
+    /// (net.*), ipc + uts (kernel.*/fs.*) — so `sysctl -w` lands in whichever
+    /// /proc/sys the key belongs to. Values with spaces survive as one argv element.
+    #[test]
+    fn test_sandbox_sysctl_argv() {
+        assert_eq!(
+            sandbox_sysctl_argv(
+                "/run/netns/pcri-abc",
+                4242,
+                "net.ipv4.ping_group_range",
+                "0 2147483647"
+            ),
+            vec![
+                "--net=/run/netns/pcri-abc",
+                "--ipc=/proc/4242/ns/ipc",
+                "--uts=/proc/4242/ns/uts",
+                "--",
+                "sysctl",
+                "-w",
+                "net.ipv4.ping_group_range=0 2147483647",
+            ]
         );
     }
 

--- a/scripts/cri-confirm-ns.sh
+++ b/scripts/cri-confirm-ns.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Definitive confirmation of pod-namespace sharing for a CRI container.
+# Runs a long-lived container with a UNIQUE marker command so the real container
+# process can be found unambiguously (not the host-side watcher), then compares
+# its net/uts/ipc namespaces + IP against the sandbox pause AND a real cluster pod.
+#
+# Usage (IPC node, never omen): sudo bash scripts/cri-confirm-ns.sh /tmp/ns.result
+set -u
+OUT="${1:-/tmp/cri-confirm-ns.result}"
+SOCK="unix:///run/pelagos/cri.sock"
+CR="crictl --runtime-endpoint $SOCK --image-endpoint $SOCK"
+IMG="registry.k8s.io/e2e-test-images/busybox:1.29-2"
+W=$(mktemp -d)
+
+cat > "$W/pod.json" <<JSON
+{ "metadata": {"name":"nsdiag-pod","namespace":"default","uid":"nsdiag-1","attempt":1},
+  "hostname": "nsdiag-host", "log_directory": "$W",
+  "linux": { "sysctls": {"kernel.shm_rmid_forced":"1"} } }
+JSON
+cat > "$W/ctr.json" <<JSON
+{ "metadata": {"name":"nsdiag-ctr","attempt":1},
+  "image": {"image":"$IMG"}, "command": ["sleep","31415926"],
+  "log_path": "c.log", "linux": {} }
+JSON
+
+exec > "$OUT" 2>&1
+echo "# cri-confirm-ns @ $(date -u +%FT%TZ)"
+echo "host init: net=$(sudo readlink /proc/1/ns/net) uts=$(sudo readlink /proc/1/ns/uts) ipc=$(sudo readlink /proc/1/ns/ipc)"
+$CR pull "$IMG" >/dev/null 2>&1
+POD=$($CR runp "$W/pod.json"); echo "POD=$POD"
+CID=$($CR create "$POD" "$W/ctr.json" "$W/pod.json"); echo "CID=$CID"
+$CR start "$CID"; sleep 2
+PN="pcri-${CID:0:12}"
+
+echo "=== state.json (pids) ==="
+sudo cat "/run/pelagos/containers/$PN/state.json" 2>/dev/null | tr ',{}' '\n' | grep -iE 'pid' || echo "no state.json"
+
+SLEEP_PID=$(pgrep -f "sleep 31415926" | head -1)
+STATE_PID=$(sudo grep -oE '"pid":[ ]*[0-9]+' "/run/pelagos/containers/$PN/state.json" 2>/dev/null | head -1 | grep -oE '[0-9]+')
+PAUSE=$(sudo grep -oE '"pause_pid":[ ]*[0-9]+' "/run/pelagos-cri/sandboxes/$POD.json" 2>/dev/null | head -1 | grep -oE '[0-9]+')
+echo "REAL container process (sleep) pid=$SLEEP_PID | state.json pid=$STATE_PID | pause pid=$PAUSE"
+
+echo "=== host-side netns/uts/ipc by pid ==="
+for lp in "sleep:$SLEEP_PID" "state:$STATE_PID" "pause:$PAUSE"; do
+  l=${lp%%:*}; p=${lp##*:}
+  echo "  $l(pid=$p): net=$(sudo readlink /proc/$p/ns/net 2>/dev/null) uts=$(sudo readlink /proc/$p/ns/uts 2>/dev/null) ipc=$(sudo readlink /proc/$p/ns/ipc 2>/dev/null)"
+done
+
+echo "=== SHARING verdict: in-container inode (crictl exec) vs pause inode ==="
+for ns in net uts ipc; do
+  cin=$($CR exec "$CID" readlink "/proc/1/ns/$ns" 2>/dev/null)
+  pin=$(sudo readlink "/proc/$PAUSE/ns/$ns" 2>/dev/null)
+  echo "  $ns: container=$cin pause=$pin  $([ -n "$cin" ] && [ "$cin" = "$pin" ] && echo SHARED || echo SEPARATE)"
+done
+echo "  hostname inside: $($CR exec "$CID" hostname 2>&1)  (want nsdiag-host)"
+echo "  ip addr:  $($CR exec "$CID" ip -o addr show 2>&1 | tr '\n' ' ')"
+echo "  shm_rmid inside: $($CR exec "$CID" cat /proc/sys/kernel/shm_rmid_forced 2>&1)  (want 1)"
+echo "  shm_rmid in pause ipc-ns: $(sudo nsenter --ipc=/proc/$PAUSE/ns/ipc -- cat /proc/sys/kernel/shm_rmid_forced 2>&1)  (want 1)"
+
+echo "=== REAL cluster pod (container process vs its pause) ==="
+RC=$($CR ps -a --state Running -q 2>/dev/null | grep -v "$CID" | head -1)
+echo "real container id: ${RC:-<none running>}"
+if [ -n "${RC:-}" ]; then
+  RPN="pcri-${RC:0:12}"
+  RCPID=$(sudo grep -oE '"pid":[ ]*[0-9]+' "/run/pelagos/containers/$RPN/state.json" 2>/dev/null | head -1 | grep -oE '[0-9]+')
+  RPOD=$($CR inspect "$RC" 2>/dev/null | grep -oE '"sandboxID": *"[a-f0-9]+"' | grep -oE '[a-f0-9]{64}' | head -1)
+  RPAUSE=$(sudo grep -oE '"pause_pid":[ ]*[0-9]+' "/run/pelagos-cri/sandboxes/$RPOD.json" 2>/dev/null | head -1 | grep -oE '[0-9]+')
+  echo "  real container(pid=$RCPID): net=$(sudo readlink /proc/$RCPID/ns/net 2>/dev/null) uts=$(sudo readlink /proc/$RCPID/ns/uts 2>/dev/null)"
+  echo "  real pause(pid=$RPAUSE):     net=$(sudo readlink /proc/$RPAUSE/ns/net 2>/dev/null) uts=$(sudo readlink /proc/$RPAUSE/ns/uts 2>/dev/null)"
+fi
+
+echo "=== cleanup ==="
+$CR stop "$CID" >/dev/null 2>&1; $CR rm "$CID" >/dev/null 2>&1
+$CR stopp "$POD" >/dev/null 2>&1; $CR rmp "$POD" >/dev/null 2>&1
+rm -rf "$W"
+echo "# done @ $(date -u +%FT%TZ)"

--- a/scripts/cri-diag-sandbox.sh
+++ b/scripts/cri-diag-sandbox.sh
@@ -58,8 +58,9 @@ echo "=== [dns] exec cat /etc/resolv.conf ==="
 $CR exec "$CID" cat /etc/resolv.conf 2>&1 || true
 
 echo "=== [ns sharing] container vs pause IPC/UTS/NET inodes ==="
-CPID=$($CR inspect "$CID" 2>/dev/null | grep -oE '"pid": *[0-9]+' | head -1 | grep -oE '[0-9]+')
-PAUSE=$(pgrep -f "sandbox __pause__" | head -1)
+# Container pid from the pelagos state file; pause pid from THIS sandbox's CRI state.
+CPID=$(sudo grep -oE '"pid":[ ]*[0-9]+' "/run/pelagos/containers/$PN/state.json" 2>/dev/null | head -1 | grep -oE '[0-9]+')
+PAUSE=$(sudo grep -oE '"pause_pid":[ ]*[0-9]+' "/run/pelagos-cri/sandboxes/$POD.json" 2>/dev/null | head -1 | grep -oE '[0-9]+')
 echo "container pid=$CPID  pause pid=$PAUSE"
 for ns in ipc uts net; do
   c=$(sudo readlink "/proc/$CPID/ns/$ns" 2>/dev/null)


### PR DESCRIPTION
Closes #355. Completes the **hostname** half of #354 (port mapping remains, next branch).

## What failed
critest "set hostname", "safe sysctls", "unsafe sysctls" — the pod hostname and sysctls were never applied. The container correctly **shares** the pause's net/uts/ipc namespaces (verified in-container on ipc2), but nothing set the values in them.

## Fix
Apply pod hostname (UTS) and sysctls (net/ipc/uts) into the pause's namespaces at `RunPodSandbox` via `nsenter`; joining containers inherit them.

## The critical guard
The apply must wait until the pause has **actually unshared** its UTS+IPC namespaces (`wait_for_pause_ns_unshare`). Without it, the apply races the unshare — `/proc/<pause>/ns/uts` still resolves to the **host** UTS, so `hostname <pod>` **renames the host** (reproduced on ipc2: the node hostname became the pod's), and a pre-unshare sysctl lands on a namespace the pause discards (never reaches the pod). Gating on the unshare fixes the apply **and** guarantees we never mutate the host — host-namespace pods that never unshare are simply skipped.

## Proven on ipc2
- `set hostname` + `safe sysctls` + `unsafe sysctls`: **3/3 pass**.
- In-container: hostname = pod name, `kernel.shm_rmid_forced` = 1.
- **Host hostname stays `ipc2`** across a full critest run (guard verified).

Tests: `sandbox_sysctl_argv`. Diagnostics added: `scripts/cri-confirm-ns.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)