### PR TITLE
fix(cri): exec defaults to container user; RunAsUserName + RunAsGroup validation (#352 user/group, 4/5)

### DIFF
--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -1202,7 +1202,7 @@ impl RuntimeService for RuntimeSvc {
             .collect();
 
         // Extract runAsUser/runAsGroup from the Linux security context.
-        let (run_as_user, run_as_group) = config
+        let (run_as_user, run_as_group, run_as_username) = config
             .linux
             .as_ref()
             .and_then(|l| l.security_context.as_ref())
@@ -1210,9 +1210,19 @@ impl RuntimeService for RuntimeSvc {
                 (
                     sc.run_as_user.as_ref().map(|v| v.value),
                     sc.run_as_group.as_ref().map(|v| v.value),
+                    sc.run_as_username.clone(),
                 )
             })
-            .unwrap_or((None, None));
+            .unwrap_or((None, None, String::new()));
+
+        // CRI requires RunAsUser (or RunAsUserName) whenever RunAsGroup is set —
+        // a group with no user is rejected (critest: "should return error if
+        // RunAsGroup is set without RunAsUser").
+        if run_as_group.is_some() && run_as_user.is_none() && run_as_username.is_empty() {
+            return Err(Status::invalid_argument(
+                "RunAsGroup is set without RunAsUser/RunAsUserName",
+            ));
+        }
 
         // B′ — UID overflow/validity guard.
         // Valid Linux UIDs are 0..=4294967294. The value 4294967295 (u32::MAX) equals
@@ -1370,6 +1380,7 @@ impl RuntimeService for RuntimeSvc {
             exit_code: 0,
             run_as_user,
             run_as_group,
+            run_as_username,
             termination_log_host_path,
             log_path: config.log_path.clone(),
             supplemental_groups: config
@@ -1497,6 +1508,11 @@ impl RuntimeService for RuntimeSvc {
                     args.push(uid.to_string());
                 }
             }
+        } else if !container.run_as_username.is_empty() {
+            // RunAsUserName: pass the name so `pelagos run` resolves it against the
+            // image's /etc/passwd (e.g. "nobody" → its uid:gid).
+            args.push("--user".into());
+            args.push(container.run_as_username.clone());
         }
 
         // Supplemental groups: merge sandbox-level (fsGroup) and container-level groups.

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -105,6 +105,10 @@ pub struct CriContainer {
     /// Override GID from pod securityContext.runAsGroup (None = use image default).
     #[serde(default)]
     pub run_as_group: Option<i64>,
+    /// Username from securityContext.runAsUsername, resolved to a uid against the
+    /// image's /etc/passwd at run time (used when run_as_user is None). Empty = unset.
+    #[serde(default)]
+    pub run_as_username: String,
     /// Host-side path of the termination log file (empty when not set).
     /// Populated from the mount whose container_path matches terminationMessagePath.
     #[serde(default)]

--- a/scripts/cri-diag-usergroup.sh
+++ b/scripts/cri-diag-usergroup.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Diagnose the #352 user/group bucket: run a container with RunAsUser/RunAsGroup/
+# SupplementalGroups set and report the EFFECTIVE id inside it, plus test the
+# RunAsGroup-without-RunAsUser validation. Writes a result file.
+#
+# Usage (IPC node, never omen): sudo bash scripts/cri-diag-usergroup.sh /tmp/ug.result
+set -u
+OUT="${1:-/tmp/ug.result}"
+SOCK="unix:///run/pelagos/cri.sock"
+CR="crictl --runtime-endpoint $SOCK --image-endpoint $SOCK"
+IMG="registry.k8s.io/e2e-test-images/busybox:1.29-2"
+W=$(mktemp -d)
+
+cat > "$W/pod.json" <<JSON
+{ "metadata": {"name":"ug-pod","namespace":"default","uid":"ug-1","attempt":1}, "log_directory": "$W" }
+JSON
+# Container with runAsUser=1000, runAsGroup=2000, supplementalGroups=[3000,4000].
+cat > "$W/ctr.json" <<JSON
+{ "metadata": {"name":"ug-ctr","attempt":1}, "image": {"image":"$IMG"},
+  "command": ["sh","-c","id; sleep 3600"], "log_path": "c.log",
+  "linux": { "security_context": {
+    "run_as_user": {"value": 1000}, "run_as_group": {"value": 2000},
+    "supplemental_groups": [3000, 4000] } } }
+JSON
+# Container with runAsGroup but NO runAsUser → CRI says this must be rejected.
+cat > "$W/badgrp.json" <<JSON
+{ "metadata": {"name":"badgrp-ctr","attempt":1}, "image": {"image":"$IMG"},
+  "command": ["sleep","3600"], "log_path": "b.log",
+  "linux": { "security_context": { "run_as_group": {"value": 2000} } } }
+JSON
+
+exec > "$OUT" 2>&1
+echo "# cri-diag-usergroup @ $(date -u +%FT%TZ)"
+$CR pull "$IMG" >/dev/null 2>&1
+POD=$($CR runp "$W/pod.json"); echo "POD=$POD"
+
+echo "=== [uid/gid/groups] expect uid=1000 gid=2000 groups=2000,3000,4000 ==="
+CID=$($CR create "$POD" "$W/ctr.json" "$W/pod.json"); $CR start "$CID" >/dev/null 2>&1; sleep 1
+# The CONTAINER's own `id` (its real process uid), from the container log:
+echo "  container-process id (from log): $($CR logs "$CID" 2>/dev/null | head -1)"
+# What `crictl exec` runs as (exec's own uid — may differ from the container):
+echo "  crictl-exec id                 : $($CR exec "$CID" id 2>&1)"
+# Host-side truth: the container process's /proc/<pid>/status Uid line:
+PN="pcri-${CID:0:12}"
+CPID=$(sudo grep -oE '"pid":[ ]*[0-9]+' "/run/pelagos/containers/$PN/state.json" 2>/dev/null | head -1 | grep -oE '[0-9]+')
+echo "  /proc/$CPID/status Uid/Gid/Groups: $(sudo grep -E '^(Uid|Gid|Groups):' /proc/$CPID/status 2>/dev/null | tr '\n' ' ')"
+
+echo "=== [validation] create with RunAsGroup and NO RunAsUser → expect an ERROR ==="
+BADOUT=$($CR create "$POD" "$W/badgrp.json" "$W/pod.json" 2>&1)
+echo "  create result: $BADOUT"
+
+echo "=== cleanup ==="
+$CR stop "$CID" >/dev/null 2>&1; $CR rm "$CID" >/dev/null 2>&1
+$CR stopp "$POD" >/dev/null 2>&1; $CR rmp "$POD" >/dev/null 2>&1
+rm -rf "$W"
+echo "# done"

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -398,6 +398,19 @@ pub fn cmd_exec(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
             cmd = cmd.with_gid(g);
         }
         cmd = cmd.with_uid(uid);
+    } else {
+        // No explicit --user: default to the container's OWN process credentials
+        // (uid/gid/supplementary groups), matching `docker exec`/containerd. The
+        // CRI ExecSync path relies on this — critest verifies RunAsUser/RunAsGroup/
+        // SupplementalGroups by exec'ing `id` and expects the container's user, not
+        // root. Creds are read from the container's main (chroot'd) process, so they
+        // are by definition valid in its user namespace (no uid_map check needed).
+        if let Some((uid, gid, groups)) = container_process_creds(root_pid) {
+            if !groups.is_empty() {
+                cmd = cmd.with_additional_gids(&groups);
+            }
+            cmd = cmd.with_gid(gid).with_uid(uid);
+        }
     }
 
     // 5. Join PID namespace in the parent thread before fork (root exec only).
@@ -717,6 +730,34 @@ pub fn discover_namespaces(
     Ok(result)
 }
 
+/// Parse the real uid, real gid, and supplementary groups from the text of a
+/// `/proc/<pid>/status` file. Returns `None` if Uid/Gid lines are missing.
+fn parse_proc_status_creds(status: &str) -> Option<(u32, u32, Vec<u32>)> {
+    let mut uid = None;
+    let mut gid = None;
+    let mut groups = Vec::new();
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("Uid:") {
+            uid = rest.split_whitespace().next().and_then(|s| s.parse().ok());
+        } else if let Some(rest) = line.strip_prefix("Gid:") {
+            gid = rest.split_whitespace().next().and_then(|s| s.parse().ok());
+        } else if let Some(rest) = line.strip_prefix("Groups:") {
+            groups = rest
+                .split_whitespace()
+                .filter_map(|s| s.parse().ok())
+                .collect();
+        }
+    }
+    Some((uid?, gid?, groups))
+}
+
+/// Read the container main process's real uid/gid + supplementary groups from
+/// `/proc/<pid>/status`, so `exec` without `--user` defaults to the container's
+/// own user (matching `docker exec`/containerd).
+fn container_process_creds(pid: i32) -> Option<(u32, u32, Vec<u32>)> {
+    parse_proc_status_creds(&std::fs::read_to_string(format!("/proc/{}/status", pid)).ok()?)
+}
+
 /// Read `/proc/{pid}/environ` — NUL-separated KEY=VALUE pairs.
 fn read_proc_environ(pid: i32) -> Vec<(String, String)> {
     let path = format!("/proc/{}/environ", pid);
@@ -751,4 +792,27 @@ fn uid_in_ns_map(uid: u32, uid_map: &str) -> bool {
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_proc_status_creds;
+
+    /// #352 RunAsUser/Group/SupplementalGroups: exec defaults to the container's
+    /// own creds, parsed from /proc/<pid>/status (real uid/gid + Groups).
+    #[test]
+    fn test_parse_proc_status_creds() {
+        let status = "Name:\tsh\nUid:\t1000\t1000\t1000\t1000\nGid:\t2000\t2000\t2000\t2000\nGroups:\t3000 4000 \n";
+        assert_eq!(
+            parse_proc_status_creds(status),
+            Some((1000, 2000, vec![3000, 4000]))
+        );
+
+        // Root container, no supplementary groups.
+        let root = "Uid:\t0\t0\t0\t0\nGid:\t0\t0\t0\t0\nGroups:\t\n";
+        assert_eq!(parse_proc_status_creds(root), Some((0, 0, vec![])));
+
+        // Missing Uid line → None.
+        assert_eq!(parse_proc_status_creds("Gid:\t0\t0\t0\t0\n"), None);
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -772,6 +772,7 @@ mod tests {
             no_nat: false,
             labels: vec!["env=staging".to_string(), "managed=true".to_string()],
             tmpfs: vec!["/run".to_string(), "/tmp:size=64m".to_string()],
+            ..Default::default()
         };
         let json = serde_json::to_string(&sc).unwrap();
         let decoded: SpawnConfig = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
Part of #352 — the user/group bucket: **4/5 specs green** on ipc2.

## Root cause (rigorously confirmed)
The container already runs as the right uid/gid/groups (proven from its own `id` output). But critest verifies via **ExecSync**, and `pelagos exec` ran as **root** — so `id` returned 0, not the container's user. Three earlier hasty reads (host-netns, exec-uid, "container is root") were measurement artifacts; the in-container/own-log truth is what nailed it.

## Changes
- **pelagos exec** defaults to the container's own creds (uid/gid/supplementary groups from `/proc/<pid>/status`) when no `--user` — `docker exec`/containerd semantics. Root containers unchanged. → fixes **RunAsUser**, **SupplementalGroups**.
- **pelagos-cri** captures `run_as_username` and passes `--user <name>` so `pelagos run` resolves it against the image `/etc/passwd`. → fixes **RunAsUserName**.
- **pelagos-cri** rejects `CreateContainer` when RunAsGroup is set without RunAsUser/RunAsUserName. → fixes the **validation** spec.
- Fixes a pre-existing broken bin-test (`SpawnConfig` literal) so `cargo test --bin pelagos` compiles.

## Verified on ipc2
User/group bucket **4 Passed / 1 Failed**. The one red — **RunAsGroup** — is **not** a user/group bug: it verifies via the container **log**, which isn't written for that short-lived container (the **#344** container-log issue). Deferred to #344.

Tests: `parse_proc_status_creds`; **18 exec integration tests pass** (no regression from the exec-as-container-user change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)