### PR TITLE
fix(cri): host-port mapping via CNI portmap capability args — completes #354

### DIFF
--- a/pelagos-cri/src/cni.rs
+++ b/pelagos-cri/src/cni.rs
@@ -92,8 +92,13 @@ pub fn delete_netns(name: &str) {
 
 /// Run CNI ADD for a sandbox.
 /// Returns the assigned IPv4 address (without prefix length) on success.
-pub fn cni_add(sandbox_id: &str, netns_path: &str, conf_path: &Path) -> Result<String, String> {
-    let result = invoke_cni("ADD", sandbox_id, netns_path, conf_path)?;
+pub fn cni_add(
+    sandbox_id: &str,
+    netns_path: &str,
+    conf_path: &Path,
+    cap_args: &serde_json::Value,
+) -> Result<String, String> {
+    let result = invoke_cni("ADD", sandbox_id, netns_path, conf_path, cap_args)?;
     let ip = result
         .get("ips")
         .and_then(|v| v.as_array())
@@ -106,8 +111,8 @@ pub fn cni_add(sandbox_id: &str, netns_path: &str, conf_path: &Path) -> Result<S
 }
 
 /// Run CNI DEL for a sandbox.  Best-effort; errors are logged but not returned.
-pub fn cni_del(sandbox_id: &str, netns_path: &str, conf_path: &Path) {
-    if let Err(e) = invoke_cni("DEL", sandbox_id, netns_path, conf_path) {
+pub fn cni_del(sandbox_id: &str, netns_path: &str, conf_path: &Path, cap_args: &serde_json::Value) {
+    if let Err(e) = invoke_cni("DEL", sandbox_id, netns_path, conf_path, cap_args) {
         log::warn!("CNI DEL for {}: {}", sandbox_id, e);
     }
 }
@@ -196,12 +201,13 @@ fn invoke_cni(
     sandbox_id: &str,
     netns_path: &str,
     conf_path: &Path,
+    cap_args: &serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let raw = std::fs::read_to_string(conf_path)
         .map_err(|e| format!("read {}: {}", conf_path.display(), e))?;
 
     if conf_path.extension().and_then(|x| x.to_str()) == Some("conflist") {
-        invoke_conflist(command, sandbox_id, netns_path, &raw)
+        invoke_conflist(command, sandbox_id, netns_path, &raw, cap_args)
     } else {
         invoke_conf(command, sandbox_id, netns_path, &raw)
     }
@@ -222,11 +228,59 @@ fn invoke_conf(
 
 /// For a conflist, call each plugin in order (ADD) or reverse (DEL), forwarding
 /// the result of each plugin as `prevResult` to the next.
+/// Build CNI capability args (`{"portMappings":[...]}`) from a sandbox's port
+/// mappings, for the `portmap` plugin. Returns an empty object when there are no
+/// host ports to map (so no `runtimeConfig` is injected).
+pub fn port_mapping_cap_args(mappings: &[crate::state::CriPortMapping]) -> serde_json::Value {
+    let pms: Vec<serde_json::Value> = mappings
+        .iter()
+        .filter(|p| p.host_port > 0 && p.container_port > 0)
+        .map(|p| {
+            serde_json::json!({
+                "hostPort": p.host_port,
+                "containerPort": p.container_port,
+                "protocol": match p.protocol { 1 => "udp", 2 => "sctp", _ => "tcp" },
+                "hostIP": p.host_ip,
+            })
+        })
+        .collect();
+    if pms.is_empty() {
+        serde_json::json!({})
+    } else {
+        serde_json::json!({ "portMappings": pms })
+    }
+}
+
+/// For a plugin that declares capabilities (e.g. `{"capabilities":{"portMappings":true}}`),
+/// inject `runtimeConfig.<cap>` from the runtime's capability args. This is how the
+/// CNI spec passes host-port mappings to the `portmap` plugin (#354) — without it
+/// portmap runs but sets up no DNAT, so host ports are unreachable.
+fn capability_runtime_config(
+    plugin_conf: &serde_json::Value,
+    cap_args: &serde_json::Value,
+) -> Option<serde_json::Value> {
+    let caps = plugin_conf.get("capabilities")?.as_object()?;
+    let mut rc = serde_json::Map::new();
+    for (cap, enabled) in caps {
+        if enabled.as_bool() == Some(true) {
+            if let Some(val) = cap_args.get(cap) {
+                rc.insert(cap.clone(), val.clone());
+            }
+        }
+    }
+    if rc.is_empty() {
+        None
+    } else {
+        Some(serde_json::Value::Object(rc))
+    }
+}
+
 fn invoke_conflist(
     command: &str,
     sandbox_id: &str,
     netns_path: &str,
     raw: &str,
+    cap_args: &serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let conflist: ConfList =
         serde_json::from_str(raw).map_err(|e| format!("parse .conflist: {}", e))?;
@@ -259,6 +313,9 @@ fn invoke_conflist(
         if let Some(ref pr) = prev_result {
             config["prevResult"] = pr.clone();
         }
+        if let Some(rc) = capability_runtime_config(plugin_conf, cap_args) {
+            config["runtimeConfig"] = rc;
+        }
 
         let config_str = serde_json::to_string(&config)
             .map_err(|e| format!("serialize config for '{}': {}", plugin_type, e))?;
@@ -271,4 +328,64 @@ fn invoke_conflist(
     }
 
     Ok(last_result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::CriPortMapping;
+
+    #[test]
+    fn test_port_mapping_cap_args() {
+        // No host ports → empty object (no runtimeConfig injected).
+        assert_eq!(port_mapping_cap_args(&[]), serde_json::json!({}));
+
+        let pms = vec![
+            CriPortMapping {
+                protocol: 0,
+                container_port: 80,
+                host_port: 8080,
+                host_ip: String::new(),
+            },
+            CriPortMapping {
+                protocol: 1,
+                container_port: 53,
+                host_port: 5353,
+                host_ip: "127.0.0.1".into(),
+            },
+            CriPortMapping {
+                protocol: 0,
+                container_port: 99,
+                host_port: 0,
+                host_ip: String::new(),
+            }, // dropped
+        ];
+        let args = port_mapping_cap_args(&pms);
+        assert_eq!(
+            args,
+            serde_json::json!({"portMappings":[
+                {"hostPort":8080,"containerPort":80,"protocol":"tcp","hostIP":""},
+                {"hostPort":5353,"containerPort":53,"protocol":"udp","hostIP":"127.0.0.1"}
+            ]})
+        );
+    }
+
+    /// #354: portmap (capabilities.portMappings) gets runtimeConfig injected;
+    /// flannel (no matching capability) does not.
+    #[test]
+    fn test_capability_runtime_config_injection() {
+        let cap_args = serde_json::json!({"portMappings":[{"hostPort":8080,"containerPort":80,"protocol":"tcp"}]});
+
+        let portmap = serde_json::json!({"type":"portmap","capabilities":{"portMappings":true}});
+        let rc =
+            capability_runtime_config(&portmap, &cap_args).expect("portmap gets runtimeConfig");
+        assert_eq!(rc["portMappings"][0]["hostPort"], 8080);
+
+        let flannel = serde_json::json!({"type":"flannel"});
+        assert!(capability_runtime_config(&flannel, &cap_args).is_none());
+
+        // Capability declared but no matching arg → nothing injected.
+        let bw = serde_json::json!({"type":"bandwidth","capabilities":{"bandwidth":true}});
+        assert!(capability_runtime_config(&bw, &cap_args).is_none());
+    }
 }

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -722,6 +722,19 @@ impl RuntimeService for RuntimeSvc {
             .map(|l| l.sysctls.clone())
             .unwrap_or_default();
 
+        // Host port mappings → CNI portmap plugin capability args (#354).
+        let sandbox_port_mappings: Vec<state::CriPortMapping> = config
+            .port_mappings
+            .iter()
+            .map(|p| state::CriPortMapping {
+                protocol: p.protocol,
+                container_port: p.container_port,
+                host_port: p.host_port,
+                host_ip: p.host_ip.clone(),
+            })
+            .collect();
+        let cni_cap_args = cni::port_mapping_cap_args(&sandbox_port_mappings);
+
         // Try CNI networking first; fall back to pelagos native if no config is present.
         let (sandbox_id, netns, ip, cni_conf, pause_pid) = if let Some(conf_path) =
             cni::find_cni_conf()
@@ -733,7 +746,7 @@ impl RuntimeService for RuntimeSvc {
             let netns_path = cni::create_netns(&ns_name)
                 .map_err(|e| Status::internal(format!("create netns for CNI sandbox: {}", e)))?;
 
-            let ip = match cni::cni_add(&id, &netns_path, &conf_path) {
+            let ip = match cni::cni_add(&id, &netns_path, &conf_path, &cni_cap_args) {
                 Ok(ip) => ip,
                 Err(e) => {
                     cni::delete_netns(&ns_name);
@@ -955,6 +968,7 @@ impl RuntimeService for RuntimeSvc {
                 .and_then(|sc| sc.namespace_options.as_ref())
                 .map(|no| no.ipc)
                 .unwrap_or(0),
+            port_mappings: sandbox_port_mappings,
         };
 
         {
@@ -1001,7 +1015,13 @@ impl RuntimeService for RuntimeSvc {
                 // ── CNI teardown ───────────────────────────────────────────────
                 let netns_path = format!("/run/netns/{}", sb.netns);
                 if !sb.cni_conf.is_empty() {
-                    cni::cni_del(&sandbox_id, &netns_path, std::path::Path::new(&sb.cni_conf));
+                    let cap_args = cni::port_mapping_cap_args(&sb.port_mappings);
+                    cni::cni_del(
+                        &sandbox_id,
+                        &netns_path,
+                        std::path::Path::new(&sb.cni_conf),
+                        &cap_args,
+                    );
                 }
                 if sb.pause_pid > 0 {
                     let _ = std::process::Command::new("kill")
@@ -3086,6 +3106,7 @@ mod tests {
             dns_options: vec!["ndots:5".into()],
             pid_namespace_mode: 0,
             ipc_namespace_mode: 0,
+            port_mappings: vec![],
         };
 
         let json = serde_json::to_string(&sandbox).expect("serialize");
@@ -3125,6 +3146,7 @@ mod tests {
             dns_options: vec![],
             pid_namespace_mode: 0,
             ipc_namespace_mode: 0,
+            port_mappings: vec![],
         };
 
         let json = serde_json::to_string(&sandbox).expect("serialize");

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -61,6 +61,21 @@ pub struct CriSandbox {
     ///   0 = POD (isolated, default), 1 = CONTAINER (isolated), 2 = NODE (host IPC namespace).
     #[serde(default)]
     pub ipc_namespace_mode: i32,
+    /// Host port mappings (PodSandboxConfig.port_mappings) — passed to the CNI
+    /// portmap plugin as capability args at ADD and (for cleanup) at DEL.
+    #[serde(default)]
+    pub port_mappings: Vec<CriPortMapping>,
+}
+
+/// A CRI `PortMapping` (host_port → container_port) persisted with the sandbox.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CriPortMapping {
+    /// Protocol: 0=TCP, 1=UDP, 2=SCTP (matches the CRI proto enum).
+    pub protocol: i32,
+    pub container_port: i32,
+    pub host_port: i32,
+    #[serde(default)]
+    pub host_ip: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
Closes #354.

## Root cause
critest "port mapping with host port and container port" failed with `connection refused`. The node's flannel conflist **already chains the `portmap` plugin**, and pelagos-cri **already invokes the whole chain** — but it never injected the `runtimeConfig.portMappings` capability args, so portmap ran with no mappings and set up no host-port DNAT. (The earlier per-container `--publish` approach failed because `pelagos run --sandbox` skips network setup.)

## Fix
Implement the standard CNI **capability-args** convention: for any plugin declaring `capabilities.<cap> == true`, inject `runtimeConfig.<cap>` from the runtime's capability args. Build `{portMappings:[...]}` from the sandbox's `port_mappings` and thread it through `cni_add` (ADD) and `cni_del` (DEL, so portmap removes its rules). Persist `port_mappings` on the sandbox for teardown. Generic (portmap today; bandwidth/etc. later).

No-op for pods without host ports (empty cap args → no `runtimeConfig`), so normal pods are unaffected.

## Proven on ipc2
- `port mapping with host port and container port`: **pass**.
- Full networking group (DNS + hostname + port + …): **4/4 pass** — confirming normal-pod CNI is not regressed.

**Completes #354**: DNS (#358) + set-hostname (#360) + host-port (this PR).

Tests: `port_mapping_cap_args`, `capability_runtime_config_injection`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)