### PR TITLE
fix(cri): default non-privileged containers to OCI capability set (#352 Privileged-is-false)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -3405,22 +3405,23 @@ into is not enforced.
 **Requires:** root, rootfs
 
 Runs a container with exactly `Capability::DEFAULT_CAPS` and reads `CapEff`
-from `/proc/self/status`.  Asserts the value is `00000000800405fb` — the 11-cap
-set (CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, SETGID, SETUID, SETPCAP,
-NET_BIND_SERVICE, SYS_CHROOT, SETFCAP).
+from `/proc/self/status`.  Asserts the value is `00000000a80425fb` — the OCI
+default 14-cap set (CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, SETGID, SETUID,
+SETPCAP, NET_BIND_SERVICE, NET_RAW, MKNOD, AUDIT_WRITE, SYS_CHROOT, SETFCAP).
 
 Failure means the `DEFAULT_CAPS` constant was modified without updating this
 test — any bit added or removed changes the hex value.
 
-### `test_default_caps_allows_chown_denies_mknod`
+### `test_default_caps_allows_chown_denies_sys_admin`
 **Requires:** root, rootfs
 
-Runs a container with `DEFAULT_CAPS` and executes both `chown nobody /tmp` and
-`mknod /tmp/testdev c 1 1`.  Asserts `CHOWN=OK` and `MKNOD=FAIL`.
+Runs a container with `DEFAULT_CAPS` and executes `chown nobody /tmp` and
+`mount -t tmpfs none /mnt`.  Asserts `CHOWN=OK` (in the OCI default set) and
+`MOUNT=FAIL` (CAP_SYS_ADMIN is NOT in the default set).
 
-Failure indicates either: CHOWN was removed from `DEFAULT_CAPS` (postgres-style
-images would break), or MKNOD was accidentally added (device-node creation
-attack surface opened).
+Failure indicates either: CHOWN was removed from `DEFAULT_CAPS` (breaking standard
+images), or SYS_ADMIN was accidentally added (a major privilege-escalation attack
+surface — mount, namespace ops, etc.).
 
 ### `test_cap_drop_all_zeros_caps`
 **Requires:** root, rootfs

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1042,9 +1042,12 @@ fn apply_cli_options(
         cmd = cmd.with_privileged();
     }
 
-    // Capabilities: start from DEFAULT_CAPS, apply --cap-drop then --cap-add.
+    // Capabilities: a non-privileged container runs with the DEFAULT_CAPS set
+    // (the OCI default 14), modified by --cap-drop then --cap-add — NOT full root
+    // caps. Without this a "privileged: false" container could still e.g. create a
+    // bridge (CAP_NET_ADMIN). Privileged containers (handled above) keep all caps.
     // --cap-drop ALL zeros the baseline; individual --cap-drop NAME removes one cap.
-    if !args.cap_drop.is_empty() || !args.cap_add.is_empty() {
+    if !args.privileged {
         let drop_all = args.cap_drop.iter().any(|c| c.eq_ignore_ascii_case("ALL"));
         let mut effective = if drop_all {
             Capability::empty()

--- a/src/container.rs
+++ b/src/container.rs
@@ -745,12 +745,17 @@ impl Capability {
     /// or `with_capabilities(Capability::DEFAULT_CAPS - dropped + added)` for
     /// fine-grained control.
     pub const DEFAULT_CAPS: Capability = Capability::from_bits_retain(
+        // The OCI/Docker default capability set (14 caps). Non-privileged
+        // containers get exactly these — notably NOT NET_ADMIN/SYS_ADMIN/etc.
         Capability::CHOWN.bits()
             | Capability::DAC_OVERRIDE.bits()
             | Capability::FOWNER.bits()
             | Capability::FSETID.bits()
             | Capability::KILL.bits()
             | Capability::NET_BIND_SERVICE.bits()
+            | Capability::NET_RAW.bits()
+            | Capability::MKNOD.bits()
+            | Capability::AUDIT_WRITE.bits()
             | Capability::SETFCAP.bits()
             | Capability::SETGID.bits()
             | Capability::SETPCAP.bits()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -18207,8 +18207,8 @@ fn test_default_caps_hex_value() {
         .unwrap_or("missing");
 
     assert_eq!(
-        capeff_val, "00000000800405fb",
-        "DEFAULT_CAPS CapEff mismatch — expected 00000000800405fb (11-cap set), got {capeff_val}"
+        capeff_val, "00000000a80425fb",
+        "DEFAULT_CAPS CapEff mismatch — expected 00000000a80425fb (OCI default 14-cap set), got {capeff_val}"
     );
 }
 
@@ -18220,15 +18220,15 @@ fn test_default_caps_hex_value() {
 /// hex value — CHOWN must work (so postgres-style images start cleanly) and MKNOD
 /// must fail (so device-node creation attacks are blocked).
 #[test]
-fn test_default_caps_allows_chown_denies_mknod() {
+fn test_default_caps_allows_chown_denies_sys_admin() {
     if !is_root() {
-        eprintln!("SKIP: test_default_caps_allows_chown_denies_mknod requires root");
+        eprintln!("SKIP: test_default_caps_allows_chown_denies_sys_admin requires root");
         return;
     }
     let rootfs = match get_test_rootfs() {
         Some(p) => p,
         None => {
-            eprintln!("SKIP: test_default_caps_allows_chown_denies_mknod requires alpine-rootfs");
+            eprintln!("SKIP: test_default_caps_allows_chown_denies_sys_admin requires alpine-rootfs");
             return;
         }
     };
@@ -18237,7 +18237,7 @@ fn test_default_caps_allows_chown_denies_mknod() {
         .args([
             "-c",
             "chown nobody /tmp && echo CHOWN=OK || echo CHOWN=FAIL; \
-             mknod /tmp/testdev c 1 1 2>/dev/null && echo MKNOD=OK || echo MKNOD=FAIL",
+             mount -t tmpfs none /mnt 2>/dev/null && echo MOUNT=OK || echo MOUNT=FAIL",
         ])
         .with_chroot(&rootfs)
         .with_proc_mount()
@@ -18252,13 +18252,15 @@ fn test_default_caps_allows_chown_denies_mknod() {
     let (_, stdout_bytes, _) = child.wait_with_output().expect("wait failed");
     let stdout = String::from_utf8_lossy(&stdout_bytes);
 
+    // CHOWN is in the OCI default 14-cap set; SYS_ADMIN (mount) is NOT — the key
+    // boundary: a default container can do ordinary file ops but not privileged ones.
     assert!(
         stdout.contains("CHOWN=OK"),
         "CHOWN should succeed with DEFAULT_CAPS; stdout={stdout:?}"
     );
     assert!(
-        stdout.contains("MKNOD=FAIL"),
-        "MKNOD should fail with DEFAULT_CAPS (not in default set); stdout={stdout:?}"
+        stdout.contains("MOUNT=FAIL"),
+        "mount (CAP_SYS_ADMIN) must fail with DEFAULT_CAPS (not in default set); stdout={stdout:?}"
     );
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -18228,7 +18228,9 @@ fn test_default_caps_allows_chown_denies_sys_admin() {
     let rootfs = match get_test_rootfs() {
         Some(p) => p,
         None => {
-            eprintln!("SKIP: test_default_caps_allows_chown_denies_sys_admin requires alpine-rootfs");
+            eprintln!(
+                "SKIP: test_default_caps_allows_chown_denies_sys_admin requires alpine-rootfs"
+            );
             return;
         }
     };


### PR DESCRIPTION
Part of #352 — the **Privileged-is-false** spec (now green on ipc2).

## Root cause
A non-privileged container could `brctl addbr` (CAP_NET_ADMIN). pelagos only applied a capability set when caps were *explicitly* added/dropped — so a container with no cap config kept **full root caps**. "privileged: false" containers were effectively privileged.

## Fix
- **pelagos run**: apply the default cap set to **all non-privileged** containers (gated on `!privileged`, not on cap-add/drop being present). Privileged containers still get all caps.
- **Align `DEFAULT_CAPS` to the OCI/Docker default 14** (added NET_RAW, MKNOD, AUDIT_WRITE) so normal pods keep working (ping needs NET_RAW). Chosen over the prior stricter 11-cap set for k8s/containerd compatibility — **per maintainer decision**. Net effect is a **security improvement**: default containers go from full root caps → the OCI default.

## Verified on ipc2
Privileged-is-false + caps (ALL/drop) + RunAsUser = **6/6**. Updated the 2 tests that encoded the old 11-cap default (+ `docs/INTEGRATION_TESTS.md`); the other 401 integration tests passed *with* this change applied. 377 lib tests pass.

Deferred (not Privileged): **NoNewPrivs** (setuid escalation — likely nosuid rootfs; own branch) and **ReadOnlyRootfs** (the #344 container-log issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)