### PR TITLE
fix(cri): full seccomp support — Localhost, exec inheritance, nil/privileged semantics (#352 seccomp 7/7)

### DIFF
--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -1280,11 +1280,14 @@ impl RuntimeService for RuntimeSvc {
                     .as_ref()
                     .map(|c| (c.add_capabilities.clone(), c.drop_capabilities.clone()))
                     .unwrap_or_default();
+                // CRI ProfileType: 0=RuntimeDefault, 1=Unconfined, 2=Localhost.
+                // A NIL seccomp field means UNCONFINED (1), not RuntimeDefault — the
+                // kubelet sets RuntimeDefault explicitly when it wants it (#352).
                 let (sec_type, sec_path) = sc
                     .seccomp
                     .as_ref()
                     .map(|s| (s.profile_type, s.localhost_ref.clone()))
-                    .unwrap_or((0, String::new()));
+                    .unwrap_or((1, String::new()));
                 (
                     add,
                     drop,
@@ -1647,7 +1650,13 @@ impl RuntimeService for RuntimeSvc {
 
         // Seccomp profile (securityContext.seccomp).
         // Profile type: 0=RuntimeDefault, 1=Unconfined, 2=Localhost.
-        match container.seccomp_profile_type {
+        // A PRIVILEGED container ignores any seccomp profile — it runs unconfined
+        // (critest "ignore a seccomp profile ... when privileged", #352).
+        match if container.privileged {
+            1 // force Unconfined
+        } else {
+            container.seccomp_profile_type
+        } {
             0 => {
                 // RuntimeDefault — use pelagos's built-in Docker-compatible seccomp profile.
                 args.push("--security-opt".into());

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -424,6 +424,28 @@ pub fn cmd_exec(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    // Inherit the container's seccomp profile so exec'd processes are filtered the
+    // same way (a profile that blocks chmod/sethostname must block them for exec
+    // too) — `docker exec` semantics. The profile is recorded in the container's
+    // security-opt at spawn time (#352). Root exec only.
+    if !is_rootless {
+        if let Some(val) = state.spawn_config.as_ref().and_then(|sc| {
+            sc.security_opt
+                .iter()
+                .find_map(|o| o.strip_prefix("seccomp="))
+        }) {
+            // "none"/"unconfined" → no filter (and no NNP needed).
+            if !matches!(val, "none" | "unconfined") {
+                // Set NO_NEW_PRIVS so the seccomp filter installs WITHOUT requiring
+                // CAP_SYS_ADMIN — exec runs with the container's reduced capability
+                // set, which usually lacks it, so without NNP the install EPERMs.
+                cmd = cmd.with_no_new_privileges(true);
+                cmd = super::apply_seccomp_opt(cmd, val)
+                    .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+            }
+        }
+    }
+
     // 5. Join PID namespace in the parent thread before fork (root exec only).
     //
     // setns(CLONE_NEWPID) updates this thread's pid_for_children to the

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -622,6 +622,38 @@ pub fn parse_capability(s: &str) -> Result<pelagos::container::Capability, Strin
     })
 }
 
+/// Apply a `seccomp=<value>` security-opt to `cmd`: a named profile
+/// (default/minimal/iouring/none) or an absolute path to an OCI seccomp profile
+/// JSON (a Kubernetes "Localhost" profile). Shared by `pelagos run` and
+/// `pelagos exec` so an exec'd process is filtered exactly like the container (#352).
+pub fn apply_seccomp_opt(
+    cmd: pelagos::container::Command,
+    val: &str,
+) -> Result<pelagos::container::Command, String> {
+    Ok(match val {
+        "default" | "" => cmd.with_seccomp_default(),
+        "minimal" => cmd.with_seccomp_minimal(),
+        "iouring" | "io-uring" => cmd.with_seccomp_allow_io_uring(),
+        "none" | "unconfined" => cmd,
+        path if path.starts_with('/') => {
+            let data = std::fs::read_to_string(path)
+                .map_err(|e| format!("read seccomp profile '{}': {}", path, e))?;
+            let oci: pelagos::oci::OciSeccomp = serde_json::from_str(&data)
+                .map_err(|e| format!("parse seccomp profile '{}': {}", path, e))?;
+            let prog = pelagos::seccomp::filter_from_oci(&oci)
+                .map_err(|e| format!("compile seccomp profile '{}': {}", path, e))?;
+            cmd.with_seccomp_program(prog)
+        }
+        other => {
+            return Err(format!(
+                "unknown seccomp profile '{}' (use: default, minimal, iouring, none, \
+                 or an absolute path to a seccomp profile JSON)",
+                other
+            ))
+        }
+    })
+}
+
 /// Format a duration in seconds as a human-readable "X minutes ago" string.
 pub fn format_age(started_at_iso: &str) -> String {
     // Parse back to epoch seconds (best-effort).

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1074,19 +1074,7 @@ fn apply_cli_options(
     for opt in &args.security_opt {
         let (key, val) = opt.split_once('=').unwrap_or((opt.as_str(), ""));
         match key {
-            "seccomp" => match val {
-                "default" | "" => cmd = cmd.with_seccomp_default(),
-                "minimal" => cmd = cmd.with_seccomp_minimal(),
-                "iouring" | "io-uring" => cmd = cmd.with_seccomp_allow_io_uring(),
-                "none" => {}
-                other => {
-                    return Err(format!(
-                        "unknown seccomp profile '{}' (use: default, minimal, iouring, none)",
-                        other
-                    )
-                    .into())
-                }
-            },
+            "seccomp" => cmd = super::apply_seccomp_opt(cmd, val)?,
             "no-new-privileges" => cmd = cmd.with_no_new_privileges(true),
             other => return Err(format!("unknown --security-opt '{}'", other).into()),
         }

--- a/src/seccomp.rs
+++ b/src/seccomp.rs
@@ -540,6 +540,14 @@ pub fn filter_from_oci(config: &crate::oci::OciSeccomp) -> Result<BpfProgram, io
                         }
                     }
                 }
+            } else {
+                // Unknown to our (hand-maintained) syscall table: the rule is dropped,
+                // which for a deny rule silently fails OPEN. Warn so the gap is visible
+                // rather than a silent hole — names should be added to syscall_number.
+                log::warn!(
+                    "seccomp: syscall '{}' not in the syscall-number table — rule NOT applied",
+                    name
+                );
             }
         }
     }
@@ -622,6 +630,10 @@ pub fn syscall_number(name: &str) -> Result<i64, io::Error> {
         // User/group
         "setuid" => Ok(105),
         "setgid" => Ok(106),
+
+        // Hostname / domain (CAP_SYS_ADMIN ops a seccomp profile may block)
+        "sethostname" => Ok(170),
+        "setdomainname" => Ok(171),
 
         // Personality
         "personality" => Ok(135),
@@ -1030,6 +1042,10 @@ pub fn syscall_number(name: &str) -> Result<i64, io::Error> {
         "setuid" => Ok(146),
         "setgid" => Ok(144),
 
+        // Hostname / domain (CAP_SYS_ADMIN ops a seccomp profile may block)
+        "sethostname" => Ok(161),
+        "setdomainname" => Ok(162),
+
         // Personality
         "personality" => Ok(92),
 
@@ -1279,6 +1295,18 @@ mod tests {
         assert!(syscall_number("io_uring_setup").is_ok());
         assert!(syscall_number("io_uring_enter").is_ok());
         assert!(syscall_number("io_uring_register").is_ok());
+    }
+
+    /// #352: a Kubernetes "Localhost" seccomp profile that blocks `sethostname`
+    /// must resolve — previously it was missing from the syscall table and the
+    /// deny rule was silently dropped (failed open).
+    #[test]
+    fn test_sethostname_syscall_known() {
+        assert!(
+            syscall_number("sethostname").is_ok(),
+            "sethostname must resolve so seccomp profiles can block it"
+        );
+        assert!(syscall_number("setdomainname").is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Part of #352 — the SeccompProfilePath bucket: **7/7 green** on ipc2. (The hardest bucket — six coordinated fixes.)

## Fixes
1. **Localhost profiles** — `seccomp=<path>` rejected JSON files; now load an absolute path via the existing `filter_from_oci` (OCI seccomp JSON → BPF). Factored into `apply_seccomp_opt`, shared by run + exec.
2. **exec inheritance** — critest verifies via ExecSync, but `pelagos exec` ran unfiltered; it now re-applies the container's recorded `seccomp=` profile (docker-exec semantics).
3. **NNP-in-exec** — a seccomp install needs CAP_SYS_ADMIN or NO_NEW_PRIVS; exec runs with the container's reduced caps, so it EPERM'd. Set NO_NEW_PRIVS before the filter.
4. **nil → unconfined** — pelagos-cri defaulted a nil seccomp field to RuntimeDefault; per CRI it's **Unconfined**.
5. **`sethostname`/`setdomainname`** were missing from the hand-maintained syscall table — a profile blocking them **silently failed open**. Added (x86_64 + aarch64) + a **warn on any unresolved syscall** (no more silent holes).
6. **privileged → unconfined** — a privileged container ignores its seccomp profile.

## Verified on ipc2
- SeccompProfilePath **7/7**.
- exec-verified buckets (RunAsUser/Name, SupplementalGroups, dropping-cap, Privileged-false, RunAsGroup, adding-ALL) **8/8** — no regression.

Tests: `sethostname_syscall_known`; 377 lib + 54 bin + 18 exec integration pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)