### PR TITLE
fix(cri): make StopContainer idempotent for unknown containers (#342)

### DIFF
--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -1866,7 +1866,12 @@ impl RuntimeService for RuntimeSvc {
             st.containers
                 .get(&container_id)
                 .map(|c| c.pelagos_name.clone())
-                .ok_or_else(|| Status::not_found("container not found"))?
+        };
+        // StopContainer must be IDEMPOTENT: stopping a container the runtime no
+        // longer knows about (already removed, or never existed) is a no-op
+        // success, not an error — the kubelet relies on this (critest #342).
+        let Some(pelagos_name) = pelagos_name else {
+            return Ok(Response::new(StopContainerResponse {}));
         };
 
         let _ = run_pelagos(&bin, &["stop", &pelagos_name]).await;


### PR DESCRIPTION
Closes #342.

## Bug
StopContainer returned `NotFound` for a container the runtime no longer tracks. Per CRI, StopContainer must be **idempotent** — the kubelet stops already-gone containers and expects success.

## Fix
Return a no-op success when the container is unknown (instead of `NotFound`).

## Verified on ipc2
Idempotence specs 2/2; container/sandbox basic-ops 17/18 (the 1 remaining is #357 "preserving container attributes", separate). 31 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)