### PR TITLE
fix(cri): preserve and report container metadata.attempt (#357)

### DIFF
--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -353,7 +353,7 @@ fn build_container_stats(c: &CriContainer) -> ContainerStats {
             id: c.id.clone(),
             metadata: Some(ContainerMetadata {
                 name: c.name.clone(),
-                attempt: 0,
+                attempt: c.attempt,
             }),
             labels: c.labels.clone(),
             annotations: c.annotations.clone(),
@@ -563,7 +563,7 @@ fn container_to_proto(c: &CriContainer) -> crate::cri::Container {
         pod_sandbox_id: c.sandbox_id.clone(),
         metadata: Some(ContainerMetadata {
             name: c.name.clone(),
-            attempt: 0,
+            attempt: c.attempt,
         }),
         image: Some(ImageSpec {
             image: c.image.clone(),
@@ -1388,6 +1388,7 @@ impl RuntimeService for RuntimeSvc {
             sandbox_id,
             pelagos_name,
             name: meta.name.clone(),
+            attempt: meta.attempt,
             image: image_ref,
             entrypoint: config.command.clone(),
             args: config.args.clone(),
@@ -2069,7 +2070,7 @@ impl RuntimeService for RuntimeSvc {
             id: container.id.clone(),
             metadata: Some(ContainerMetadata {
                 name: container.name.clone(),
-                attempt: 0,
+                attempt: container.attempt,
             }),
             state: cstate,
             created_at: container.created_at_ns,

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -99,6 +99,10 @@ pub struct CriContainer {
     pub sandbox_id: String,
     pub pelagos_name: String,
     pub name: String,
+    /// CRI metadata.attempt — the container's restart attempt counter; must be
+    /// preserved and reported back in ContainerStatus/ListContainers (#357).
+    #[serde(default)]
+    pub attempt: u32,
     pub image: String,
     /// CRI `command` field — overrides image ENTRYPOINT.
     pub entrypoint: Vec<String>,


### PR DESCRIPTION
Closes #357.

## Bug
CreateContainer dropped the CRI `metadata.attempt` and ContainerStatus / ListContainers / ContainerStats all hardcoded `attempt: 0`. critest "preserving container attributes" sets attempt=2 and asserts ContainerStatus reports it — got 0.

## Fix
Store `meta.attempt` on `CriContainer`; report it from all three `ContainerMetadata` sites.

## Verified on ipc2
"starting container" + "preserving container attributes" pass; container/sandbox basic-ops **18/18**. 31 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)