### PR TITLE
fix(cri): report OOMKilled reason + exit code 137 in ContainerStatus (#343)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -412,6 +412,22 @@ writing 100 MB into a tmpfs. If the memory limit is not enforced, dd completes s
 (exit 0). A correctly working limit OOM-kills the container (non-zero exit / signal). Failure
 would indicate the cgroup setup race has regressed.
 
+### `test_oom_killed_flag_set`
+**Requires:** root, rootfs
+
+Verifies the #343 OOM-reporting mechanism: `ExitStatus::oom_killed()` is read from
+the cgroup-v2 `memory.events` `oom_kill` counter in `wait()` **before** the cgroup is
+torn down. Runs `dd if=/dev/zero of=/tmp/fill bs=1M count=100` against a 16 MB hard
+memory limit (`with_cgroup_memory_swap(0)`) so the kernel OOM killer SIGKILLs the
+writer, then asserts `status.oom_killed() == true`. A second container that exits
+cleanly (`echo hi`) must report `oom_killed() == false`.
+
+Failure of the first assertion would mean the OOM signal was lost (e.g. the counter
+was read after teardown removed the cgroup, or the wrong cgroup path was read),
+causing the CRI shim to misreport an OOM kill as a generic `Error` instead of
+`OOMKilled` — the exact debuggability regression #343 targets. Failure of the second
+would mean we falsely flag clean exits as OOM kills.
+
 ### `test_cgroup_pids_limit`
 **Requires:** root, rootfs
 

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -77,6 +77,10 @@ struct PelagosContainerState {
     /// Relative to the cgroup root (no leading `/sys/fs/cgroup`).
     #[serde(default)]
     cgroup_name: Option<String>,
+    /// True if the kernel OOM killer terminated the container (#343). Surfaced
+    /// as `reason: OOMKilled` in ContainerStatus.
+    #[serde(default)]
+    oom_killed: bool,
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -1402,6 +1406,7 @@ impl RuntimeService for RuntimeSvc {
             finished_at_ns: 0,
             state: MyContainerState::Created,
             exit_code: 0,
+            oom_killed: false,
             run_as_user,
             run_as_group,
             run_as_username,
@@ -1939,6 +1944,7 @@ impl RuntimeService for RuntimeSvc {
                             if let Some(c) = st.containers.get_mut(&id) {
                                 c.state = MyContainerState::Exited;
                                 c.exit_code = live.exit_code.unwrap_or(0);
+                                c.oom_killed = live.oom_killed;
                                 c.finished_at_ns = now_ns();
                                 let _ = state::save_container(c);
                             }
@@ -2025,6 +2031,7 @@ impl RuntimeService for RuntimeSvc {
                     if let Some(c) = st.containers.get_mut(&container_id) {
                         c.state = MyContainerState::Exited;
                         c.exit_code = live.exit_code.unwrap_or(0);
+                        c.oom_killed = live.oom_killed;
                         c.finished_at_ns = now_ns();
                         let _ = state::save_container(c);
                     }
@@ -2083,7 +2090,15 @@ impl RuntimeService for RuntimeSvc {
                 ..Default::default()
             }),
             image_ref: container.image.clone(),
-            reason: String::new(),
+            // Kubernetes surfaces this verbatim (pod status, `kubectl describe`).
+            // An OOM-killed container must report "OOMKilled" (#343); otherwise the
+            // kill is misattributed to a generic Error and memory-limit debugging
+            // breaks. Exit code 137 (128+SIGKILL) is carried in exit_code above.
+            reason: if container.oom_killed {
+                "OOMKilled".to_string()
+            } else {
+                String::new()
+            },
             message,
             labels: container.labels.clone(),
             annotations: container.annotations.clone(),

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -118,6 +118,10 @@ pub struct CriContainer {
     pub finished_at_ns: i64,
     pub state: ContainerState,
     pub exit_code: i32,
+    /// True if the kernel OOM killer terminated the container (#343). Reported as
+    /// `reason: OOMKilled` in ContainerStatus.
+    #[serde(default)]
+    pub oom_killed: bool,
     /// Override UID from pod securityContext.runAsUser (None = use image default).
     #[serde(default)]
     pub run_as_user: Option<i64>,

--- a/scripts/cri-conformance-343.sh
+++ b/scripts/cri-conformance-343.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Focused critest conformance run for the #343 OOMKilled reporting fix.
+#
+# Runs ONLY the "Container OOM" spec against the live pelagos-cri socket and
+# writes a result file the caller can read separately (critest is long-running;
+# do not pipe it to tail).
+#
+# Verifies an OOM-killed container reports `reason: OOMKilled` and exit code 137
+# in ContainerStatus.
+#
+# Usage (on an IPC test node, never omen):
+#   sudo bash scripts/cri-conformance-343.sh /tmp/cri-343.result
+set -u
+
+SOCK="unix:///run/pelagos/cri.sock"
+OUT="${1:-/tmp/cri-343.result}"
+
+# Ginkgo regex for the OOM spec(s).
+FOCUS='OOM|OOMKilled'
+
+: > "$OUT"
+echo "# critest focus: $FOCUS" >> "$OUT"
+echo "# endpoint: $SOCK" >> "$OUT"
+echo "# pelagos-cri: $(systemctl is-active pelagos-cri 2>/dev/null)" >> "$OUT"
+echo "# started: $(date -u +%FT%TZ)" >> "$OUT"
+echo "----------------------------------------" >> "$OUT"
+
+critest --runtime-endpoint "$SOCK" --ginkgo.focus="$FOCUS" >> "$OUT" 2>&1
+rc=$?
+
+echo "----------------------------------------" >> "$OUT"
+echo "# critest exit: $rc" >> "$OUT"
+echo "# finished: $(date -u +%FT%TZ)" >> "$OUT"
+exit "$rc"

--- a/src/cli/compose.rs
+++ b/src/cli/compose.rs
@@ -776,6 +776,7 @@ fn spawn_service(
         watcher_pid: unsafe { libc::getpid() },
         started_at: now_iso8601(),
         exit_code: None,
+        oom_killed: false,
         command: exe_and_args.clone(),
         stdout_log: Some(stdout_log.to_string_lossy().into_owned()),
         stderr_log: Some(stderr_log.to_string_lossy().into_owned()),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -266,6 +266,11 @@ pub struct ContainerState {
     pub started_at: String,
     /// Exit code, populated when status == exited.
     pub exit_code: Option<i32>,
+    /// True if the kernel OOM killer terminated the container (#343). Read from
+    /// the cgroup `memory.events` at reap time and surfaced by the CRI shim as
+    /// `reason: OOMKilled` in ContainerStatus.
+    #[serde(default)]
+    pub oom_killed: bool,
     /// The command run inside the container.
     pub command: Vec<String>,
     /// Path to captured stdout log (detached mode only).
@@ -868,6 +873,7 @@ mod tests {
                 watcher_pid: 0,
                 started_at: "2026-01-01T00:00:00Z".to_string(),
                 exit_code: None,
+                oom_killed: false,
                 command: vec!["/bin/sh".to_string()],
                 stdout_log: None,
                 stderr_log: None,
@@ -934,6 +940,7 @@ mod tests {
             watcher_pid: 0,
             started_at: "2026-01-01T00:00:00Z".to_string(),
             exit_code: None,
+            oom_killed: false,
             command: vec!["/bin/sh".to_string()],
             stdout_log: None,
             stderr_log: None,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1261,6 +1261,7 @@ fn run_foreground(
         watcher_pid: 0,
         started_at: super::now_iso8601(),
         exit_code: None,
+        oom_killed: false,
         command: command.clone(),
         stdout_log: None,
         stderr_log: None,
@@ -1384,6 +1385,7 @@ fn run_interactive(
         watcher_pid: 0,
         started_at: super::now_iso8601(),
         exit_code: None,
+        oom_killed: false,
         command: command.clone(),
         stdout_log: None,
         stderr_log: None,
@@ -1471,6 +1473,7 @@ fn run_detached(a: DetachedArgs) -> Result<(), Box<dyn std::error::Error>> {
         watcher_pid: 0,
         started_at: super::now_iso8601(),
         exit_code: None,
+        oom_killed: false,
         command: command.clone(),
         stdout_log: Some(stdout_log.to_string_lossy().into_owned()),
         stderr_log: Some(stderr_log.to_string_lossy().into_owned()),
@@ -1688,7 +1691,15 @@ fn run_detached(a: DetachedArgs) -> Result<(), Box<dyn std::error::Error>> {
 
             // Update final state.
             updated.status = ContainerStatus::Exited;
-            updated.exit_code = exit.code();
+            updated.oom_killed = exit.oom_killed();
+            // A container killed by a signal has no normal exit code. Report the
+            // conventional 128+signal value (137 for the SIGKILL the OOM killer
+            // sends) so the CRI shim and `pelagos ps` surface 137/OOMKilled (#343)
+            // instead of a misleading 0.
+            updated.exit_code = exit
+                .code()
+                .or_else(|| exit.signal().map(|s| 128 + s))
+                .or(Some(0));
             let _ = write_state(&updated);
 
             unsafe { libc::_exit(0) };

--- a/src/container.rs
+++ b/src/container.rs
@@ -8026,8 +8026,16 @@ impl Child {
     /// If a cgroup was configured, it is deleted after the child exits.
     pub fn wait(&mut self) -> Result<ExitStatus, Error> {
         let status = self.wait_inner()?;
+        // Read the OOM-kill counter from the cgroup BEFORE teardown removes it (#343).
+        let oom_killed = self
+            .cgroup_path()
+            .map(|p| cgroup_oom_killed(&p))
+            .unwrap_or(false);
         self.teardown_resources(false);
-        Ok(ExitStatus { inner: status })
+        Ok(ExitStatus {
+            inner: status,
+            oom_killed,
+        })
     }
 
     /// Wait for the child process to exit, preserving the overlay base directory.
@@ -8046,7 +8054,13 @@ impl Child {
             .as_ref()
             .and_then(|merged| merged.parent().map(|p| p.to_path_buf()));
         self.teardown_resources(true);
-        Ok((ExitStatus { inner: status }, overlay_base))
+        Ok((
+            ExitStatus {
+                inner: status,
+                oom_killed: false,
+            },
+            overlay_base,
+        ))
     }
 
     /// Wait for the child to exit and collect all output.
@@ -8079,8 +8093,19 @@ impl Child {
             }
         }
         let status = self.wait_inner()?;
+        let oom_killed = self
+            .cgroup_path()
+            .map(|p| cgroup_oom_killed(&p))
+            .unwrap_or(false);
         self.teardown_resources(false);
-        Ok((ExitStatus { inner: status }, stdout_buf, stderr_buf))
+        Ok((
+            ExitStatus {
+                inner: status,
+                oom_killed,
+            },
+            stdout_buf,
+            stderr_buf,
+        ))
     }
 
     /// Read current resource usage from the container's cgroup.
@@ -8225,6 +8250,11 @@ impl Drop for Child {
 #[derive(Debug, Clone)]
 pub struct ExitStatus {
     inner: StdExitStatus,
+    /// True if the kernel OOM killer terminated a process in the container's
+    /// cgroup. Captured in `wait()` from `memory.events` before the cgroup is
+    /// torn down, so callers (CRI `OOMKilled` reporting, #343) can distinguish
+    /// an out-of-memory kill from an ordinary SIGKILL.
+    oom_killed: bool,
 }
 
 impl ExitStatus {
@@ -8242,6 +8272,40 @@ impl ExitStatus {
     pub fn signal(&self) -> Option<i32> {
         self.inner.signal()
     }
+
+    /// Returns true if the container was killed by the kernel OOM killer.
+    ///
+    /// Detected from the cgroup-v2 `memory.events` `oom_kill` counter at reap
+    /// time. Always false for OOM-incapable runs (no cgroup, rootless) or when
+    /// the counter could not be read.
+    pub fn oom_killed(&self) -> bool {
+        self.oom_killed
+    }
+}
+
+/// Read the cgroup-v2 `memory.events` OOM-kill counters for a relative cgroup
+/// path (e.g. `"kubepods/podXXX/cYYY"`). Returns true if the kernel OOM killer
+/// has killed at least one process in this cgroup. Best-effort: any missing
+/// file or parse failure returns false (the container simply isn't reported as
+/// OOM-killed). Must be read before the cgroup directory is removed.
+fn cgroup_oom_killed(rel_path: &str) -> bool {
+    let path = format!(
+        "/sys/fs/cgroup/{}/memory.events",
+        rel_path.trim_start_matches('/')
+    );
+    let Ok(data) = std::fs::read_to_string(&path) else {
+        return false;
+    };
+    for line in data.lines() {
+        let mut it = line.split_whitespace();
+        if let (Some(key), Some(val)) = (it.next(), it.next()) {
+            if (key == "oom_kill" || key == "oom_group_kill") && val.parse::<u64>().unwrap_or(0) > 0
+            {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 /// Errors that can occur during container operations.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2194,6 +2194,67 @@ mod cgroups {
     }
 
     #[test]
+    fn test_oom_killed_flag_set() {
+        // #343: when the kernel OOM killer terminates a container, `wait()` must
+        // report `ExitStatus::oom_killed() == true` (read from the cgroup
+        // `memory.events` oom_kill counter before teardown). The CRI shim relies
+        // on this to surface `reason: OOMKilled` to Kubernetes.
+        if !is_root() {
+            eprintln!("Skipping test_oom_killed_flag_set: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping test_oom_killed_flag_set: alpine-rootfs not found");
+            return;
+        };
+
+        // Write 100 MB to tmpfs against a 16 MB hard memory limit (swap disabled):
+        // the cgroup OOM killer fires and SIGKILLs the writer.
+        let mut child = Command::new("/bin/ash")
+            .args([
+                "-c",
+                "dd if=/dev/zero of=/tmp/fill bs=1M count=100 2>/dev/null; echo done",
+            ])
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS)
+            .with_chroot(&rootfs)
+            .env("PATH", ALPINE_PATH)
+            .with_cgroup_memory(16 * 1024 * 1024)
+            .with_cgroup_memory_swap(0)
+            .with_tmpfs("/tmp", "")
+            .with_dev_mount()
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Null)
+            .stderr(Stdio::Null)
+            .spawn()
+            .expect("Failed to spawn with cgroup memory limit");
+
+        let status = child.wait().expect("Failed to wait for child");
+        assert!(
+            status.oom_killed(),
+            "oom_killed() should be true after a cgroup OOM kill (signal={:?}, code={:?})",
+            status.signal(),
+            status.code()
+        );
+        // A non-OOM clean exit must NOT set the flag.
+        let mut ok = Command::new("/bin/ash")
+            .args(["-c", "echo hi"])
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS)
+            .with_chroot(&rootfs)
+            .env("PATH", ALPINE_PATH)
+            .with_cgroup_memory(64 * 1024 * 1024)
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Null)
+            .stderr(Stdio::Null)
+            .spawn()
+            .expect("Failed to spawn clean container");
+        let ok_status = ok.wait().expect("Failed to wait for clean child");
+        assert!(
+            !ok_status.oom_killed(),
+            "oom_killed() must be false for a container that exits cleanly"
+        );
+    }
+
+    #[test]
     fn test_cgroup_pids_limit() {
         if !is_root() {
             eprintln!("Skipping test_cgroup_pids_limit: requires root");


### PR DESCRIPTION
## Summary
Closes #343. An OOM-killed container now reports `reason: OOMKilled` and exit code `137` in `ContainerStatus`, so Kubernetes surfaces OOM kills correctly (pod status, `kubectl describe`) instead of misattributing them to a generic `Error`.

## Root cause
Two losses of signal:
1. `Child::wait()` ran `teardown_resources()` (which **removes the cgroup**) before anything read `memory.events` — the only reliable OOM indicator.
2. A signal-killed process has no normal exit code, so the watcher persisted `exit_code: None` → the CRI shim reported exit `0` with empty `reason`.

## Fix
**Runtime (`src/`):**
- `ExitStatus` gains `oom_killed`, captured in `wait()` / `wait_with_output()` from the cgroup-v2 `memory.events` `oom_kill`/`oom_group_kill` counters **before** teardown removes the cgroup (`cgroup_oom_killed()` helper + `ExitStatus::oom_killed()`).
- The detached watcher records `oom_killed` and computes the exit code as `code | 128+signal | 0` — a SIGKILL now surfaces as `137`, not a misleading `0`. `ContainerState` gains `oom_killed`.

**CRI (`pelagos-cri/`):**
- `PelagosContainerState` / `CriContainer` carry `oom_killed`; the exited-state refresh (list + status) copies it from live state; `container_status` sets `reason = "OOMKilled"` when set.

## Tests
- `test_oom_killed_flag_set` (root+rootfs): drives a real cgroup OOM (100 MB into a 16 MB hard limit), asserts `oom_killed()` true; false for a clean exit. Documented in `docs/INTEGRATION_TESTS.md`.
- **Full integration suite: 403 passed + `test_oom_killed_flag_set`**; the 2 transient failures were the known `#[serial(nat)]` NAT-state flakes — both pass on a clean isolated re-run.
- `cargo fmt` / `clippy` clean; 380 lib tests pass.
- `scripts/cri-conformance-343.sh` added for focused critest OOM verification on ipc2 (pending; deploy deferred this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)