### PR TITLE
fix(cri): enforce memory limits so the OOM killer fires (#373)

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1002,7 +1002,12 @@ fn apply_cli_options(
         }
     }
     if let Some(swap) = args.memory_swap {
-        cmd = cmd.with_cgroup_memory_swap(swap);
+        let mem = args
+            .memory
+            .as_deref()
+            .and_then(|m| parse_memory(m).ok())
+            .unwrap_or(0);
+        cmd = cmd.with_cgroup_memory_swap(combined_swap_to_v2_swap_only(swap, mem));
     }
     if let Some(ref c) = args.cpus {
         let (quota, period) = parse_cpus(c)?;
@@ -1842,9 +1847,40 @@ fn deregister_dns(container_name: &str, network_ips: &[(String, String)]) {
     }
 }
 
+/// Convert a Docker-style **combined** memory+swap limit (`--memory-swap`) into
+/// the cgroup v2 swap-ONLY value for `memory.swap.max`.
+///
+/// Docker/CRI express the limit as memory+swap combined; cgroup v2 wants the
+/// swap portion alone (`swap.max = combined - memory`). Kubernetes sets the
+/// combined limit equal to the memory limit when swap is disabled (the default),
+/// which must yield `swap.max = 0` so the OOM killer fires at the memory limit
+/// instead of paging to host swap (#343). `-1` (unlimited swap) passes through.
+fn combined_swap_to_v2_swap_only(memory_swap: i64, memory_bytes: i64) -> i64 {
+    if memory_swap < 0 {
+        memory_swap
+    } else {
+        (memory_swap - memory_bytes).max(0)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_combined_swap_to_v2_swap_only() {
+        let mb = 1 << 20;
+        // Kubernetes swap-disabled: combined == memory -> no swap.
+        assert_eq!(combined_swap_to_v2_swap_only(15 * mb, 15 * mb), 0);
+        // Combined above memory -> the extra is swap.
+        assert_eq!(combined_swap_to_v2_swap_only(30 * mb, 15 * mb), 15 * mb);
+        // Unlimited swap passes through unchanged.
+        assert_eq!(combined_swap_to_v2_swap_only(-1, 15 * mb), -1);
+        // Defensive: combined below memory clamps to 0 (never negative swap.max).
+        assert_eq!(combined_swap_to_v2_swap_only(10 * mb, 15 * mb), 0);
+        // No memory limit -> treat the value as swap-only.
+        assert_eq!(combined_swap_to_v2_swap_only(20 * mb, 0), 20 * mb);
+    }
 
     #[test]
     fn test_parse_port_forwards_tcp_default() {

--- a/src/container.rs
+++ b/src/container.rs
@@ -3621,16 +3621,30 @@ impl Command {
                 // runs shortly after and supersedes this; everywhere else pgid == pid.
                 libc::setpgid(0, 0);
 
-                // Step 0: For non-PID-namespace containers (single fork), add ourselves
-                // to the pre-created cgroup immediately so all subsequent memory
-                // allocations (including from exec'd code) are charged to it.
-                // For PID-namespace containers, this happens in the grandchild at step 1.65.
-                if !namespaces.contains(Namespace::PID) {
-                    if let Some(ref procs_path) = pre_cgroup_procs_path {
+                // Step 0: Add ourselves to the pre-created cgroup BEFORE unshare and
+                // exec, so all subsequent memory allocations (including the exec'd
+                // workload's) are charged to it and the OOM killer fires at the limit
+                // (#343). cgroup v2 does NOT migrate existing charges on move, so a
+                // late assignment leaves memory the workload already faulted charged to
+                // the wrong cgroup — the limit never bites.
+                if let Some(ref procs_path) = pre_cgroup_procs_path {
+                    if !namespaces.contains(Namespace::PID) {
+                        // Single-fork: our own (host) PID identifies us, and the path is
+                        // still visible (no CGROUP-namespace unshare yet).
                         let pid = libc::getpid();
                         let pid_str = format!("{}\n", pid);
                         std::fs::write(procs_path, pid_str.as_bytes())
                             .map_err(|e| pre_exec_err("cgroup self-assign", e))?;
+                    } else if has_explicit_cgroup_path {
+                        // PID-namespace + explicit (kubepods-style) path: the grandchild
+                        // can't write this host-anchored path after unshare(CLONE_NEWCGROUP)
+                        // (step 1.65 skips it for explicit paths). Join HERE instead, before
+                        // the unshare hides the path: "0" tells the kernel to move the
+                        // calling process; the PID-ns intermediate and the container
+                        // grandchild both inherit this cgroup. Best-effort — the host-side
+                        // parent's post-spawn cgroup.procs write remains the fallback, so a
+                        // race here never breaks startup.
+                        let _ = std::fs::write(procs_path, b"0\n");
                     }
                 }
 
@@ -6310,14 +6324,22 @@ impl Command {
                 }
                 libc::close(slave_raw_fd);
 
-                // For non-PID-namespace containers, add ourselves to the pre-created
-                // cgroup immediately (same pattern as spawn() Step 0).
-                if !namespaces.contains(Namespace::PID) {
-                    if let Some(ref procs_path) = pre_cgroup_procs_path_i {
+                // Add ourselves to the pre-created cgroup immediately (same pattern as
+                // spawn() Step 0): join BEFORE unshare/exec so the workload's memory
+                // charges to the limit cgroup and the OOM killer fires at the limit (#343).
+                if let Some(ref procs_path) = pre_cgroup_procs_path_i {
+                    if !namespaces.contains(Namespace::PID) {
                         let pid = libc::getpid();
                         let pid_str = format!("{}\n", pid);
                         std::fs::write(procs_path, pid_str.as_bytes())
                             .map_err(|e| pre_exec_err("cgroup self-assign", e))?;
+                    } else if has_explicit_cgroup_path_i {
+                        // PID-namespace + explicit (kubepods-style) path: join here, before
+                        // unshare(CLONE_NEWCGROUP) hides the host-anchored path. "0" moves
+                        // the calling process; the PID-ns intermediate and grandchild
+                        // inherit it. Best-effort — the parent's post-spawn write is the
+                        // fallback.
+                        let _ = std::fs::write(procs_path, b"0\n");
                     }
                 }
 


### PR DESCRIPTION
## Summary
Closes #373; **completes #343** (the OOMKilled critest now passes). Part of #338.

CRI containers with a memory limit never triggered the kernel OOM killer — `memory.max`/`memory.oom.group=1` were set, but `memory.events:oom_kill` stayed `0` and `memory.current` never approached the limit. Two independent root causes, both found by instrumenting the failing critest on ipc2:

### 1. Swap-limit mistranslation (`src/cli/run.rs`)
Kubernetes (swap disabled = default) sets CRI `memory_swap == memory` — a Docker-style **combined** memsw limit meaning *no swap*. pelagos mapped that straight into cgroup v2 `memory.swap.max`, which is swap **on top of** memory (≈2× the limit). On a swap-enabled host the workload fit in RAM+swap and never OOMed. Now converted at the CLI boundary: `swap.max = memory_swap − memory` (k8s → 0, `-1` → unlimited). Extracted as `combined_swap_to_v2_swap_only` with a unit test.

### 2. Late cgroup placement for PID-ns + explicit paths (`src/container.rs`)
For an explicit kubepods-style `--cgroup-path` under a PID namespace, the container joined its limit cgroup only via the **parent's post-`spawn()` `cgroup.procs` write** — after the workload exec'd and faulted its memory. cgroup v2 doesn't migrate existing charges on move, so the limit never bit. Now the container self-assigns in `pre_exec` **before** `unshare(CLONE_NEWCGROUP)` hides the path: writing `"0"` moves the calling process; the PID-ns intermediate and container grandchild inherit the cgroup. The parent post-spawn write remains a fallback → **no startup regression**. Applied to both spawn paths.

## Verification
- Focused OOM critest on **ipc2**: was a 60s timeout (state never reached Exited), now **PASS in ~4.5s** (OOM fires immediately, exit 137 + reason OOMKilled).
- **Full integration suite: 405 passed / 0 failed** (core spawn `pre_exec` change — gated locally).
- `combined_swap_to_v2_swap_only` unit test; `cargo fmt`/`clippy` clean.

## Diagnosis notes
Instrumented the live critest container on ipc2: caught `dd` *in* its limit cgroup with ~21MB RSS but cgroup `memory.current` only ~8MB (the 13MB gap = memory faulted before the late cgroup move), and `memory.swap.max=15MB` (= the memory limit, the swap bug). Both fixes were proven necessary and sufficient on ipc2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)