### PR TITLE
fix(cri): support non-recursive readonly mounts (#356)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -342,6 +342,19 @@ Runs `touch /mnt/ro/newfile` and captures the exit code. Verifies `exit=1` — t
 write is rejected because the mount is read-only. The `MS_BIND | MS_RDONLY` remount
 is required by the Linux kernel (two calls: bind, then remount-ro).
 
+### `test_bind_mount_ro_non_recursive_submount_writable`
+**Requires:** root, rootfs
+
+Verifies the #356 non-recursive readonly-mount semantics: a readonly bind is
+established **recursively** (`MS_BIND | MS_REC`) so submounts under the source are
+carried into the container, but the readonly remount is **non-recursive** (top mount
+only) so submounts stay writable. The test mounts a tmpfs at `outer/inner` on the
+host, binds `outer` read-only at `/mnt/ro`, then asserts `touch /mnt/ro/inner/sub`
+**succeeds** (`sub=0`, submount writable) while `touch /mnt/ro/top` **fails**
+(`top=1`, top read-only). Failure of the submount write would mean either the
+submount wasn't carried in (non-recursive bind) or the readonly remount was applied
+recursively — both of which break the CRI `recursive_read_only=false` contract.
+
 ### `test_cli_volume_flag_ro`
 **Requires:** root, rootfs
 

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -14,7 +14,7 @@ use crate::cri::{
     ListContainersResponse, ListMetricDescriptorsRequest, ListMetricDescriptorsResponse,
     ListPodSandboxMetricsRequest, ListPodSandboxMetricsResponse, ListPodSandboxRequest,
     ListPodSandboxResponse, ListPodSandboxStatsRequest, ListPodSandboxStatsResponse, MemoryUsage,
-    Namespace, NamespaceOption, PodSandbox, PodSandboxAttributes, PodSandboxMetadata,
+    Mount, Namespace, NamespaceOption, PodSandbox, PodSandboxAttributes, PodSandboxMetadata,
     PodSandboxNetworkStatus, PodSandboxState, PodSandboxStats, PodSandboxStatsRequest,
     PodSandboxStatsResponse, PodSandboxStatus as CriPodSandboxStatus, PodSandboxStatusRequest,
     PodSandboxStatusResponse, PortForwardRequest, PortForwardResponse, RemoveContainerRequest,
@@ -1222,6 +1222,8 @@ impl RuntimeService for RuntimeSvc {
                 host_path: m.host_path.clone(),
                 container_path: m.container_path.clone(),
                 readonly: m.readonly,
+                recursive_read_only: m.recursive_read_only,
+                propagation: m.propagation,
             })
             .collect();
 
@@ -2102,7 +2104,22 @@ impl RuntimeService for RuntimeSvc {
             message,
             labels: container.labels.clone(),
             annotations: container.annotations.clone(),
-            mounts: vec![],
+            // Report the container's mounts with their readonly / recursive_read_only
+            // attributes so the kubelet and critest can confirm the runtime honored the
+            // request (#356). Was hardcoded empty, which failed the non-recursive
+            // readonly-mount conformance spec (it inspects ContainerStatus.mounts).
+            mounts: container
+                .mounts
+                .iter()
+                .map(|m| Mount {
+                    container_path: m.container_path.clone(),
+                    host_path: m.host_path.clone(),
+                    readonly: m.readonly,
+                    recursive_read_only: m.recursive_read_only,
+                    propagation: m.propagation,
+                    ..Default::default()
+                })
+                .collect(),
             log_path: full_log_path,
             resources: None,
             image_id: container.image.clone(),

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -91,6 +91,14 @@ pub struct CriMount {
     pub host_path: String,
     pub container_path: String,
     pub readonly: bool,
+    /// CRI Mount.recursive_read_only (#356). Reported back in ContainerStatus so
+    /// the kubelet/critest can confirm the runtime honored the request. `false`
+    /// = non-recursive readonly (top mount only); `true` = recursive readonly.
+    #[serde(default)]
+    pub recursive_read_only: bool,
+    /// CRI Mount.propagation enum value (0=PRIVATE, 1=HOST_TO_CONTAINER, 2=BIDIRECTIONAL).
+    #[serde(default)]
+    pub propagation: i32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/scripts/cri-conformance-356.sh
+++ b/scripts/cri-conformance-356.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Focused critest conformance run for #356 (non-recursive readonly mounts).
+# Usage (on an IPC test node, never omen):
+#   sudo bash scripts/cri-conformance-356.sh /tmp/cri-356.result
+set -u
+SOCK="unix:///run/pelagos/cri.sock"
+OUT="${1:-/tmp/cri-356.result}"
+FOCUS='readonly mounts'
+: > "$OUT"
+echo "# critest focus: $FOCUS" >> "$OUT"
+echo "# pelagos-cri: $(systemctl is-active pelagos-cri 2>/dev/null)" >> "$OUT"
+echo "# started: $(date -u +%FT%TZ)" >> "$OUT"
+echo "----------------------------------------" >> "$OUT"
+critest --runtime-endpoint "$SOCK" --ginkgo.focus="$FOCUS" >> "$OUT" 2>&1
+rc=$?
+echo "----------------------------------------" >> "$OUT"
+echo "# critest exit: $rc" >> "$OUT"
+exit "$rc"

--- a/src/container.rs
+++ b/src/container.rs
@@ -4589,12 +4589,18 @@ impl Command {
                         }
                         let src_c = CString::new(bm.source.as_os_str().as_bytes()).unwrap();
                         let tgt_c = CString::new(host_target.as_os_str().as_bytes()).unwrap();
-                        // Step 1: establish the bind
+                        // Step 1: establish the bind. Use a RECURSIVE bind so any
+                        // submounts under the source (e.g. a tmpfs the caller mounted
+                        // inside the volume) are carried into the container. The
+                        // readonly remount below is non-recursive (top mount only), so
+                        // those submounts stay writable — the CRI non-recursive
+                        // readonly-mount semantics (#356). For a plain directory or file
+                        // with no submounts, MS_REC is a harmless no-op.
                         let r = libc::mount(
                             src_c.as_ptr(),
                             tgt_c.as_ptr(),
                             ptr::null(),
-                            libc::MS_BIND,
+                            libc::MS_BIND | libc::MS_REC,
                             ptr::null(),
                         );
                         if r != 0 {
@@ -7135,11 +7141,13 @@ impl Command {
                         }
                         let src_c = CString::new(bm.source.as_os_str().as_bytes()).unwrap();
                         let tgt_c = CString::new(host_target.as_os_str().as_bytes()).unwrap();
+                        // Recursive bind so submounts under the source are carried in;
+                        // the readonly remount below stays non-recursive (#356).
                         let r = libc::mount(
                             src_c.as_ptr(),
                             tgt_c.as_ptr(),
                             ptr::null(),
-                            libc::MS_BIND,
+                            libc::MS_BIND | libc::MS_REC,
                             ptr::null(),
                         );
                         if r != 0 {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1675,6 +1675,82 @@ mod filesystem {
         );
     }
 
+    #[test]
+    fn test_bind_mount_ro_non_recursive_submount_writable() {
+        // #356: a readonly bind mount is established RECURSIVELY (MS_REC) so any
+        // submount under the source is carried into the container, but the
+        // readonly remount is NON-recursive (top mount only) — so a submount
+        // stays writable. This is the CRI non-recursive readonly-mount semantics
+        // verified by critest (`touch <submount>/file` must succeed while the top
+        // is read-only).
+        use std::os::unix::ffi::OsStrExt as _;
+        if !is_root() {
+            eprintln!("Skipping test_bind_mount_ro_non_recursive_submount_writable: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping test_bind_mount_ro_non_recursive_submount_writable: no rootfs");
+            return;
+        };
+
+        let outer = tempfile::tempdir().expect("failed to create temp dir");
+        let inner = outer.path().join("inner");
+        std::fs::create_dir_all(&inner).expect("mkdir inner");
+
+        // Mount a tmpfs at outer/inner on the host so it is a submount of the bind source.
+        let inner_c = std::ffi::CString::new(inner.as_os_str().as_bytes()).unwrap();
+        let tmpfs_c = std::ffi::CString::new("tmpfs").unwrap();
+        let rc = unsafe {
+            libc::mount(
+                tmpfs_c.as_ptr(),
+                inner_c.as_ptr(),
+                tmpfs_c.as_ptr(),
+                0,
+                std::ptr::null(),
+            )
+        };
+        assert_eq!(
+            rc,
+            0,
+            "host tmpfs mount failed: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let mut child = Command::new("/bin/ash")
+            .args([
+                "-c",
+                "touch /mnt/ro/inner/sub 2>/dev/null; echo sub=$?; \
+                 touch /mnt/ro/top 2>/dev/null; echo top=$?",
+            ])
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS)
+            .with_chroot(&rootfs)
+            .env("PATH", ALPINE_PATH)
+            .with_bind_mount_ro(outer.path(), "/mnt/ro")
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Piped)
+            .stderr(Stdio::Piped)
+            .spawn()
+            .expect("Failed to spawn with read-only bind mount + submount");
+
+        let (status, stdout, _) = child.wait_with_output().expect("Failed to collect output");
+        // Unmount the host tmpfs before assertions so the TempDir can be cleaned up.
+        unsafe {
+            libc::umount(inner_c.as_ptr());
+        }
+        assert!(status.success(), "Shell should exit cleanly");
+        let out = String::from_utf8_lossy(&stdout);
+        assert!(
+            out.contains("sub=0"),
+            "submount under a non-recursive readonly bind must be writable, got: {}",
+            out
+        );
+        assert!(
+            out.contains("top=1"),
+            "top of a readonly bind must be read-only, got: {}",
+            out
+        );
+    }
+
     /// test_cli_volume_flag_ro
     ///
     /// Requires: root, rootfs.


### PR DESCRIPTION
## Summary
Closes #356. Part of #338. The `[k8s.io] Container Mount Readonly › should support non-recursive readonly mounts` critest spec now passes on ipc2.

Two fixes were needed (the spec checks *both* reporting and behavior):

### 1. Reporting (`pelagos-cri`)
`ContainerStatus.mounts` was hardcoded `vec![]`, and `CriMount` didn't store `recursive_read_only`/`propagation`. The spec inspects `ContainerStatus.mounts` to confirm the runtime honored the request, so it failed before starting the container (`Expected <[]*v1.Mount len:0>: nil`). `CriMount` now carries `recursive_read_only` + `propagation` (captured at CreateContainer), and `container_status` reports the container's mounts with those fields.

### 2. Behavior (`src/container.rs`)
The spec then starts the container and requires `touch <submount>/file` to **succeed** — a tmpfs submounted under the bind source must be carried in and stay writable, since readonly is non-recursive. pelagos established binds with a non-recursive `MS_BIND`, so the submount never appeared and the write hit the read-only top. Binds are now **recursive** (`MS_BIND | MS_REC`) so submounts are carried in, while the readonly remount stays **non-recursive** (top mount only) — the `recursive_read_only=false` contract. `MS_REC` is a no-op for a plain dir/file. Applied to both spawn paths.

## Verification
- Focused #356 critest on **ipc2**: was a 2-stage failure (empty status mounts → then submount read-only), now **PASS**.
- New integration test `test_bind_mount_ro_non_recursive_submount_writable`: tmpfs submount under a RO bind stays writable (`sub=0`) while the top is read-only (`top=1`).
- **Full integration suite: 404 passed + the new test** (2 unrelated flakes — `cgroup_path`, `auto_pull` — pass on isolated re-run).
- `cargo fmt`/`clippy` clean.

## Scope note
`recursive_read_only=true` (recursive RO via `mount_setattr(AT_RECURSIVE)`) is not implemented — pelagos doesn't advertise the `recursive_read_only_mounts` runtime capability, so the kubelet won't request it. The value is captured and reported faithfully; recursive-RO *application* can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)