### PR TITLE
feat(cri): mount propagation — rslave + rprivate (#341, 2/3)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -355,6 +355,20 @@ host, binds `outer` read-only at `/mnt/ro`, then asserts `touch /mnt/ro/inner/su
 submount wasn't carried in (non-recursive bind) or the readonly remount was applied
 recursively — both of which break the CRI `recursive_read_only=false` contract.
 
+### `test_bind_mount_propagation_host_to_container`
+**Requires:** root, rootfs
+
+Verifies #341 `rslave` (CRI `PROPAGATION_HOST_TO_CONTAINER`) mount propagation: a
+mount created on the host under the bind source after the container starts must
+appear inside the container. The test makes the source a shared mount on the host,
+starts a container (`with_bind_mount_propagated(..., HostToContainer)`) that polls for
+`/mnt/dyn/flag`, then — after a delay so the container's bind is established — mounts a
+tmpfs at `<source>/dyn` on the host and touches the flag. The container must print
+`PROPAGATED` (not `TIMEOUT`). Failure means slave propagation isn't reaching the
+container — i.e. the root was recursively privatized (severing the peer group) or the
+per-mount `MS_SLAVE` wasn't applied. Container→host (bidirectional/`rshared`) is a
+separate, deferred follow-up.
+
 ### `test_cli_volume_flag_ro`
 **Requires:** root, rootfs
 

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -1490,11 +1490,19 @@ impl RuntimeService for RuntimeSvc {
 
         for m in &container.mounts {
             args.push("-v".into());
+            let mut spec = format!("{}:{}", m.host_path, m.container_path);
             if m.readonly {
-                args.push(format!("{}:{}:ro", m.host_path, m.container_path));
-            } else {
-                args.push(format!("{}:{}", m.host_path, m.container_path));
+                spec.push_str(":ro");
             }
+            // CRI MountPropagation → pelagos -v suffix (#341):
+            // 1 = HOST_TO_CONTAINER (rslave), 2 = BIDIRECTIONAL (rshared),
+            // 0 = PRIVATE (default, no suffix).
+            match m.propagation {
+                1 => spec.push_str(":rslave"),
+                2 => spec.push_str(":rshared"),
+                _ => {}
+            }
+            args.push(spec);
         }
 
         // Kubelet may pass the sha256 digest form rather than the tag; resolve to a known tag.

--- a/scripts/cri-conformance-341.sh
+++ b/scripts/cri-conformance-341.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Focused critest conformance run for #341 (mount propagation: rshared/rslave/rprivate).
+# Usage (on an IPC test node, never omen):
+#   sudo bash scripts/cri-conformance-341.sh /tmp/cri-341.result
+set -u
+SOCK="unix:///run/pelagos/cri.sock"
+OUT="${1:-/tmp/cri-341.result}"
+FOCUS='Mount Propagation'
+: > "$OUT"
+echo "# critest focus: $FOCUS" >> "$OUT"
+echo "# pelagos-cri: $(systemctl is-active pelagos-cri 2>/dev/null)" >> "$OUT"
+echo "# started: $(date -u +%FT%TZ)" >> "$OUT"
+echo "----------------------------------------" >> "$OUT"
+critest --runtime-endpoint "$SOCK" --ginkgo.focus="$FOCUS" >> "$OUT" 2>&1
+rc=$?
+echo "----------------------------------------" >> "$OUT"
+echo "# critest exit: $rc" >> "$OUT"
+exit "$rc"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -895,29 +895,45 @@ fn apply_cli_options(
         cmd = cmd.with_readonly_rootfs(true);
     }
     for v in &args.volume {
-        if let Some((src, rest)) = v.split_once(':') {
-            // Support "src:tgt" and "src:tgt:ro" (Docker compat).
-            let (tgt, readonly) = match rest.rsplit_once(':') {
-                Some((t, "ro")) => (t, true),
-                Some((t, "rw")) => (t, false),
-                _ => (rest, false),
-            };
-            if src.starts_with('/') {
-                if readonly {
-                    cmd = cmd.with_bind_mount_ro(src, tgt);
-                } else {
-                    cmd = cmd.with_bind_mount(src, tgt);
-                }
-            } else {
-                let vol = Volume::open(src).or_else(|_| Volume::create(src))?;
-                cmd = cmd.with_volume(&vol, tgt);
-            }
-        } else {
+        // Format: src:tgt[:opt[:opt...]] where opt ∈ {ro, rw, rprivate, rslave,
+        // rshared} (and the non-recursive aliases private/slave/shared). The
+        // propagation options (#341) map to CRI MountPropagation: rprivate =
+        // PRIVATE, rslave = HOST_TO_CONTAINER, rshared = BIDIRECTIONAL.
+        let parts: Vec<&str> = v.split(':').collect();
+        if parts.len() < 2 {
             return Err(format!(
-                "invalid --volume '{}': expected NAME:/path or /host:/path[:ro|:rw]",
+                "invalid --volume '{}': expected NAME:/path or \
+                 /host:/path[:ro|:rw][:rprivate|:rslave|:rshared]",
                 v
             )
             .into());
+        }
+        let (src, tgt) = (parts[0], parts[1]);
+        let mut readonly = false;
+        let mut propagation = pelagos::container::MountPropagation::Private;
+        for opt in &parts[2..] {
+            match *opt {
+                "ro" => readonly = true,
+                "rw" => readonly = false,
+                "rprivate" | "private" => {
+                    propagation = pelagos::container::MountPropagation::Private
+                }
+                "rslave" | "slave" => {
+                    propagation = pelagos::container::MountPropagation::HostToContainer
+                }
+                "rshared" | "shared" => {
+                    propagation = pelagos::container::MountPropagation::Bidirectional
+                }
+                other => {
+                    return Err(format!("invalid --volume option '{}' in '{}'", other, v).into())
+                }
+            }
+        }
+        if src.starts_with('/') {
+            cmd = cmd.with_bind_mount_propagated(src, tgt, readonly, propagation);
+        } else {
+            let vol = Volume::open(src).or_else(|_| Volume::create(src))?;
+            cmd = cmd.with_volume(&vol, tgt);
         }
     }
     for b in &args.bind {

--- a/src/container.rs
+++ b/src/container.rs
@@ -853,6 +853,22 @@ pub enum OciMountEntry {
     Bind(BindMount),
 }
 
+/// Mount propagation mode for a bind mount (#341), mirroring the CRI
+/// `MountPropagation` enum / the OCI `rprivate`/`rslave`/`rshared` options.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MountPropagation {
+    /// `rprivate` — no propagation in either direction (the default, full isolation).
+    #[default]
+    Private,
+    /// `rslave` — mounts created on the host under the source propagate INTO the
+    /// container, but not vice versa (CRI `PROPAGATION_HOST_TO_CONTAINER`).
+    HostToContainer,
+    /// `rshared` — mounts propagate BOTH ways (CRI `PROPAGATION_BIDIRECTIONAL`).
+    /// Required by CSI drivers to publish volumes into pods; lets the container
+    /// create mounts visible on the host, so the source must be a shared mount.
+    Bidirectional,
+}
+
 /// A bind mount that maps a host directory into the container.
 #[derive(Debug, Clone)]
 pub struct BindMount {
@@ -862,6 +878,31 @@ pub struct BindMount {
     pub target: PathBuf,
     /// If true, the bind mount is read-only inside the container.
     pub readonly: bool,
+    /// Mount propagation mode (#341). Defaults to `Private`.
+    pub propagation: MountPropagation,
+}
+
+/// Default propagation flags for the container's root mount when
+/// `linux.rootfsPropagation` is not explicitly set (#341).
+///
+/// Normally `rprivate` (`MS_PRIVATE | MS_REC`) for full isolation. But if any
+/// bind requests host→container (`rslave`) or bidirectional (`rshared`)
+/// propagation we instead make `/` a NON-recursive slave: a recursive
+/// private/slave would sever every bind source from its host peer group *before*
+/// the bind mounts run, so host↔container propagation could never be
+/// established. A non-recursive slave on `/` leaves the inherited submounts
+/// (the bind sources) in their peer groups, which is exactly what lets a
+/// propagated bind join the host's peer group; each bind then gets its own
+/// explicit propagation applied after it is established.
+fn default_rootfs_propagation(bind_mounts: &[BindMount]) -> libc::c_ulong {
+    let needs_propagation = bind_mounts
+        .iter()
+        .any(|b| b.propagation != MountPropagation::Private);
+    if needs_propagation {
+        libc::MS_REC | libc::MS_SLAVE
+    } else {
+        libc::MS_REC | libc::MS_PRIVATE
+    }
 }
 
 /// Resolve a mount destination path within the container rootfs, following any
@@ -2612,6 +2653,7 @@ impl Command {
             source: source.into(),
             target: target.into(),
             readonly: false,
+            propagation: MountPropagation::Private,
         });
         self
     }
@@ -2628,6 +2670,28 @@ impl Command {
             source: source.into(),
             target: target.into(),
             readonly: true,
+            propagation: MountPropagation::Private,
+        });
+        self
+    }
+
+    /// Add a bind mount with an explicit [`MountPropagation`] mode (#341).
+    pub fn with_bind_mount_propagated<P1, P2>(
+        mut self,
+        source: P1,
+        target: P2,
+        readonly: bool,
+        propagation: MountPropagation,
+    ) -> Self
+    where
+        P1: Into<PathBuf>,
+        P2: Into<PathBuf>,
+    {
+        self.bind_mounts.push(BindMount {
+            source: source.into(),
+            target: target.into(),
+            readonly,
+            propagation,
         });
         self
     }
@@ -3774,8 +3838,8 @@ impl Command {
                     if namespaces.contains(Namespace::MOUNT) {
                         use std::ptr;
 
-                        let prop_flags =
-                            rootfs_propagation.unwrap_or(libc::MS_REC | libc::MS_PRIVATE);
+                        let prop_flags = rootfs_propagation
+                            .unwrap_or_else(|| default_rootfs_propagation(&bind_mounts));
                         let root = c"/";
                         let result = libc::mount(
                             ptr::null(),   // source: NULL (remount)
@@ -4589,6 +4653,20 @@ impl Command {
                         }
                         let src_c = CString::new(bm.source.as_os_str().as_bytes()).unwrap();
                         let tgt_c = CString::new(host_target.as_os_str().as_bytes()).unwrap();
+                        // #341: for bidirectional propagation the SOURCE must be a shared
+                        // mount (member of a peer group) so the bind joins that group and
+                        // mounts the container creates propagate back to the host. The
+                        // kubelet marks the host path shared for bidirectional mounts;
+                        // re-assert it here (best-effort) before binding.
+                        if bm.propagation == MountPropagation::Bidirectional {
+                            let _ = libc::mount(
+                                ptr::null(),
+                                src_c.as_ptr(),
+                                ptr::null(),
+                                libc::MS_SHARED | libc::MS_REC,
+                                ptr::null(),
+                            );
+                        }
                         // Step 1: establish the bind. Use a RECURSIVE bind so any
                         // submounts under the source (e.g. a tmpfs the caller mounted
                         // inside the volume) are carried into the container. The
@@ -4628,6 +4706,22 @@ impl Command {
                                 )));
                             }
                         }
+                        // Step 3 (#341): apply the requested mount propagation on the
+                        // target. Best-effort — under a user namespace the kernel locks
+                        // inherited mounts (EINVAL on propagation changes); the new mount
+                        // namespace already isolates by default, so don't fail startup.
+                        let prop_flags = match bm.propagation {
+                            MountPropagation::Private => libc::MS_PRIVATE | libc::MS_REC,
+                            MountPropagation::HostToContainer => libc::MS_SLAVE | libc::MS_REC,
+                            MountPropagation::Bidirectional => libc::MS_SHARED | libc::MS_REC,
+                        };
+                        let _ = libc::mount(
+                            ptr::null(),
+                            tgt_c.as_ptr(),
+                            ptr::null(),
+                            prop_flags,
+                            ptr::null(),
+                        );
                     }
 
                     // Normal path: pivot_root atomically makes new_root the
@@ -6461,8 +6555,8 @@ impl Command {
 
                     // linux.rootfsPropagation overrides the default MS_PRIVATE|MS_REC.
                     if namespaces.contains(Namespace::MOUNT) {
-                        let prop_flags =
-                            rootfs_propagation.unwrap_or(libc::MS_REC | libc::MS_PRIVATE);
+                        let prop_flags = rootfs_propagation
+                            .unwrap_or_else(|| default_rootfs_propagation(&bind_mounts));
                         let root = c"/";
                         let result = libc::mount(
                             ptr::null(),
@@ -7141,6 +7235,16 @@ impl Command {
                         }
                         let src_c = CString::new(bm.source.as_os_str().as_bytes()).unwrap();
                         let tgt_c = CString::new(host_target.as_os_str().as_bytes()).unwrap();
+                        // #341: bidirectional needs the source to be a shared mount.
+                        if bm.propagation == MountPropagation::Bidirectional {
+                            let _ = libc::mount(
+                                ptr::null(),
+                                src_c.as_ptr(),
+                                ptr::null(),
+                                libc::MS_SHARED | libc::MS_REC,
+                                ptr::null(),
+                            );
+                        }
                         // Recursive bind so submounts under the source are carried in;
                         // the readonly remount below stays non-recursive (#356).
                         let r = libc::mount(
@@ -7174,6 +7278,19 @@ impl Command {
                                 )));
                             }
                         }
+                        // #341: apply requested propagation on the target (best-effort).
+                        let prop_flags = match bm.propagation {
+                            MountPropagation::Private => libc::MS_PRIVATE | libc::MS_REC,
+                            MountPropagation::HostToContainer => libc::MS_SLAVE | libc::MS_REC,
+                            MountPropagation::Bidirectional => libc::MS_SHARED | libc::MS_REC,
+                        };
+                        let _ = libc::mount(
+                            ptr::null(),
+                            tgt_c.as_ptr(),
+                            ptr::null(),
+                            prop_flags,
+                            ptr::null(),
+                        );
                     }
 
                     // Normal path: pivot_root atomically makes new_root the
@@ -8559,6 +8676,44 @@ mod tests {
         let resolved = resolve_mount_target_in_root(root.path(), std::path::Path::new("/dev"));
         assert_eq!(resolved, root.path().join("real-dev"));
         assert!(resolved.starts_with(root.path()));
+    }
+
+    #[test]
+    fn test_default_rootfs_propagation() {
+        // #341: with no propagation mounts, the root stays fully isolated
+        // (rprivate); if any mount requests slave/shared propagation, the root
+        // becomes a recursive SLAVE instead — a recursive private/slave applied
+        // before the binds would sever their sources from the host peer groups.
+        let bm = |p: MountPropagation| BindMount {
+            source: PathBuf::from("/h"),
+            target: PathBuf::from("/c"),
+            readonly: false,
+            propagation: p,
+        };
+        assert_eq!(
+            default_rootfs_propagation(&[]),
+            libc::MS_REC | libc::MS_PRIVATE
+        );
+        assert_eq!(
+            default_rootfs_propagation(&[bm(MountPropagation::Private)]),
+            libc::MS_REC | libc::MS_PRIVATE
+        );
+        assert_eq!(
+            default_rootfs_propagation(&[bm(MountPropagation::HostToContainer)]),
+            libc::MS_REC | libc::MS_SLAVE
+        );
+        assert_eq!(
+            default_rootfs_propagation(&[bm(MountPropagation::Bidirectional)]),
+            libc::MS_REC | libc::MS_SLAVE
+        );
+        // Mixed: any non-private mount triggers the slave root.
+        assert_eq!(
+            default_rootfs_propagation(&[
+                bm(MountPropagation::Private),
+                bm(MountPropagation::HostToContainer)
+            ]),
+            libc::MS_REC | libc::MS_SLAVE
+        );
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -15,7 +15,7 @@
 
 use pelagos::cgroup::ResourceStats;
 use pelagos::container::{
-    Capability, Command, GidMap, Namespace, SeccompProfile, Stdio, UidMap, Volume,
+    Capability, Command, GidMap, MountPropagation, Namespace, SeccompProfile, Stdio, UidMap, Volume,
 };
 use pelagos::network::NetworkMode;
 use serial_test::serial;
@@ -1747,6 +1747,100 @@ mod filesystem {
         assert!(
             out.contains("top=1"),
             "top of a readonly bind must be read-only, got: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_bind_mount_propagation_host_to_container() {
+        // #341: an `rslave` (HOST_TO_CONTAINER) bind propagates mounts created on
+        // the host under the source INTO the container after it has started. We
+        // make the source a shared mount on the host, start a container that polls
+        // for /mnt/dyn/flag, then mount a tmpfs at <source>/dyn on the host — it
+        // must appear inside the container via slave propagation.
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt as _;
+        use std::ptr;
+        if !is_root() {
+            eprintln!("Skipping test_bind_mount_propagation_host_to_container: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping test_bind_mount_propagation_host_to_container: no rootfs");
+            return;
+        };
+
+        let src = tempfile::tempdir().expect("tempdir");
+        let src_path = src.path().to_path_buf();
+        let src_c = CString::new(src_path.as_os_str().as_bytes()).unwrap();
+        // Make the source a shared mount (its own peer group) on the host.
+        unsafe {
+            libc::mount(
+                src_c.as_ptr(),
+                src_c.as_ptr(),
+                ptr::null(),
+                libc::MS_BIND | libc::MS_REC,
+                ptr::null(),
+            );
+            libc::mount(
+                ptr::null(),
+                src_c.as_ptr(),
+                ptr::null(),
+                libc::MS_SHARED | libc::MS_REC,
+                ptr::null(),
+            );
+        }
+        let dyn_dir = src_path.join("dyn");
+        std::fs::create_dir_all(&dyn_dir).expect("mkdir dyn");
+
+        let mut child = Command::new("/bin/ash")
+            .args([
+                "-c",
+                "for i in $(seq 1 40); do [ -e /mnt/dyn/flag ] && { echo PROPAGATED; exit 0; }; \
+                 sleep 0.25; done; echo TIMEOUT",
+            ])
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS)
+            .with_chroot(&rootfs)
+            .env("PATH", ALPINE_PATH)
+            .with_bind_mount_propagated(&src_path, "/mnt", false, MountPropagation::HostToContainer)
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Piped)
+            .stderr(Stdio::Piped)
+            .spawn()
+            .expect("Failed to spawn with rslave bind mount");
+
+        // Let the container establish its bind, then mount a tmpfs under the source
+        // on the host — it must propagate INTO the container.
+        std::thread::sleep(std::time::Duration::from_millis(1500));
+        let dyn_c = CString::new(dyn_dir.as_os_str().as_bytes()).unwrap();
+        let tmpfs_c = CString::new("tmpfs").unwrap();
+        let rc = unsafe {
+            libc::mount(
+                tmpfs_c.as_ptr(),
+                dyn_c.as_ptr(),
+                tmpfs_c.as_ptr(),
+                0,
+                ptr::null(),
+            )
+        };
+        assert_eq!(
+            rc,
+            0,
+            "host tmpfs mount failed: {}",
+            std::io::Error::last_os_error()
+        );
+        std::fs::write(dyn_dir.join("flag"), b"x").expect("write flag");
+
+        let (_status, stdout, _) = child.wait_with_output().expect("Failed to collect output");
+        // Cleanup host mounts before TempDir drop.
+        unsafe {
+            libc::umount(dyn_c.as_ptr());
+            libc::umount2(src_c.as_ptr(), libc::MNT_DETACH);
+        }
+        let out = String::from_utf8_lossy(&stdout);
+        assert!(
+            out.contains("PROPAGATED"),
+            "host->container (rslave) propagation failed; container output: {}",
             out
         );
     }


### PR DESCRIPTION
## Summary
Part of #341 (and #338). Lands `rprivate` + `rslave` (host→container) mount propagation — **2 of the 3 critest specs** now pass on ipc2 (was 1/3). Bidirectional (`rshared`) is split into follow-up #376.

Previously pelagos ignored CRI `Mount.propagation` and made the whole tree `MS_PRIVATE|MS_REC`, severing every bind source from its host peer group so no propagation could occur.

## Changes
- `MountPropagation` enum (Private / HostToContainer / Bidirectional) on `BindMount`; `with_bind_mount_propagated()` builder.
- `pelagos run -v src:tgt[:ro][:rprivate|:rslave|:rshared]` parsing.
- pelagos-cri maps CRI `MountPropagation` → the `-v` suffix.
- **Root propagation (step 1.5)**: unchanged `MS_PRIVATE|MS_REC` (full isolation) for normal containers; switches to `MS_SLAVE|MS_REC` **only** when a mount requests slave/shared propagation — a recursive private applied before the binds would sever the sources. `default_rootfs_propagation()` + unit test.
- **Per-mount**: after the recursive bind, apply `MS_PRIVATE`/`MS_SLAVE`/`MS_SHARED` on the target (best-effort — userns-locked mounts EINVAL on prop changes; the new namespace already isolates). Both spawn paths.

## Verification
- **ipc2 critest**: `rslave` (host→container) + `rprivate` PASS (was 1/3, now 2/3).
- Integration test `test_bind_mount_propagation_host_to_container` drives **real** host→container slave propagation (mount a tmpfs on the host under the source after the container starts → it appears inside).
- `default_rootfs_propagation` unit test.
- **Full integration suite: 405 + 2 new propagation tests** (2 unrelated flakes — cgroup placement, seccomp errno — pass on isolated re-run).
- `cargo fmt`/`clippy` clean.

## Empirical method
The exact mount sequence was determined by experimenting on ipc2 with `unshare -m --propagation unchanged` + `nsenter` (raw mount commands), then encoded. `unshare -m`'s default `--propagation private` was a red herring — pelagos uses raw `CLONE_NEWNS` which preserves peer groups.

## Deferred: bidirectional (#376)
`rshared` container→host needs the bind to stay a *member* of the host peer group, impossible once the source is slaved. pelagos's root-prop-before-binds + `pivot_root` ordering can't provide that without a mount-API (`open_tree`/`move_mount`) refactor. The infra (Bidirectional variant, `:rshared`, `MS_SHARED`) is in place for that follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)