### PR TITLE
feat(cri): recursive read-only mounts (recursive_read_only, #356)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -355,6 +355,19 @@ host, binds `outer` read-only at `/mnt/ro`, then asserts `touch /mnt/ro/inner/su
 submount wasn't carried in (non-recursive bind) or the readonly remount was applied
 recursively — both of which break the CRI `recursive_read_only=false` contract.
 
+### `test_bind_mount_recursive_ro_submount_readonly`
+**Requires:** root, rootfs
+
+Verifies the #356 `recursive_read_only` semantics (the inverse of the non-recursive
+test): a recursive readonly bind
+(`with_bind_mount_propagated(..., readonly=true, recursive_readonly=true, ...)`)
+applies `MOUNT_ATTR_RDONLY` to the top mount **and every submount** via
+`mount_setattr(AT_RECURSIVE)` (kernel ≥ 5.12). With a tmpfs at `outer/inner` bound
+recursively-readonly at `/mnt/rro`, asserts `touch /mnt/rro/inner/sub` **fails**
+(`sub=1`, submount read-only) and `touch /mnt/rro/top` **fails** (`top=1`). Failure of
+the submount assertion would mean the readonly attribute wasn't applied recursively —
+breaking the CRI `recursive_read_only=true` contract.
+
 ### `test_bind_mount_propagation_host_to_container`
 **Requires:** root, rootfs
 

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -20,15 +20,16 @@ use crate::cri::{
     PodSandboxStatusResponse, PortForwardRequest, PortForwardResponse, RemoveContainerRequest,
     RemoveContainerResponse, RemovePodSandboxRequest, RemovePodSandboxResponse,
     ReopenContainerLogRequest, ReopenContainerLogResponse, RuntimeCondition, RuntimeConfigRequest,
-    RuntimeConfigResponse, RuntimeStatus, StartContainerRequest, StartContainerResponse,
-    StatusRequest, StatusResponse, StopContainerRequest, StopContainerResponse,
-    StopPodSandboxRequest, StopPodSandboxResponse, StreamContainerStatsRequest,
-    StreamContainerStatsResponse, StreamContainersRequest, StreamContainersResponse,
-    StreamPodSandboxMetricsRequest, StreamPodSandboxMetricsResponse, StreamPodSandboxStatsRequest,
-    StreamPodSandboxStatsResponse, StreamPodSandboxesRequest, StreamPodSandboxesResponse,
-    UInt64Value, UpdateContainerResourcesRequest, UpdateContainerResourcesResponse,
-    UpdatePodSandboxResourcesRequest, UpdatePodSandboxResourcesResponse,
-    UpdateRuntimeConfigRequest, UpdateRuntimeConfigResponse, VersionRequest, VersionResponse,
+    RuntimeConfigResponse, RuntimeHandler, RuntimeHandlerFeatures, RuntimeStatus,
+    StartContainerRequest, StartContainerResponse, StatusRequest, StatusResponse,
+    StopContainerRequest, StopContainerResponse, StopPodSandboxRequest, StopPodSandboxResponse,
+    StreamContainerStatsRequest, StreamContainerStatsResponse, StreamContainersRequest,
+    StreamContainersResponse, StreamPodSandboxMetricsRequest, StreamPodSandboxMetricsResponse,
+    StreamPodSandboxStatsRequest, StreamPodSandboxStatsResponse, StreamPodSandboxesRequest,
+    StreamPodSandboxesResponse, UInt64Value, UpdateContainerResourcesRequest,
+    UpdateContainerResourcesResponse, UpdatePodSandboxResourcesRequest,
+    UpdatePodSandboxResourcesResponse, UpdateRuntimeConfigRequest, UpdateRuntimeConfigResponse,
+    VersionRequest, VersionResponse,
 };
 use crate::invoke::run_pelagos;
 use crate::scope;
@@ -729,7 +730,15 @@ impl RuntimeService for RuntimeSvc {
                 ],
             }),
             info: HashMap::new(),
-            runtime_handlers: vec![],
+            // Advertise recursive read-only mount support (#356) on the default
+            // handler so the kubelet/critest will request and exercise it.
+            runtime_handlers: vec![RuntimeHandler {
+                name: String::new(),
+                features: Some(RuntimeHandlerFeatures {
+                    recursive_read_only_mounts: true,
+                    ..Default::default()
+                }),
+            }],
             features: None,
         }))
     }
@@ -1247,6 +1256,25 @@ impl RuntimeService for RuntimeSvc {
             })
             .collect();
 
+        // Validate recursive_read_only constraints (#356): the CRI spec requires a
+        // recursive readonly mount to also be readonly and have PRIVATE propagation.
+        // critest expects CreateContainer to reject violations.
+        for m in &config.mounts {
+            if m.recursive_read_only {
+                if !m.readonly {
+                    return Err(Status::invalid_argument(format!(
+                        "recursive_read_only mount {:?} requires readonly=true",
+                        m.container_path
+                    )));
+                }
+                if m.propagation != 0 {
+                    return Err(Status::invalid_argument(format!(
+                        "recursive_read_only mount {:?} requires PRIVATE propagation",
+                        m.container_path
+                    )));
+                }
+            }
+        }
         let mounts: Vec<CriMount> = config
             .mounts
             .iter()
@@ -1547,7 +1575,11 @@ impl RuntimeService for RuntimeSvc {
         for m in &container.mounts {
             args.push("-v".into());
             let mut spec = format!("{}:{}", m.host_path, m.container_path);
-            if m.readonly {
+            // recursive_read_only (#356) → :rro (mount_setattr AT_RECURSIVE);
+            // plain readonly → :ro (non-recursive, top mount only).
+            if m.recursive_read_only {
+                spec.push_str(":rro");
+            } else if m.readonly {
                 spec.push_str(":ro");
             }
             // CRI MountPropagation → pelagos -v suffix (#341):

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -910,11 +910,18 @@ fn apply_cli_options(
         }
         let (src, tgt) = (parts[0], parts[1]);
         let mut readonly = false;
+        let mut recursive_readonly = false;
         let mut propagation = pelagos::container::MountPropagation::Private;
         for opt in &parts[2..] {
             match *opt {
                 "ro" => readonly = true,
                 "rw" => readonly = false,
+                // `rro` = recursive read-only (#356): readonly applied to all
+                // submounts via mount_setattr(AT_RECURSIVE).
+                "rro" => {
+                    readonly = true;
+                    recursive_readonly = true;
+                }
                 "rprivate" | "private" => {
                     propagation = pelagos::container::MountPropagation::Private
                 }
@@ -930,7 +937,8 @@ fn apply_cli_options(
             }
         }
         if src.starts_with('/') {
-            cmd = cmd.with_bind_mount_propagated(src, tgt, readonly, propagation);
+            cmd =
+                cmd.with_bind_mount_propagated(src, tgt, readonly, recursive_readonly, propagation);
         } else {
             let vol = Volume::open(src).or_else(|_| Volume::create(src))?;
             cmd = cmd.with_volume(&vol, tgt);

--- a/src/container.rs
+++ b/src/container.rs
@@ -878,8 +878,49 @@ pub struct BindMount {
     pub target: PathBuf,
     /// If true, the bind mount is read-only inside the container.
     pub readonly: bool,
+    /// If true (and `readonly`), the read-only attribute is applied RECURSIVELY
+    /// to every submount via `mount_setattr(AT_RECURSIVE)` — the CRI
+    /// `recursive_read_only` semantics. When false, `readonly` is non-recursive
+    /// (top mount only; submounts stay writable, see #356). Defaults to false.
+    pub recursive_readonly: bool,
     /// Mount propagation mode (#341). Defaults to `Private`.
     pub propagation: MountPropagation,
+}
+
+/// Apply `MOUNT_ATTR_RDONLY` recursively (`AT_RECURSIVE`) to the mount at
+/// `target` via `mount_setattr(2)` — the CRI `recursive_read_only` semantics
+/// (#356 follow-up). Returns true on success; false (so the caller can fall back
+/// to a non-recursive remount) on `ENOSYS`/older kernels (mount_setattr needs
+/// kernel ≥ 5.12). Allocation-free, safe to call from the pre-exec hook.
+fn mount_setattr_rdonly_recursive(target: &std::ffi::CStr) -> bool {
+    #[repr(C)]
+    struct MountAttr {
+        attr_set: u64,
+        attr_clr: u64,
+        propagation: u64,
+        userns_fd: u64,
+    }
+    const MOUNT_ATTR_RDONLY: u64 = 0x0000_0001;
+    const AT_RECURSIVE: libc::c_uint = 0x8000;
+    // __NR_mount_setattr is 442 on both x86_64 and aarch64.
+    const SYS_MOUNT_SETATTR: libc::c_long = 442;
+    let attr = MountAttr {
+        attr_set: MOUNT_ATTR_RDONLY,
+        attr_clr: 0,
+        propagation: 0,
+        userns_fd: 0,
+    };
+    let rc = unsafe {
+        libc::syscall(
+            SYS_MOUNT_SETATTR,
+            libc::AT_FDCWD,
+            target.as_ptr(),
+            AT_RECURSIVE,
+            &attr as *const MountAttr,
+            std::mem::size_of::<MountAttr>(),
+        )
+    };
+    rc == 0
 }
 
 /// Default propagation flags for the container's root mount when
@@ -2653,6 +2694,7 @@ impl Command {
             source: source.into(),
             target: target.into(),
             readonly: false,
+            recursive_readonly: false,
             propagation: MountPropagation::Private,
         });
         self
@@ -2670,17 +2712,20 @@ impl Command {
             source: source.into(),
             target: target.into(),
             readonly: true,
+            recursive_readonly: false,
             propagation: MountPropagation::Private,
         });
         self
     }
 
-    /// Add a bind mount with an explicit [`MountPropagation`] mode (#341).
+    /// Add a bind mount with an explicit [`MountPropagation`] mode (#341) and
+    /// optional recursive read-only (#356 `recursive_read_only`).
     pub fn with_bind_mount_propagated<P1, P2>(
         mut self,
         source: P1,
         target: P2,
         readonly: bool,
+        recursive_readonly: bool,
         propagation: MountPropagation,
     ) -> Self
     where
@@ -2691,6 +2736,7 @@ impl Command {
             source: source.into(),
             target: target.into(),
             readonly,
+            recursive_readonly,
             propagation,
         });
         self
@@ -4689,21 +4735,31 @@ impl Command {
                                 io::Error::last_os_error()
                             )));
                         }
-                        // Step 2 (if readonly): remount read-only — Linux requires two calls
+                        // Step 2 (if readonly): make the mount read-only.
                         if bm.readonly {
-                            let r2 = libc::mount(
-                                ptr::null(),
-                                tgt_c.as_ptr(),
-                                ptr::null(),
-                                libc::MS_REMOUNT | libc::MS_BIND | libc::MS_RDONLY,
-                                ptr::null(),
-                            );
-                            if r2 != 0 {
-                                return Err(io::Error::other(format!(
-                                    "bind mount remount ro {}: {}",
-                                    host_target.display(),
-                                    io::Error::last_os_error()
-                                )));
+                            // Recursive RO (#356 recursive_read_only): mount_setattr
+                            // with AT_RECURSIVE marks the top mount AND every submount
+                            // read-only. Falls through to the non-recursive remount on
+                            // older kernels (mount_setattr needs ≥5.12).
+                            let did_recursive =
+                                bm.recursive_readonly && mount_setattr_rdonly_recursive(&tgt_c);
+                            if !did_recursive {
+                                // Non-recursive: remount the top mount RO (submounts stay
+                                // writable — #356). Linux requires the two-call remount.
+                                let r2 = libc::mount(
+                                    ptr::null(),
+                                    tgt_c.as_ptr(),
+                                    ptr::null(),
+                                    libc::MS_REMOUNT | libc::MS_BIND | libc::MS_RDONLY,
+                                    ptr::null(),
+                                );
+                                if r2 != 0 {
+                                    return Err(io::Error::other(format!(
+                                        "bind mount remount ro {}: {}",
+                                        host_target.display(),
+                                        io::Error::last_os_error()
+                                    )));
+                                }
                             }
                         }
                         // Step 3 (#341): apply the requested mount propagation on the
@@ -7263,19 +7319,25 @@ impl Command {
                             )));
                         }
                         if bm.readonly {
-                            let r2 = libc::mount(
-                                ptr::null(),
-                                tgt_c.as_ptr(),
-                                ptr::null(),
-                                libc::MS_REMOUNT | libc::MS_BIND | libc::MS_RDONLY,
-                                ptr::null(),
-                            );
-                            if r2 != 0 {
-                                return Err(io::Error::other(format!(
-                                    "bind mount remount ro {}: {}",
-                                    host_target.display(),
-                                    io::Error::last_os_error()
-                                )));
+                            // Recursive RO (#356) via mount_setattr(AT_RECURSIVE);
+                            // fall back to a non-recursive remount on older kernels.
+                            let did_recursive =
+                                bm.recursive_readonly && mount_setattr_rdonly_recursive(&tgt_c);
+                            if !did_recursive {
+                                let r2 = libc::mount(
+                                    ptr::null(),
+                                    tgt_c.as_ptr(),
+                                    ptr::null(),
+                                    libc::MS_REMOUNT | libc::MS_BIND | libc::MS_RDONLY,
+                                    ptr::null(),
+                                );
+                                if r2 != 0 {
+                                    return Err(io::Error::other(format!(
+                                        "bind mount remount ro {}: {}",
+                                        host_target.display(),
+                                        io::Error::last_os_error()
+                                    )));
+                                }
                             }
                         }
                         // #341: apply requested propagation on the target (best-effort).
@@ -8688,6 +8750,7 @@ mod tests {
             source: PathBuf::from("/h"),
             target: PathBuf::from("/c"),
             readonly: false,
+            recursive_readonly: false,
             propagation: p,
         };
         assert_eq!(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1752,6 +1752,84 @@ mod filesystem {
     }
 
     #[test]
+    fn test_bind_mount_recursive_ro_submount_readonly() {
+        // #356 recursive_read_only: a RECURSIVE readonly bind
+        // (with_bind_mount_propagated(..., recursive_readonly=true, ...)) applies
+        // MOUNT_ATTR_RDONLY to the top mount AND every submount via
+        // mount_setattr(AT_RECURSIVE) — so a submount is also read-only (the
+        // opposite of the non-recursive case). `touch <submount>/file` must FAIL.
+        use std::os::unix::ffi::OsStrExt as _;
+        if !is_root() {
+            eprintln!("Skipping test_bind_mount_recursive_ro_submount_readonly: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping test_bind_mount_recursive_ro_submount_readonly: no rootfs");
+            return;
+        };
+
+        let outer = tempfile::tempdir().expect("failed to create temp dir");
+        let inner = outer.path().join("inner");
+        std::fs::create_dir_all(&inner).expect("mkdir inner");
+        let inner_c = std::ffi::CString::new(inner.as_os_str().as_bytes()).unwrap();
+        let tmpfs_c = std::ffi::CString::new("tmpfs").unwrap();
+        let rc = unsafe {
+            libc::mount(
+                tmpfs_c.as_ptr(),
+                inner_c.as_ptr(),
+                tmpfs_c.as_ptr(),
+                0,
+                std::ptr::null(),
+            )
+        };
+        assert_eq!(
+            rc,
+            0,
+            "host tmpfs mount failed: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let mut child = Command::new("/bin/ash")
+            .args([
+                "-c",
+                "touch /mnt/rro/inner/sub 2>/dev/null; echo sub=$?; \
+                 touch /mnt/rro/top 2>/dev/null; echo top=$?",
+            ])
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS)
+            .with_chroot(&rootfs)
+            .env("PATH", ALPINE_PATH)
+            .with_bind_mount_propagated(
+                outer.path(),
+                "/mnt/rro",
+                true,
+                true,
+                MountPropagation::Private,
+            )
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Piped)
+            .stderr(Stdio::Piped)
+            .spawn()
+            .expect("Failed to spawn with recursive readonly bind mount");
+
+        let (status, stdout, _) = child.wait_with_output().expect("Failed to collect output");
+        unsafe {
+            libc::umount(inner_c.as_ptr());
+        }
+        assert!(status.success(), "Shell should exit cleanly");
+        let out = String::from_utf8_lossy(&stdout);
+        assert!(
+            out.contains("sub=1"),
+            "submount under a RECURSIVE readonly bind must be read-only, got: {}",
+            out
+        );
+        assert!(
+            out.contains("top=1"),
+            "top of a recursive readonly bind must be read-only, got: {}",
+            out
+        );
+    }
+
+    #[test]
     fn test_bind_mount_propagation_host_to_container() {
         // #341: an `rslave` (HOST_TO_CONTAINER) bind propagates mounts created on
         // the host under the source INTO the container after it has started. We
@@ -1802,7 +1880,13 @@ mod filesystem {
             .with_namespaces(Namespace::MOUNT | Namespace::UTS)
             .with_chroot(&rootfs)
             .env("PATH", ALPINE_PATH)
-            .with_bind_mount_propagated(&src_path, "/mnt", false, MountPropagation::HostToContainer)
+            .with_bind_mount_propagated(
+                &src_path,
+                "/mnt",
+                false,
+                false,
+                MountPropagation::HostToContainer,
+            )
             .stdin(Stdio::Null)
             .stdout(Stdio::Piped)
             .stderr(Stdio::Piped)


### PR DESCRIPTION
## Summary
Completes the #356 follow-up: CRI `recursive_read_only=true` — the readonly attribute applies to the bind's top mount **and every submount** (inverse of the non-recursive readonly mount already shipped). `Container Mount Readonly` critest goes to **5/5** on ipc2.

### Runtime (`src`)
- `BindMount.recursive_readonly`; when set, apply readonly via `mount_setattr(AT_RECURSIVE, MOUNT_ATTR_RDONLY)` (kernel ≥ 5.12), falling back to the non-recursive remount on older kernels. `mount_setattr_rdonly_recursive` helper, applied in both spawn paths.
- `pelagos run -v src:tgt:rro` → readonly + recursive_readonly.

### CRI (`pelagos-cri`)
- Map `recursive_read_only=true` → `-v :rro`.
- **Advertise** the `recursive_read_only_mounts` runtime-handler feature in `Status` so the kubelet/critest request it (this is what surfaces the specs — they were skipped before).
- **Reject** invalid requests at CreateContainer — the spec requires a recursive readonly mount to also be `readonly` and have `PRIVATE` propagation (critest's three "should reject a recursive readonly mount with PROPAGATION_HOST_TO_CONTAINER / PROPAGATION_BIDIRECTIONAL / ReadOnly: false" specs).

## Verification
- **ipc2 critest `readonly mounts`: 5/5** (advertising the capability surfaced the 2 recursive-RO enforcement + 3 rejection specs; all pass).
- New integration test `test_bind_mount_recursive_ro_submount_readonly` (submount is read-only under `rro`).
- **Full suite: 406 passed** (2 unrelated flakes — `auto_pull`, NAT — pass on isolated re-run).
- `cargo fmt`/`clippy` clean.

> Tested with the ipc2 kubelet stopped (#379), so no orphan-sandbox GC interference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)