### PR TITLE
fix(cri): image identity, User uid, untagged ImageStatus (#382)

### DIFF
--- a/pelagos-cri/src/image.rs
+++ b/pelagos-cri/src/image.rs
@@ -151,19 +151,34 @@ impl ImageSvc {
                 continue;
             };
             // The config digest = sha256 of the raw OCI config blob, which is
-            // identical for the same image across tags and registries. Fall back
-            // to the manifest digest if the config blob isn't present (e.g. an
-            // older or locally-built image).
-            let config_digest = match tokio::fs::read(dir.join("oci-config.json")).await {
-                Ok(bytes) => format!("sha256:{:x}", Sha256::digest(&bytes)),
-                Err(_) => m.digest.clone(),
+            // identical for the same image across tags and registries. Also read
+            // the OCI config's `User` straight from that blob — the authoritative
+            // source — so ImageStatus reports uid/username even when the stored
+            // manifest didn't capture it (#382). Fall back to the manifest digest
+            // and manifest config.user if the config blob isn't present.
+            let (config_digest, oci_user) = match tokio::fs::read(dir.join("oci-config.json")).await
+            {
+                Ok(bytes) => {
+                    let digest = format!("sha256:{:x}", Sha256::digest(&bytes));
+                    let user = serde_json::from_slice::<serde_json::Value>(&bytes)
+                        .ok()
+                        .and_then(|v| v["config"]["User"].as_str().map(String::from))
+                        .unwrap_or_default();
+                    (digest, user)
+                }
+                Err(_) => (m.digest.clone(), String::new()),
+            };
+            let user = if oci_user.is_empty() {
+                m.config.user
+            } else {
+                oci_user
             };
             out.push(StoredImage {
                 reference: m.reference,
                 manifest_digest: m.digest,
                 config_digest,
                 layers: m.layers,
-                user: m.config.user,
+                user,
             });
         }
         out
@@ -243,11 +258,17 @@ impl ImageSvc {
     /// Find the aggregated image matching `r`, which may be a tag, a
     /// `repo@digest`, the config-digest id, or a bare manifest digest.
     fn match_image(images: &[Image], r: &str) -> Option<Image> {
+        // A bare repo reference (no `:tag`, no `@digest`) defaults to `:latest`,
+        // so `ImageStatus("repo")` finds the image pulled as `repo:latest` (#382).
+        let r_latest = (!r.contains('@') && repo_of(r) == r).then(|| format!("{}:latest", r));
         images
             .iter()
             .find(|img| {
                 img.id == r
                     || img.repo_tags.iter().any(|t| t == r)
+                    || r_latest
+                        .as_deref()
+                        .is_some_and(|rl| img.repo_tags.iter().any(|t| t == rl))
                     || img.repo_digests.iter().any(|d| d == r)
                     // also accept a bare manifest digest (the `@sha256:...` part)
                     || img
@@ -546,6 +567,24 @@ mod tests {
         assert!(ImageSvc::match_image(&imgs, "alpine@sha256:m1").is_some()); // by repo_digest
         assert!(ImageSvc::match_image(&imgs, "sha256:m1").is_some()); // by bare manifest digest
         assert!(ImageSvc::match_image(&imgs, "nonexistent:1").is_none());
+    }
+
+    #[test]
+    fn test_match_image_bare_repo_defaults_latest() {
+        // #382: ImageStatus("repo") with no tag must find the image pulled as
+        // "repo:latest" (note the repo name itself ends in "-latest" to guard the
+        // tag-vs-repo parsing).
+        let imgs = aggregate(vec![stored(
+            "gcr.io/x/test-image-latest:latest",
+            "sha256:m",
+            "sha256:c",
+            "",
+        )]);
+        assert!(ImageSvc::match_image(&imgs, "gcr.io/x/test-image-latest").is_some());
+        assert!(ImageSvc::match_image(&imgs, "gcr.io/x/test-image-latest:latest").is_some());
+        // A bare repo not pulled as :latest must NOT match (no implicit cross-tag).
+        let other = aggregate(vec![stored("repo:v1", "sha256:m", "sha256:c2", "")]);
+        assert!(ImageSvc::match_image(&other, "repo").is_none());
     }
 
     #[test]

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -629,8 +629,25 @@ impl RuntimeSvc {
         self.state.inner.lock().await.pelagos_bin.clone()
     }
 
+    /// The config digest (image id) of a stored image dir: sha256 of its raw
+    /// `oci-config.json` blob (matches containerd's image id and what PullImage/
+    /// ImageStatus report). Falls back to the manifest digest when the config
+    /// blob isn't present (older/locally-built images). #382.
+    async fn config_digest_of(dir: &std::path::Path, manifest_digest: &str) -> String {
+        match tokio::fs::read(dir.join("oci-config.json")).await {
+            Ok(bytes) => {
+                use sha2::Digest as _;
+                format!("sha256:{:x}", sha2::Sha256::digest(&bytes))
+            }
+            Err(_) => manifest_digest.to_string(),
+        }
+    }
+
     /// Resolve a digest-form image ref (sha256:...) to a repo tag by scanning the image store.
-    /// Kubelet may pass the digest it received from ImageStatus rather than the original tag.
+    /// The kubelet creates containers using the image **id** (config digest) it received from
+    /// PullImage/ImageStatus, not the original tag — so match the config digest as well as the
+    /// manifest digest, otherwise `pelagos run` would try to pull `docker.io/library/sha256:…`
+    /// and fail (#382).
     async fn resolve_image_ref(image_ref: &str) -> String {
         if !image_ref.starts_with("sha256:") {
             return image_ref.to_string();
@@ -639,10 +656,12 @@ impl RuntimeSvc {
             return image_ref.to_string();
         };
         while let Ok(Some(entry)) = rd.next_entry().await {
-            let manifest_path = entry.path().join("manifest.json");
-            if let Ok(data) = tokio::fs::read_to_string(&manifest_path).await {
+            let dir = entry.path();
+            if let Ok(data) = tokio::fs::read_to_string(dir.join("manifest.json")).await {
                 if let Ok(m) = serde_json::from_str::<serde_json::Value>(&data) {
-                    if m["digest"].as_str() == Some(image_ref) {
+                    let manifest_digest = m["digest"].as_str().unwrap_or("");
+                    let config_digest = Self::config_digest_of(&dir, manifest_digest).await;
+                    if config_digest == image_ref || manifest_digest == image_ref {
                         if let Some(tag) = m["reference"].as_str() {
                             return tag.to_string();
                         }
@@ -660,14 +679,18 @@ impl RuntimeSvc {
             return (vec![], vec![]);
         };
         while let Ok(Some(entry)) = rd.next_entry().await {
-            let manifest_path = entry.path().join("manifest.json");
-            let Ok(data) = tokio::fs::read_to_string(&manifest_path).await else {
+            let dir = entry.path();
+            let Ok(data) = tokio::fs::read_to_string(dir.join("manifest.json")).await else {
                 continue;
             };
             let Ok(m) = serde_json::from_str::<serde_json::Value>(&data) else {
                 continue;
             };
-            if m["reference"].as_str() == Some(image_ref) || m["digest"].as_str() == Some(image_ref)
+            let manifest_digest = m["digest"].as_str().unwrap_or("");
+            let config_digest = Self::config_digest_of(&dir, manifest_digest).await;
+            if m["reference"].as_str() == Some(image_ref)
+                || manifest_digest == image_ref
+                || config_digest == image_ref
             {
                 let ep = m["config"]["entrypoint"]
                     .as_array()


### PR DESCRIPTION
## Summary
Closes #382. Part of #338. Fixes the 4 failing critest **Image** specs — the bucket goes to **16/16** on ipc2.

### A — Container start by image **ID** (the 2 *Identifier Consistency* specs)
PullImage/ImageStatus correctly report the **config digest** as the image id (`sha256:40d29c…`). But when the kubelet then creates a container using that id, `resolve_image_ref` only matched the stored **manifest** digest (`sha256:dcae30…`), so it couldn't map the id to a local image and `pelagos run` tried to pull `docker.io/library/sha256:…` → `pull failed: 'sha256' does not exist`. `resolve_image_ref` / `load_image_defaults` now also match the config digest (`config_digest_of` = sha256 of `oci-config.json`).

### B — `Image.uid`/`username` empty
The OCI config `User` wasn't surfaced. `read_stored` now reads `User` straight from the stored `oci-config.json` (the authoritative blob it already reads for the config digest), falling back to the manifest's `config.user`. A numeric `User` (e.g. `1002`) yields `uid=1002`.

### C — ImageStatus by **untagged** reference returned nil
critest pulls `…/test-image-latest:latest` then queries `ImageStatus(…/test-image-latest)` with no tag. A bare repo ref (no `:tag`, no `@digest`) now defaults to `:latest` in `match_image`.

## Verification
- **ipc2 `Image` critest: 16/16** (was 4 failing), kubelet stopped (#379).
- pelagos-cri unit tests **32 passed** incl. new `test_match_image_bare_repo_defaults_latest`.
- `cargo fmt`/`clippy` clean. (pelagos-cri-only; the pelagos runtime is unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)