### PR TITLE
fix(image): re-extract rootless-degraded layers for root containers — NoNewPrivs (#384)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -1497,6 +1497,19 @@ it via `image::extract_layer()`, and verifies the files exist with correct conte
 the content-addressable layer store. Failure indicates the tar+gzip extraction pipeline
 or layer store layout is broken.
 
+### `test_extract_layer_reextracts_rootless_degraded_layer`
+**Requires:** root
+
+Verifies the #384 fix: a rootless (non-`CAP_FSETID`) unpack silently strips setuid/setgid
+bits, and the shared content-addressable layer cache must not serve such a degraded layer
+to a **root** container (it would break setuid escalation — the NoNewPrivs spec). Builds a
+tar.gz with a `0o4755` (setuid-root) file, extracts it as root (suid preserved, no marker),
+then simulates a prior rootless-degraded layer (strips the suid bit + writes the
+`<digest>.rootless` marker) and extracts again. The second root extraction must **re-extract**
+(driven by the marker), restoring the suid bit and clearing the marker. Failure means a
+rootless pull would permanently degrade setuid binaries for every root container reusing the
+layer.
+
 ### `test_multi_layer_overlay_merge`
 **Requires:** root, rootfs
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -321,8 +321,20 @@ pub fn extract_layer(digest: &str, tar_gz_path: &Path) -> io::Result<PathBuf> {
     ensure_image_dirs()?;
     let rootless = crate::paths::is_rootless();
     let dest = layer_dir(digest);
+    // A rootless (non-CAP_FSETID) unpack silently strips setuid/setgid bits, so a
+    // layer extracted rootless degrades any ROOT container that later reuses it —
+    // setuid binaries stop escalating (#384). Mark rootless extractions and, when
+    // a root extraction finds such a degraded layer in the shared cache, re-extract
+    // it with full fidelity rather than reusing it. The marker is a sibling file,
+    // never inside the layer dir (which becomes a container rootfs layer).
+    let rootless_marker = dest.with_extension("rootless");
     if dest.is_dir() {
-        return Ok(dest);
+        if rootless || !rootless_marker.exists() {
+            return Ok(dest); // rootless reuse, or root reusing a root-extracted layer
+        }
+        // Root extraction over a rootless-degraded layer: re-extract from scratch.
+        std::fs::remove_dir_all(&dest)?;
+        let _ = std::fs::remove_file(&rootless_marker);
     }
 
     // Extract to a temporary sibling, then rename atomically.
@@ -378,6 +390,14 @@ pub fn extract_layer(digest: &str, tar_gz_path: &Path) -> io::Result<PathBuf> {
     // Ensure parent dir exists and rename partial → final.
     std::fs::create_dir_all(dest.parent().unwrap())?;
     std::fs::rename(&partial, &dest)?;
+
+    // Record that this layer was extracted rootless (setuid/setgid bits stripped),
+    // so a later ROOT extraction re-extracts it with full fidelity (#384).
+    if rootless {
+        let _ = std::fs::File::create(&rootless_marker);
+    } else {
+        let _ = std::fs::remove_file(&rootless_marker);
+    }
 
     Ok(dest)
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7994,6 +7994,85 @@ mod linking {
 mod images {
     use super::*;
 
+    #[test]
+    fn test_extract_layer_reextracts_rootless_degraded_layer() {
+        // #384: a rootless (non-CAP_FSETID) unpack strips setuid bits, and the
+        // shared content-addressable cache would serve that degraded layer to a
+        // ROOT container — breaking setuid escalation (the NoNewPrivs spec). A root
+        // extraction must RE-extract a layer previously marked rootless, restoring
+        // full fidelity. Verify the marker drives the re-extraction.
+        use std::os::unix::fs::PermissionsExt;
+        if !is_root() {
+            eprintln!(
+                "Skipping test_extract_layer_reextracts_rootless_degraded_layer: requires root"
+            );
+            return;
+        }
+
+        // Build a layer tarball containing a setuid-root binary (tar as root
+        // captures the suid bit).
+        let work = tempfile::tempdir().expect("tempdir");
+        let src = work.path().join("layer");
+        std::fs::create_dir_all(src.join("usr/bin")).unwrap();
+        let bin = src.join("usr/bin/suidtool");
+        std::fs::write(&bin, b"x").unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o4755)).unwrap();
+        let tar_gz = work.path().join("layer.tar.gz");
+        let st = std::process::Command::new("tar")
+            .args([
+                "-czf",
+                tar_gz.to_str().unwrap(),
+                "-C",
+                src.to_str().unwrap(),
+                ".",
+            ])
+            .status()
+            .expect("tar");
+        assert!(st.success(), "tar build failed");
+
+        // A unique digest so the test never collides with a real layer; clean any
+        // prior state from a previous run.
+        let digest = "sha256:0000000000000000000000000000000000000000000000000000000000000384";
+        let dir = pelagos::image::layer_dir(digest);
+        let marker = dir.with_extension("rootless");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_file(&marker);
+
+        // Root extract: suid preserved, no rootless marker.
+        let layer = pelagos::image::extract_layer(digest, &tar_gz).expect("extract");
+        let suidtool = layer.join("usr/bin/suidtool");
+        let mode1 = std::fs::metadata(&suidtool).unwrap().permissions().mode();
+        assert_eq!(mode1 & 0o4000, 0o4000, "root extract must preserve suid");
+        assert!(
+            !marker.exists(),
+            "root extract must not write a rootless marker"
+        );
+
+        // Simulate a prior ROOTLESS-degraded layer in the cache: strip suid + mark.
+        std::fs::set_permissions(&suidtool, std::fs::Permissions::from_mode(0o0755)).unwrap();
+        std::fs::File::create(&marker).unwrap();
+
+        // Root re-extract: the marker must trigger a full re-extraction that
+        // restores the suid bit and clears the marker.
+        let layer2 = pelagos::image::extract_layer(digest, &tar_gz).expect("re-extract");
+        let mode2 = std::fs::metadata(layer2.join("usr/bin/suidtool"))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(
+            mode2 & 0o4000,
+            0o4000,
+            "root re-extract over a rootless-degraded layer must restore suid"
+        );
+        assert!(
+            !marker.exists(),
+            "rootless marker must be cleared after root re-extract"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_file(&marker);
+    }
+
     /// Copy the rootfs into a temp directory, excluding pseudo-filesystem
     /// contents (/sys, /proc, /dev) that can't be copied from a live mount.
     /// Re-creates the empty mount-point directories afterward.


### PR DESCRIPTION
## Summary
Closes #384. Fixes the critest `NoNewPrivs › should allow privilege escalation when false` failure (part of #352/#338). The non-streaming sweep's NoNewPrivs spec now passes.

## Root cause (not a runtime bug)
`pelagos-cri` pulls as root and **does** preserve setuid — a clean root pull of the test image gives `nnp` mode `-rwsr-sr-x root:root`, and the spec passes 2/2. The failure was a **stale rootless-extracted layer** in the shared cache:
- A rootless (non-`CAP_FSETID`) unpack silently **strips setuid/setgid bits** (the kernel drops them for an unprivileged process), leaving `-rwxrwxr-x root:pelagos`.
- `extract_layer` short-circuits when the layer dir exists (`dest.is_dir()`), so a **root** container reusing that degraded layer gets no-suid binaries → `uid 1000` exec'ing the setuid-root `nnp` reports `euid 1000`.

So once a rootless `image pull`/`build` contaminates the cache, **every** subsequent root container reusing that layer silently loses setuid escalation.

## Fix
Mark a rootless extraction with a sibling `<digest>.rootless` file (outside the layer dir, so it never lands in a container rootfs). When a **root** extraction finds a layer carrying that marker, **re-extract** it with full fidelity rather than reusing it; root extractions clear the marker. Root↔root and rootless↔rootless reuse is unchanged.

## Verification
- **ipc2 `NoNewPrivs` critest 2/2** (with the fix deployed).
- Integration test `test_extract_layer_reextracts_rootless_degraded_layer`: root re-extract over a marked, suid-stripped layer restores the suid bit and clears the marker.
- **Full suite: 407 passed** (2 unrelated flakes — cgroup/NAT — pass on isolated re-run). `cargo fmt`/`clippy` clean.

> Note: pre-existing degraded layers (extracted before this fix, no marker) are still reused until re-pulled; clearing `/var/lib/pelagos/layers/<digest>` forces a clean re-extract. Going forward, rootless contamination self-heals on the next root use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)