### PR TITLE
fix(cri): hostIPC pods share the host IPC namespace (#386)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -5280,3 +5280,16 @@ removal touched the host filesystem. Complemented by the unit tests
 managed roots and wholesale parent dirs, and `join`/`..` escapes; accepts legitimate
 container/sandbox/overlay/image subpaths) and `test_guarded_remove_refuses_unmanaged_dir`
 (functional proof that `guarded_remove_dir_all` leaves an out-of-tree directory intact).
+
+## `issue_347_no_host_destruction::test_sandbox_pause_host_ipc_shares_host_namespace`
+**Requires root** (creates a named netns, unshares namespaces).
+CRI hostIPC conformance (#386 / #352). Spawns the internal `sandbox __pause__` process
+twice over a named netns — once with `--host-ipc` and once without — and compares each
+pause's `/proc/<pid>/ns/ipc` inode against the host's `/proc/self/ns/ipc`. Asserts the
+inode **equals** the host's with `--host-ipc` (the pod shares the host IPC namespace,
+`hostIPC: true`) and **differs** without it (the default private pod IPC namespace).
+Failure of the equal case means a hostIPC pod still gets a private IPC namespace, so host
+System V IPC objects stay invisible inside the pod — exactly the critest "HostIpc is true"
+failure (`Expected '' to contain '6'`) this fixes. The pause is what `RunPodSandbox` spawns
+to hold pod namespaces open; CreateContainer passes `--host-ipc` to it when the sandbox's
+`namespace_options.ipc == NODE`.

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -803,6 +803,19 @@ impl RuntimeService for RuntimeSvc {
             .collect();
         let cni_cap_args = cni::port_mapping_cap_args(&sandbox_port_mappings);
 
+        // Host IPC namespace mode (namespace_options.ipc == NODE). When set, the
+        // pause must not unshare IPC so the pod shares the host IPC namespace
+        // (hostIPC: true — #386). Read it up front: the pause is spawned before
+        // the CriSandbox struct (which also records this) is built.
+        let sandbox_ipc_ns_mode = config
+            .linux
+            .as_ref()
+            .and_then(|l| l.security_context.as_ref())
+            .and_then(|sc| sc.namespace_options.as_ref())
+            .map(|no| no.ipc)
+            .unwrap_or(0);
+        let host_ipc = sandbox_ipc_ns_mode == 2;
+
         // Try CNI networking first; fall back to pelagos native if no config is present.
         let (sandbox_id, netns, ip, cni_conf, pause_pid) = if let Some(conf_path) =
             cni::find_cni_conf()
@@ -877,13 +890,18 @@ impl RuntimeService for RuntimeSvc {
             // The pause blocks forever, so it must be a backgrounded *service*
             // (not a `--scope`, which would block); its real PID is the unit's
             // MainPID. Off systemd we fall back to a plain leaked child.
+            // pause argv: hostIPC pods append --host-ipc so the pause keeps the
+            // host IPC namespace instead of unsharing a private one (#386).
+            let mut pause_argv: Vec<&str> = vec!["sandbox", "__pause__", &ns_name];
+            if host_ipc {
+                pause_argv.push("--host-ipc");
+            }
             let pause_pid = if scope::systemd_available() {
                 let unit = scope::sandbox_unit(&id);
                 // A re-run for the same sandbox id would collide with a lingering
                 // unit; clear any stale one first (best effort).
                 scope::stop_unit(&unit).await;
-                let argv =
-                    scope::build_service_argv(&unit, &bin, &["sandbox", "__pause__", &ns_name]);
+                let argv = scope::build_service_argv(&unit, &bin, &pause_argv);
                 let out = tokio::process::Command::new(&argv[0])
                     .args(&argv[1..])
                     .output()
@@ -914,7 +932,7 @@ impl RuntimeService for RuntimeSvc {
                 pid
             } else {
                 let pause = std::process::Command::new(&bin)
-                    .args(["sandbox", "__pause__", &ns_name])
+                    .args(&pause_argv)
                     .stdin(std::process::Stdio::null())
                     .stdout(std::process::Stdio::null())
                     .stderr(std::process::Stdio::null())

--- a/scripts/cri-conformance-386.sh
+++ b/scripts/cri-conformance-386.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Focused critest conformance run for #386 (hostIPC — pod shares the host IPC namespace).
+# Usage (on an IPC test node, never omen):
+#   sudo bash scripts/cri-conformance-386.sh /tmp/cri-386.result
+set -u
+SOCK="unix:///run/pelagos/cri.sock"
+OUT="${1:-/tmp/cri-386.result}"
+FOCUS='HostIpc is true'
+
+# ENV NOTE: this spec creates a host SysV shm segment with `ipcmk` (the creator
+# then exits, leaving nattch=0) and expects the container to see it. If the node
+# has `kernel.shm_rmid_forced=1`, the kernel force-frees that unattached segment
+# instantly and the spec fails for ANY runtime — it is not a pelagos isolation
+# bug. Run with the kernel default (0) to exercise the real behavior:
+#   sudo sysctl -w kernel.shm_rmid_forced=0   # remember to restore the prior value
+RMID_FORCED="$(sysctl -n kernel.shm_rmid_forced 2>/dev/null || echo '?')"
+[ "$RMID_FORCED" = "1" ] && echo "WARNING: kernel.shm_rmid_forced=1 will fail this spec environmentally (unattached shm reaped); set it to 0 for a valid run." >&2
+: > "$OUT"
+echo "# critest focus: $FOCUS" >> "$OUT"
+echo "# pelagos-cri: $(systemctl is-active pelagos-cri 2>/dev/null)" >> "$OUT"
+echo "# pelagos: $(/usr/local/bin/pelagos --version 2>/dev/null)" >> "$OUT"
+echo "# started: $(date -u +%FT%TZ)" >> "$OUT"
+echo "----------------------------------------" >> "$OUT"
+critest --runtime-endpoint "$SOCK" --ginkgo.focus="$FOCUS" >> "$OUT" 2>&1
+rc=$?
+echo "----------------------------------------" >> "$OUT"
+echo "# critest exit: $rc" >> "$OUT"
+exit "$rc"

--- a/scripts/probe-hostipc.sh
+++ b/scripts/probe-hostipc.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Probe: does a hostIPC pod's CONTAINER land in the host IPC namespace?
+#   sudo bash scripts/probe-hostipc.sh
+set -u
+SOCK="unix:///run/pelagos/cri.sock"
+C() { sudo crictl -r "$SOCK" "$@"; }
+
+ipcmk -M 1024 >/dev/null 2>&1 || true
+echo "host    ipc ns: $(readlink /proc/self/ns/ipc)"
+
+cat >/tmp/hostipc-pod.json <<JSON
+{ "metadata": {"name":"hipc-probe","namespace":"default","uid":"hipc-probe-uid","attempt":1},
+  "log_directory":"/tmp",
+  "linux": {"security_context": {"namespace_options": {"ipc": 2}}} }
+JSON
+cat >/tmp/hostipc-ctr.json <<JSON
+{ "metadata": {"name":"hipc-c"},
+  "image": {"image":"registry.k8s.io/e2e-test-images/busybox:1.29-2"},
+  "command": ["sleep","600"], "log_path":"hipc-c.log" }
+JSON
+
+SB=$(C runp /tmp/hostipc-pod.json 2>/dev/null | tail -1)
+CID=$(C create "$SB" /tmp/hostipc-ctr.json /tmp/hostipc-pod.json 2>/dev/null | tail -1)
+C start "$CID" >/dev/null 2>&1
+CPID=$(C inspect "$CID" 2>/dev/null | python3 -c 'import sys,json; print(json.load(sys.stdin)["info"]["pid"])' 2>/dev/null)
+echo "sandbox=$SB container=$CID cpid=$CPID"
+echo "ctr     ipc ns: $( [ -n "$CPID" ] && readlink /proc/$CPID/ns/ipc )"
+echo "ctr     net ns: $( [ -n "$CPID" ] && readlink /proc/$CPID/ns/net )  (for reference)"
+echo "--- ipcs -m as seen from inside the container's IPC ns (nsenter) ---"
+[ -n "$CPID" ] && sudo nsenter -t "$CPID" -i ipcs -m 2>&1 | head -8
+
+echo "=== cleanup ==="
+C stop "$CID" >/dev/null 2>&1; C rm "$CID" >/dev/null 2>&1
+C stopp "$SB" >/dev/null 2>&1; C rmp "$SB" >/dev/null 2>&1

--- a/src/cli/sandbox.rs
+++ b/src/cli/sandbox.rs
@@ -40,6 +40,9 @@ pub enum SandboxCmd {
     Pause {
         /// Network namespace name
         ns_name: String,
+        /// Don't unshare IPC — the pod shares the host IPC namespace (hostIPC: true).
+        #[clap(long = "host-ipc")]
+        host_ipc: bool,
     },
 }
 
@@ -50,7 +53,7 @@ pub fn cmd_sandbox(cmd: SandboxCmd) -> Result<(), Box<dyn std::error::Error>> {
         SandboxCmd::Create { name } => cmd_sandbox_create(name.as_deref()),
         SandboxCmd::Ls { json } => cmd_sandbox_ls(json),
         SandboxCmd::Rm { id } => cmd_sandbox_rm(&id),
-        SandboxCmd::Pause { ns_name } => cmd_sandbox_pause(&ns_name),
+        SandboxCmd::Pause { ns_name, host_ipc } => cmd_sandbox_pause(&ns_name, host_ipc),
     }
 }
 
@@ -113,7 +116,12 @@ fn cmd_sandbox_rm(id: &str) -> Result<(), Box<dyn std::error::Error>> {
 /// The pause process purpose is to keep the IPC and UTS namespaces alive even
 /// after containers in the sandbox exit.  The NET namespace is the named netns
 /// `/run/netns/<ns_name>` which persists independently.
-fn cmd_sandbox_pause(ns_name: &str) -> Result<(), Box<dyn std::error::Error>> {
+///
+/// When `host_ipc` is set (pod `hostIPC: true`, `namespace_options.ipc == NODE`)
+/// the pause does **not** unshare IPC, so `/proc/<pause>/ns/ipc` is the host IPC
+/// namespace.  Containers join that namespace via `with_sandbox()`, making host
+/// System V IPC objects visible inside the pod (CRI conformance #386 / #352).
+fn cmd_sandbox_pause(ns_name: &str, host_ipc: bool) -> Result<(), Box<dyn std::error::Error>> {
     // Join the named network namespace.
     let netns_path = format!("/run/netns/{}", ns_name);
     let netns_c = std::ffi::CString::new(netns_path.as_bytes())
@@ -139,10 +147,18 @@ fn cmd_sandbox_pause(ns_name: &str) -> Result<(), Box<dyn std::error::Error>> {
         .into());
     }
 
-    // Unshare IPC and UTS namespaces so containers in the sandbox share them.
-    let rc = unsafe { libc::unshare(libc::CLONE_NEWIPC | libc::CLONE_NEWUTS) };
+    // Unshare UTS (pod hostname) and — unless the pod requested host IPC — IPC,
+    // so containers in the sandbox share a private IPC namespace.  For a hostIPC
+    // pod we skip the IPC unshare so the pause (and every container joining it)
+    // stays in the host IPC namespace.
+    let unshare_flags = if host_ipc {
+        libc::CLONE_NEWUTS
+    } else {
+        libc::CLONE_NEWIPC | libc::CLONE_NEWUTS
+    };
+    let rc = unsafe { libc::unshare(unshare_flags) };
     if rc != 0 {
-        return Err(format!("unshare IPC/UTS: {}", std::io::Error::last_os_error()).into());
+        return Err(format!("unshare UTS/IPC: {}", std::io::Error::last_os_error()).into());
     }
 
     // Block until terminated. `pause()` returns on ANY caught signal — a stray

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -28557,4 +28557,96 @@ mod issue_347_no_host_destruction {
             "#347 regression: /bin was removed by `pelagos rm`"
         );
     }
+
+    /// test_sandbox_pause_host_ipc_shares_host_namespace
+    ///
+    /// Requires: root (creates a named netns, unshares namespaces).
+    ///
+    /// Spawns the internal `sandbox __pause__` process twice over a named netns —
+    /// once with `--host-ipc` and once without — and compares each pause's
+    /// `/proc/<pid>/ns/ipc` inode against the host's `/proc/self/ns/ipc`.
+    ///
+    /// Asserts the inode EQUALS the host's with `--host-ipc` (the pod shares the
+    /// host IPC namespace, `hostIPC: true`) and DIFFERS without it (the default
+    /// private pod IPC namespace). Failure of the equal case means a hostIPC pod
+    /// still gets a private IPC namespace, so host System V IPC objects are
+    /// invisible inside the pod — the CRI "HostIpc is true" conformance failure
+    /// this fixes (#386 / #352).
+    #[test]
+    fn test_sandbox_pause_host_ipc_shares_host_namespace() {
+        if !is_root() {
+            eprintln!("Skipping test_sandbox_pause_host_ipc_shares_host_namespace: requires root");
+            return;
+        }
+        use std::os::unix::fs::MetadataExt;
+
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+        let host_ipc_inode = std::fs::metadata("/proc/self/ns/ipc")
+            .expect("stat /proc/self/ns/ipc")
+            .ino();
+
+        // Create a named netns and spawn the pause (optionally with --host-ipc).
+        // The plain `pelagos sandbox __pause__` runs in the spawned process itself
+        // (no double-fork), so /proc/<child>/ns/ipc is the pause's IPC namespace.
+        fn spawn_pause(bin: &str, tag: &str, host_ipc: bool) -> (std::process::Child, String) {
+            let ns = format!("pel-hipc-{}-{}", tag, std::process::id());
+            let _ = std::process::Command::new("ip")
+                .args(["netns", "del", &ns])
+                .status();
+            let added = std::process::Command::new("ip")
+                .args(["netns", "add", &ns])
+                .status()
+                .expect("ip netns add");
+            assert!(added.success(), "ip netns add {} failed", ns);
+
+            let mut args = vec!["sandbox", "__pause__", ns.as_str()];
+            if host_ipc {
+                args.push("--host-ipc");
+            }
+            let child = std::process::Command::new(bin)
+                .args(&args)
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .expect("spawn pause");
+            (child, ns)
+        }
+
+        let (mut host_child, host_ns) = spawn_pause(bin, "host", true);
+        let (mut priv_child, priv_ns) = spawn_pause(bin, "priv", false);
+
+        // Allow the pauses to setns into the netns and (not) unshare IPC.
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        let host_pause_inode = std::fs::metadata(format!("/proc/{}/ns/ipc", host_child.id()))
+            .expect("stat host-ipc pause ns/ipc")
+            .ino();
+        let priv_pause_inode = std::fs::metadata(format!("/proc/{}/ns/ipc", priv_child.id()))
+            .expect("stat private pause ns/ipc")
+            .ino();
+
+        // Tear down before asserting so a failure still cleans up.
+        let _ = host_child.kill();
+        let _ = priv_child.kill();
+        let _ = host_child.wait();
+        let _ = priv_child.wait();
+        for ns in [&host_ns, &priv_ns] {
+            let _ = std::process::Command::new("ip")
+                .args(["netns", "del", ns])
+                .status();
+        }
+
+        assert_eq!(
+            host_pause_inode, host_ipc_inode,
+            "pause --host-ipc should keep the host IPC namespace (inode {}), got {}",
+            host_ipc_inode, host_pause_inode
+        );
+        assert_ne!(
+            priv_pause_inode, host_ipc_inode,
+            "pause without --host-ipc should unshare a private IPC namespace, \
+             but its inode matches the host's ({})",
+            host_ipc_inode
+        );
+    }
 }


### PR DESCRIPTION
Closes #386. First of the three remaining `NamespaceOption` conformance specs (#352 / #338); part of the staged host-namespace work (HostIpc → HostNetwork → PodPID).

## Problem
critest *"runtime should support HostIpc is true"* expects a container in a `hostIPC: true` pod to see host System V IPC objects; pelagos returned empty (`Expected '' to contain '<id>'`).

The sandbox **pause** process unconditionally ran `unshare(CLONE_NEWIPC | CLONE_NEWUTS)`, giving every pod a **private** IPC namespace; containers join the pause's IPC via `with_sandbox()`. CreateContainer's `--no-ipc-ns` only skipped the container's own unshare — the container still joined the pause's *private* IPC, and `/proc` (mounted before the join) was tied to that private namespace.

## Fix
The pause gains `--host-ipc`, which **skips the IPC unshare** so `/proc/<pause>/ns/ipc` is the host IPC namespace. `RunPodSandbox` passes it to the pause when `namespace_options.ipc == NODE`. Combined with the existing `--no-ipc-ns` (the container never unshares IPC, so its `/proc` ties to host IPC), a hostIPC pod's container correctly sees host IPC objects. **Default pods (POD/CONTAINER) keep a private IPC namespace, fully unaffected** — the new branch is guarded by `ipc == NODE`.

## Design note (why this is correct, not a test hack)
`hostIPC: true` is an explicit, admission-gated opt-in (PodSecurity `baseline`/`restricted` forbid it). The runtime's job is to faithfully honor it. Selection is per-pod via the spec field — there is intentionally no pelagos-global toggle. The secure default (private per-pod IPC) is the untouched path.

## Verification
- Integration test `test_sandbox_pause_host_ipc_shares_host_namespace`: the pause's `/proc/<pid>/ns/ipc` inode **equals** the host's with `--host-ipc`, **differs** without it.
- critest `HostIpc is true` on ipc2: **1/1 PASS**.
  - ⚠️ Environmental gotcha: ipc2 had `kernel.shm_rmid_forced=1`, which force-frees critest's *unattached* test segment (`ipcmk`, `nattch=0`) before the container can read it — failing the spec for **any** runtime. With the kernel default (`=0`) it passes. Documented in `scripts/cri-conformance-386.sh`. Real hostIPC workloads keep segments attached, so they're unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)