### PR TITLE
ci: fix integration/e2e jobs — run setup.sh + mirror Docker Hub via ECR Public (#388)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
         run: cargo build -p pelagos -p pelagos-dockerd -p pelagos-cri
       - name: Build rootfs
         run: sudo ./scripts/build-rootfs-tarball.sh
+      - name: Set up pelagos system directories
+        run: sudo ./scripts/setup.sh --no-user
       - name: Configure registry mirror (ECR Public — avoid Docker Hub rate limits)
         run: |
           sudo install -d /etc/pelagos
@@ -75,6 +77,8 @@ jobs:
           sudo apt-get install -y nftables iproute2 passt
       - name: Build rootfs
         run: sudo ./scripts/build-rootfs-tarball.sh
+      - name: Set up pelagos system directories
+        run: sudo ./scripts/setup.sh --no-user
       - name: Configure registry mirror (ECR Public — avoid Docker Hub rate limits)
         run: |
           sudo install -d /etc/pelagos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
         run: cargo build -p pelagos -p pelagos-dockerd -p pelagos-cri
       - name: Build rootfs
         run: sudo ./scripts/build-rootfs-tarball.sh
+      - name: Configure registry mirror (ECR Public — avoid Docker Hub rate limits)
+        run: |
+          sudo install -d /etc/pelagos
+          sudo install -m 0644 ci/registries.toml /etc/pelagos/registries.toml
       - name: Reset test environment
         run: sudo ./scripts/reset-test-env.sh
       - name: Run integration tests
@@ -71,6 +75,10 @@ jobs:
           sudo apt-get install -y nftables iproute2 passt
       - name: Build rootfs
         run: sudo ./scripts/build-rootfs-tarball.sh
+      - name: Configure registry mirror (ECR Public — avoid Docker Hub rate limits)
+        run: |
+          sudo install -d /etc/pelagos
+          sudo install -m 0644 ci/registries.toml /etc/pelagos/registries.toml
       - name: Reset test environment
         run: sudo ./scripts/reset-test-env.sh
       - name: Run e2e tests

--- a/ci/registries.toml
+++ b/ci/registries.toml
@@ -1,0 +1,15 @@
+# Registry mirror config for CI (installed to /etc/pelagos/registries.toml).
+#
+# GitHub Actions runners are cloud-hosted and share IPs, so anonymous Docker Hub
+# pulls hit the per-IP rate limit and fail the integration/e2e jobs. The nazgul
+# Zot cache (docs/ZOT_MIRROR_SETUP.md) can't help — it lives on the home LAN
+# (192.168.89.2), unreachable from the runners.
+#
+# AWS ECR Public mirrors the Docker Hub official images at
+# public.ecr.aws/docker/<repo> and is internet-reachable without the Docker Hub
+# per-IP limit. pelagos (src/registry_mirror.rs, #319) rewrites
+# docker.io/<repo> -> public.ecr.aws/docker/<repo>, stores the image under its
+# canonical ref (so `pelagos run alpine` is unchanged), and falls back to
+# docker.io if ECR is unavailable.
+[mirrors]
+"docker.io" = ["https://public.ecr.aws/docker"]

--- a/src/registry_mirror.rs
+++ b/src/registry_mirror.rs
@@ -112,6 +112,26 @@ mod tests {
     }
 
     #[test]
+    fn test_rewrite_reference_ecr_public_path_prefix() {
+        // ECR Public mirrors Docker Hub official images under a `/docker` path
+        // prefix (public.ecr.aws/docker/library/<image>). A mirror endpoint with
+        // a path component must be preserved so the rewritten reference resolves
+        // to the correct ECR repository. This is what the CI mirror config relies
+        // on (ci/registries.toml, issue #388).
+        let out = rewrite_reference(
+            "docker.io/library/alpine:latest",
+            "https://public.ecr.aws/docker",
+        );
+        assert_eq!(out, "public.ecr.aws/docker/library/alpine:latest");
+        // Trailing slash on the endpoint must not double up.
+        let out = rewrite_reference(
+            "docker.io/library/busybox:1.36",
+            "https://public.ecr.aws/docker/",
+        );
+        assert_eq!(out, "public.ecr.aws/docker/library/busybox:1.36");
+    }
+
+    #[test]
     fn test_is_insecure_endpoint() {
         assert!(is_insecure_endpoint("http://nazgul:5000"));
         assert!(!is_insecure_endpoint("https://mirror.example.com"));


### PR DESCRIPTION
Closes #388.

## What CI's own run revealed
The `integration-tests` and `e2e-tests` jobs were red on **every** run. There were **two** independent causes, and the first masked the second:

1. **Missing `scripts/setup.sh`** (primary). `pelagos image pull`/`run` reject the environment in their install preflight when `/var/lib/pelagos` isn't initialised — `installation problems detected: … mode 0755 (expected at least 2775)`. First CI run of this PR showed **173** such messages and **0** `via mirror` / `0` `Rate exceeded`: the pulls never reached the network. So the ~147 integration "pre-test alpine pull failed" failures were **not** Docker Hub rate limits — they were this.
2. **Docker Hub rate limits** (secondary). Once the preflight passes, pulls hit the network; anonymous docker.io pulls on shared GitHub Actions IPs are rate-limited. The nazgul Zot cache can't help (LAN-only, `192.168.89.2`).

## Fix (both, in the two test jobs)
- `sudo ./scripts/setup.sh --no-user` — idempotent; creates the `pelagos` group and `/var/lib/pelagos` with the expected modes. Lets pull/run pass the preflight.
- `ci/registries.toml` → `/etc/pelagos/registries.toml` — redirects Docker Hub through **AWS ECR Public** (`public.ecr.aws/docker/<repo>`), storing under the canonical ref (so `pelagos run alpine` is unchanged), with docker.io fallback. Unit test `test_rewrite_reference_ecr_public_path_prefix` pins the path-prefix rewrite.

## Validation
- ECR mirror validated locally: full uncached `hello-world` pull via `public.ecr.aws/docker`, stored canonically; ECR `alpine:latest` and `alpine:3.21` manifests both return HTTP 200.
- The real proof is this PR's re-run of `integration-tests` / `e2e-tests`.

## Out of scope
`wasm-e2e` / `wasm-embedded-e2e` failures are unrelated (Wasm module execution: `hello wasm`, `--env`, `--bind`).