### PR TITLE
fix(seccomp): allow capset in the minimal profile (#390)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -132,6 +132,20 @@ Applies the minimal seccomp profile and attempts `exit 0`. Does not assert succe
 failure — the minimal profile may be too strict for even `ash` to start. Verifies
 only that the filter compiles and can be applied without a Rust error.
 
+### `test_seccomp_minimal_allows_process_with_cap_drop`
+**Requires:** root, rootfs
+
+Regression test for #390. pelagos installs the seccomp filter while still holding
+`CAP_SYS_ADMIN` (so it need not set `no_new_privs` — see `apply_filter_no_nnp`) and then
+drops capabilities with `capset(2)` **after** the filter is active. Runs `/bin/echo` under
+the minimal profile **with `drop_all_capabilities()`** and asserts the process succeeds and
+prints `seccomp-min-ok`. Failure (spawn returns `Operation not permitted`) means
+`minimal_filter()` is missing `capset`, so the post-seccomp cap drop is denied and *every*
+spawn under the minimal profile fails — the bug that broke
+`pelagos run --security-opt seccomp=minimal` and the e2e suite. Unlike
+`test_seccomp_minimal_is_restrictive` (no cap drop, tolerates failure), this test exercises
+the post-seccomp `capset` path and asserts success.
+
 ### `test_seccomp_profile_api`
 **Type:** API-only
 

--- a/src/seccomp.rs
+++ b/src/seccomp.rs
@@ -281,7 +281,9 @@ pub fn minimal_filter() -> Result<BpfProgram, io::Error> {
 
     // Only allow essential syscalls for basic process execution.
     // This is restrictive but sufficient to run simple statically- or
-    // dynamically-linked binaries (e.g. /bin/echo on Alpine/musl).
+    // dynamically-linked binaries (e.g. /bin/echo on Alpine/musl), including
+    // the capability syscalls pelagos itself invokes after installing the
+    // filter (see the Capabilities note below).
     let allowed_syscalls = vec![
         // Process lifecycle
         "exit",
@@ -386,6 +388,14 @@ pub fn minimal_filter() -> Result<BpfProgram, io::Error> {
         "getresgid",
         "getrlimit",
         "prlimit64",
+        // Capabilities. pelagos applies the seccomp filter while still holding
+        // CAP_SYS_ADMIN (so it can install the filter without setting
+        // no_new_privs — see apply_filter_no_nnp), then drops to the final
+        // capability set with capset(2) *after* the filter is active. The
+        // profile must therefore allow capset/capget or every spawn under the
+        // minimal profile fails with EPERM at that post-seccomp cap drop (#390).
+        "capset",
+        "capget",
         // Arch-specific / thread setup
         "arch_prctl",
         "set_tid_address",

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -661,6 +661,64 @@ mod security {
         // Test passes if we got here (seccomp was applied)
     }
 
+    /// test_seccomp_minimal_allows_process_with_cap_drop
+    ///
+    /// Requires: root, rootfs.
+    ///
+    /// Regression test for #390. pelagos installs the seccomp filter while still
+    /// holding CAP_SYS_ADMIN (so it need not set no_new_privs — see
+    /// apply_filter_no_nnp) and then drops capabilities with capset(2) *after*
+    /// the filter is active. If the minimal profile does not permit capset, that
+    /// post-seccomp cap drop returns EPERM and EVERY spawn under the minimal
+    /// profile fails with "spawn failed: Operation not permitted" — the symptom
+    /// that broke `pelagos run --security-opt seccomp=minimal` and the e2e suite.
+    ///
+    /// Runs /bin/echo under the minimal profile WITH a full capability drop and
+    /// asserts the process runs and prints its output, which only holds if
+    /// capset is in minimal_filter()'s allow-list. The pre-existing
+    /// test_seccomp_minimal_is_restrictive does not drop caps and tolerates
+    /// spawn failure, so it never exercised this path.
+    #[test]
+    fn test_seccomp_minimal_allows_process_with_cap_drop() {
+        if !is_root() {
+            eprintln!("Skipping test_seccomp_minimal_allows_process_with_cap_drop: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!(
+                "Skipping test_seccomp_minimal_allows_process_with_cap_drop: alpine-rootfs not found"
+            );
+            return;
+        };
+
+        let mut child = Command::new("/bin/echo")
+            .args(["seccomp-min-ok"])
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Piped)
+            .stderr(Stdio::Piped)
+            .with_chroot(&rootfs)
+            .env("PATH", ALPINE_PATH)
+            .with_namespaces(Namespace::UTS | Namespace::MOUNT)
+            .with_proc_mount()
+            .drop_all_capabilities()
+            .with_seccomp_minimal()
+            .spawn()
+            .expect("spawn under minimal seccomp + cap drop must not fail (capset allowed — #390)");
+
+        let (status, stdout, stderr) = child.wait_with_output().expect("wait_with_output");
+
+        assert!(
+            status.success(),
+            "process under minimal seccomp + cap drop should succeed; stderr: {}",
+            String::from_utf8_lossy(&stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&stdout).contains("seccomp-min-ok"),
+            "expected 'seccomp-min-ok' in stdout, got: {:?}",
+            String::from_utf8_lossy(&stdout)
+        );
+    }
+
     #[test]
     fn test_seccomp_without_flag_works() {
         if !is_root() {


### PR DESCRIPTION
Closes #390.

## Problem
`pelagos run --security-opt seccomp=minimal <image> /bin/echo hi` fails for **every** command:
```
pelagos: error: spawn failed: Failed to spawn process: Operation not permitted (os error 1)
```
Reproduces locally (omen) and in CI — it was the single remaining `e2e-tests` failure after #389.

## Root cause (an ordering subtlety)
pelagos installs the seccomp filter while still holding `CAP_SYS_ADMIN` so it can do so **without** setting `no_new_privs` (`apply_filter_no_nnp`, from #384), then drops to the final capability set with `capset(2)` **after** the filter is active. strace of the container child:
```
prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, ...)   = 0
capset(...)                                        = -1 EPERM
```
`minimal_filter()` didn't allow `capset`, so that post-seccomp cap drop was denied and the spawn aborted before `execve`. The Docker **default** profile allows `capset`, which is why `seccomp=default` worked all along.

## Fix
Add `capset`/`capget` to `minimal_filter()`. The minimal profile stays very restrictive (no mount, ptrace, network admin, etc.); it now just permits the capability syscalls pelagos itself needs to finish container setup — exactly as the default profile does.

## Test
`test_seccomp_minimal_allows_process_with_cap_drop` runs `/bin/echo` under the minimal profile **with `drop_all_capabilities()`** and asserts it prints its output. Verified it **fails** with "Operation not permitted" without this change and **passes** with it. Once merged, the `seccomp=minimal` e2e assertion passes and the e2e CI job goes fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)