### PR TITLE
ci: run setup.sh in the wasm e2e jobs (#392)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
           echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
       - name: Build pelagos
         run: cargo build
+      - name: Set up pelagos system directories
+        run: sudo ./scripts/setup.sh --no-user
       - name: Run Wasm e2e tests
         run: sudo -E env "PATH=$PATH" bash scripts/test-wasm-e2e.sh
 
@@ -119,5 +121,7 @@ jobs:
         run: |
           curl -fsSL https://wasmtime.dev/install.sh | bash
           echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+      - name: Set up pelagos system directories
+        run: sudo ./scripts/setup.sh --no-user
       - name: Run embedded Wasm e2e tests
         run: sudo -E env "PATH=$PATH" bash scripts/test-wasm-embedded-e2e.sh


### PR DESCRIPTION
Closes #392.

## Cause
The `wasm-e2e-tests` and `wasm-embedded-e2e-tests` jobs were the last two red CI jobs (integration/e2e/lint/unit are green after #389/#391). Not a wasmtime issue — the **same missing-`setup.sh`** root cause as #389:

`scripts/test-wasm-e2e.sh` / `test-wasm-embedded-e2e.sh` write a synthetic Wasm image to `/var/lib/pelagos/{layers,images}` and then exercise `pelagos image ls` / `run` / `build`. With `/var/lib/pelagos` uninitialised, the install preflight rejects every one of those, so all the image/run assertions fail.

## Fix
Add `sudo ./scripts/setup.sh --no-user` to both wasm jobs (same step #389 added to integration/e2e).

## Verification
Both scripts pass locally where `setup.sh` has been run: `test-wasm-e2e.sh` → **7 passed / 0 failed**; `test-wasm-embedded-e2e.sh` → **9 passed / 0 failed** (1 skipped locally only because the `wasm32-wasip2` std target isn't installed; CI installs it). The PR's own wasm CI jobs are the proof.

With this, all six CI jobs are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)