### PR TITLE
refactor: unify sandbox namespace-mode handling (#395)

### DIFF
--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -803,18 +803,19 @@ impl RuntimeService for RuntimeSvc {
             .collect();
         let cni_cap_args = cni::port_mapping_cap_args(&sandbox_port_mappings);
 
-        // Host IPC namespace mode (namespace_options.ipc == NODE). When set, the
-        // pause must not unshare IPC so the pod shares the host IPC namespace
-        // (hostIPC: true — #386). Read it up front: the pause is spawned before
-        // the CriSandbox struct (which also records this) is built.
-        let sandbox_ipc_ns_mode = config
+        // Network / PID / IPC namespace sharing modes — read from the pod's
+        // NamespaceOption exactly once here, then reused for the pause flags and
+        // stored in the sandbox state (rather than re-derived in several places).
+        // Read up front because the pause is spawned before the CriSandbox struct.
+        let namespaces = config
             .linux
             .as_ref()
             .and_then(|l| l.security_context.as_ref())
             .and_then(|sc| sc.namespace_options.as_ref())
-            .map(|no| no.ipc)
-            .unwrap_or(0);
-        let host_ipc = sandbox_ipc_ns_mode == 2;
+            .map(|no| state::NamespaceModes::from_cri(no.network, no.pid, no.ipc))
+            .unwrap_or_default();
+        // hostIPC (#386): the pause skips unshare(IPC) so the pod shares host IPC.
+        let host_ipc = namespaces.host_ipc();
 
         // Try CNI networking first; fall back to pelagos native if no config is present.
         let (sandbox_id, netns, ip, cni_conf, pause_pid) = if let Some(conf_path) =
@@ -947,8 +948,15 @@ impl RuntimeService for RuntimeSvc {
             };
 
             // Write pelagos-format sandbox state so `pelagos run --sandbox` works.
-            state::write_pelagos_sandbox_state(&id, Some(&meta.name), pause_pid, &ns_name, &ip)
-                .map_err(|e| Status::internal(format!("write sandbox state: {}", e)))?;
+            state::write_pelagos_sandbox_state(
+                &id,
+                Some(&meta.name),
+                pause_pid,
+                &ns_name,
+                &ip,
+                namespaces,
+            )
+            .map_err(|e| Status::internal(format!("write sandbox state: {}", e)))?;
 
             // Apply pod hostname + sysctls into the pause namespaces — but ONLY after
             // confirming the pause has unshared UTS/IPC, so nsenter targets the POD
@@ -1040,20 +1048,7 @@ impl RuntimeService for RuntimeSvc {
                 .as_ref()
                 .map(|d| d.options.clone())
                 .unwrap_or_default(),
-            pid_namespace_mode: config
-                .linux
-                .as_ref()
-                .and_then(|l| l.security_context.as_ref())
-                .and_then(|sc| sc.namespace_options.as_ref())
-                .map(|no| no.pid)
-                .unwrap_or(0),
-            ipc_namespace_mode: config
-                .linux
-                .as_ref()
-                .and_then(|l| l.security_context.as_ref())
-                .and_then(|sc| sc.namespace_options.as_ref())
-                .map(|no| no.ipc)
-                .unwrap_or(0),
+            namespaces,
             port_mappings: sandbox_port_mappings,
         };
 
@@ -1702,13 +1697,13 @@ impl RuntimeService for RuntimeSvc {
             args.push(g.to_string());
         }
 
-        // DNS config, cgroup placement, and PID namespace mode from the pod sandbox.
+        // DNS config, cgroup placement, and host-PID flag from the pod sandbox.
         let (
             sandbox_dns_servers,
             sandbox_dns_searches,
             sandbox_dns_options,
             sandbox_cgroup_parent,
-            sandbox_pid_ns_mode,
+            sandbox_host_pid,
         ) = {
             let st = self.state.inner.lock().await;
             st.sandboxes
@@ -1719,7 +1714,7 @@ impl RuntimeService for RuntimeSvc {
                         s.dns_searches.clone(),
                         s.dns_options.clone(),
                         s.cgroup_parent.clone(),
-                        s.pid_namespace_mode,
+                        s.namespaces.host_pid(),
                     )
                 })
                 .unwrap_or_default()
@@ -1738,7 +1733,7 @@ impl RuntimeService for RuntimeSvc {
         }
         // NODE PID namespace mode (hostPID: true): run in the host PID namespace so
         // the SPIRE agent can attest workloads via SO_PEERCRED (PID 0 is never returned).
-        if sandbox_pid_ns_mode == 2 {
+        if sandbox_host_pid {
             args.push("--no-pid-ns".into());
         }
 
@@ -1864,17 +1859,17 @@ impl RuntimeService for RuntimeSvc {
             args.push(format!("--memory-swap={}", container.memory_swap_limit));
         }
 
-        // Host IPC namespace mode (sandbox namespace_options.ipc == 2).
+        // Host IPC namespace mode (sandbox namespace_options.ipc == NODE).
         // Pass --no-ipc-ns to skip IPC namespace unsharing so the container
         // shares the host IPC namespace (hostIPC: true in the pod spec).
-        let sandbox_ipc_ns_mode = {
+        let sandbox_host_ipc = {
             let st = self.state.inner.lock().await;
             st.sandboxes
                 .get(&container.sandbox_id)
-                .map(|s| s.ipc_namespace_mode)
-                .unwrap_or(0)
+                .map(|s| s.namespaces.host_ipc())
+                .unwrap_or(false)
         };
-        if sandbox_ipc_ns_mode == 2 {
+        if sandbox_host_ipc {
             args.push("--no-ipc-ns".into());
         }
 
@@ -3458,8 +3453,7 @@ mod tests {
             dns_servers: vec!["10.96.0.10".into()],
             dns_searches: vec!["default.svc.cluster.local".into(), "cluster.local".into()],
             dns_options: vec!["ndots:5".into()],
-            pid_namespace_mode: 0,
-            ipc_namespace_mode: 0,
+            namespaces: state::NamespaceModes::default(),
             port_mappings: vec![],
         };
 
@@ -3498,8 +3492,7 @@ mod tests {
             dns_servers: vec![],
             dns_searches: vec![],
             dns_options: vec![],
-            pid_namespace_mode: 0,
-            ipc_namespace_mode: 0,
+            namespaces: state::NamespaceModes::default(),
             port_mappings: vec![],
         };
 

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -8,6 +8,85 @@ use tokio::sync::Mutex;
 const SANDBOXES_DIR: &str = "/run/pelagos-cri/sandboxes";
 const CONTAINERS_DIR: &str = "/run/pelagos-cri/containers";
 
+// ── Namespace modes ──────────────────────────────────────────────────────────
+//
+// Mirror of `pelagos::sandbox::{NsMode, NamespaceModes}`. pelagos-cri is a lean
+// CRI shim that shells out to the `pelagos` binary rather than linking the
+// runtime library (which would pull in cgroups-rs/seccompiler/oci-client/...), so
+// the type is duplicated here. The two stay compatible through the sandbox-state
+// JSON contract: serde serialises the `NsMode` unit variants as the strings
+// "Pod"/"Container"/"Node", which the library deserialises back into its own enum.
+
+/// How a single Linux namespace is shared for a sandbox, mirroring the CRI
+/// `NamespaceMode` enum: `Pod` (0), `Container` (1), `Node` (2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum NsMode {
+    /// Isolated namespace shared among the pod's containers (CRI `POD`).
+    #[default]
+    Pod,
+    /// Per-container isolated namespace (CRI `CONTAINER`).
+    Container,
+    /// The host namespace — no isolation (CRI `NODE`, e.g. `hostNetwork`).
+    Node,
+}
+
+impl NsMode {
+    /// Convert a CRI `NamespaceMode` i32 (0=`POD`, 1=`CONTAINER`, 2=`NODE`).
+    pub fn from_cri(mode: i32) -> Self {
+        match mode {
+            2 => NsMode::Node,
+            1 => NsMode::Container,
+            _ => NsMode::Pod,
+        }
+    }
+
+    /// True if this is the host namespace (CRI `NODE`).
+    pub fn is_host(self) -> bool {
+        matches!(self, NsMode::Node)
+    }
+}
+
+/// Network / PID / IPC namespace sharing modes for a sandbox, read from the pod's
+/// CRI `NamespaceOption` exactly once and carried through sandbox state.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct NamespaceModes {
+    /// Network namespace mode (`hostNetwork: true` ⇒ `Node`).
+    #[serde(default)]
+    pub network: NsMode,
+    /// PID namespace mode (`hostPID: true` ⇒ `Node`).
+    #[serde(default)]
+    pub pid: NsMode,
+    /// IPC namespace mode (`hostIPC: true` ⇒ `Node`).
+    #[serde(default)]
+    pub ipc: NsMode,
+}
+
+impl NamespaceModes {
+    /// Build from a CRI `NamespaceOption`'s (network, pid, ipc) i32 modes.
+    pub fn from_cri(network: i32, pid: i32, ipc: i32) -> Self {
+        NamespaceModes {
+            network: NsMode::from_cri(network),
+            pid: NsMode::from_cri(pid),
+            ipc: NsMode::from_cri(ipc),
+        }
+    }
+    /// True when the pod shares the host network namespace.
+    // Consumed by the HostNetwork branch (#394); the `network` mode is already
+    // captured and persisted here so that work only adds the call site.
+    #[allow(dead_code)]
+    pub fn host_network(&self) -> bool {
+        self.network.is_host()
+    }
+    /// True when the pod shares the host IPC namespace.
+    pub fn host_ipc(&self) -> bool {
+        self.ipc.is_host()
+    }
+    /// True when the pod shares the host PID namespace.
+    pub fn host_pid(&self) -> bool {
+        self.pid.is_host()
+    }
+}
+
 // ── CRI sandbox metadata ─────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -53,14 +132,11 @@ pub struct CriSandbox {
     /// DNS resolver options from the pod DNS config.
     #[serde(default)]
     pub dns_options: Vec<String>,
-    /// PID namespace mode from namespace_options.pid:
-    ///   0 = POD (isolated, default), 1 = CONTAINER (isolated), 2 = NODE (host PID namespace).
+    /// Network / PID / IPC namespace sharing modes, read once from the pod's
+    /// `NamespaceOption` (POD / CONTAINER / NODE). Replaces the former separate
+    /// `pid_namespace_mode` / `ipc_namespace_mode` i32 fields and adds `network`.
     #[serde(default)]
-    pub pid_namespace_mode: i32,
-    /// IPC namespace mode from namespace_options.ipc:
-    ///   0 = POD (isolated, default), 1 = CONTAINER (isolated), 2 = NODE (host IPC namespace).
-    #[serde(default)]
-    pub ipc_namespace_mode: i32,
+    pub namespaces: NamespaceModes,
     /// Host port mappings (PodSandboxConfig.port_mappings) — passed to the CNI
     /// portmap plugin as capability args at ADD and (for cleanup) at DEL.
     #[serde(default)]
@@ -416,6 +492,7 @@ pub fn write_pelagos_sandbox_state(
     pause_pid: i32,
     ns_name: &str,
     container_ip: &str,
+    namespaces: NamespaceModes,
 ) -> std::io::Result<()> {
     let dir = format!("{}/{}", PELAGOS_SANDBOXES_DIR, id);
     std::fs::create_dir_all(&dir)?;
@@ -427,6 +504,7 @@ pub fn write_pelagos_sandbox_state(
         "ns_name": ns_name,
         "veth_host": "",        // CNI owns its own veth — pelagos must not delete it
         "container_ip": container_ip,
+        "namespaces": namespaces,
     });
     std::fs::write(
         format!("{}/state.json", dir),

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -56,6 +56,70 @@ impl From<io::Error> for SandboxError {
     }
 }
 
+// ── Namespace modes ──────────────────────────────────────────────────────────
+
+/// How a single Linux namespace is shared for a sandbox, mirroring the CRI
+/// `NamespaceMode` enum (runtime.v1): `Pod` (0), `Container` (1), `Node` (2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum NsMode {
+    /// Isolated namespace shared among the pod's containers (CRI `POD`).
+    #[default]
+    Pod,
+    /// Per-container isolated namespace (CRI `CONTAINER`).
+    Container,
+    /// The host namespace — no isolation (CRI `NODE`, e.g. `hostNetwork`).
+    Node,
+}
+
+impl NsMode {
+    /// Convert a CRI `NamespaceMode` i32 (0=`POD`, 1=`CONTAINER`, 2=`NODE`).
+    pub fn from_cri(mode: i32) -> Self {
+        match mode {
+            2 => NsMode::Node,
+            1 => NsMode::Container,
+            _ => NsMode::Pod,
+        }
+    }
+
+    /// True if this is the host namespace (CRI `NODE`).
+    pub fn is_host(self) -> bool {
+        matches!(self, NsMode::Node)
+    }
+}
+
+/// The network / PID / IPC namespace sharing modes for a sandbox.
+///
+/// Read from the CRI `NamespaceOption` exactly once (in `RunPodSandbox`) and
+/// carried through sandbox state, so the pause, container join, and teardown all
+/// consult one source of truth rather than re-deriving from scattered fields.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct NamespaceModes {
+    /// Network namespace mode (`hostNetwork: true` ⇒ `Node`).
+    #[serde(default)]
+    pub network: NsMode,
+    /// PID namespace mode (`hostPID: true` ⇒ `Node`).
+    #[serde(default)]
+    pub pid: NsMode,
+    /// IPC namespace mode (`hostIPC: true` ⇒ `Node`).
+    #[serde(default)]
+    pub ipc: NsMode,
+}
+
+impl NamespaceModes {
+    /// True when the pod shares the host network namespace.
+    pub fn host_network(&self) -> bool {
+        self.network.is_host()
+    }
+    /// True when the pod shares the host IPC namespace.
+    pub fn host_ipc(&self) -> bool {
+        self.ipc.is_host()
+    }
+    /// True when the pod shares the host PID namespace.
+    pub fn host_pid(&self) -> bool {
+        self.pid.is_host()
+    }
+}
+
 // ── SandboxState ─────────────────────────────────────────────────────────────
 
 /// Persistent state for a running sandbox.
@@ -73,6 +137,11 @@ pub struct SandboxState {
     pub veth_host: String,
     /// Container IP assigned to the sandbox's eth0.
     pub container_ip: String,
+    /// Network / PID / IPC namespace sharing modes for the sandbox.
+    /// `#[serde(default)]` keeps state written before this field existed
+    /// loadable (defaults to all-`Pod`, i.e. the previous behaviour).
+    #[serde(default)]
+    pub namespaces: NamespaceModes,
 }
 
 impl SandboxState {
@@ -225,6 +294,8 @@ pub fn create_sandbox(name: Option<&str>) -> io::Result<SandboxState> {
         ns_name: ns_name.clone(),
         veth_host,
         container_ip,
+        // `pelagos sandbox create` (non-CRI) always uses isolated pod namespaces.
+        namespaces: NamespaceModes::default(),
     };
     state.save()?;
 
@@ -287,4 +358,59 @@ pub fn remove_sandbox(id: &str) -> io::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nsmode_from_cri() {
+        assert_eq!(NsMode::from_cri(0), NsMode::Pod);
+        assert_eq!(NsMode::from_cri(1), NsMode::Container);
+        assert_eq!(NsMode::from_cri(2), NsMode::Node);
+        // Unknown values default to the safe isolated Pod mode.
+        assert_eq!(NsMode::from_cri(99), NsMode::Pod);
+        assert!(NsMode::Node.is_host());
+        assert!(!NsMode::Pod.is_host());
+        assert!(!NsMode::Container.is_host());
+    }
+
+    #[test]
+    fn test_namespace_modes_host_helpers() {
+        let m = NamespaceModes {
+            network: NsMode::Node,
+            pid: NsMode::Pod,
+            ipc: NsMode::Node,
+        };
+        assert!(m.host_network());
+        assert!(!m.host_pid());
+        assert!(m.host_ipc());
+        // Default (all Pod) = fully isolated, the pre-refactor behaviour.
+        let d = NamespaceModes::default();
+        assert!(!d.host_network() && !d.host_pid() && !d.host_ipc());
+    }
+
+    #[test]
+    fn test_namespace_modes_serde_contract() {
+        // pelagos-cri serialises its mirror NamespaceModes into the sandbox-state
+        // JSON; the library must deserialise it back. The wire form is the unit
+        // variant names "Pod"/"Container"/"Node" — pin that so the two crates
+        // can't silently drift apart.
+        let m = NamespaceModes {
+            network: NsMode::Node,
+            pid: NsMode::Container,
+            ipc: NsMode::Pod,
+        };
+        let json = serde_json::to_string(&m).unwrap();
+        assert_eq!(json, r#"{"network":"Node","pid":"Container","ipc":"Pod"}"#);
+        let back: NamespaceModes = serde_json::from_str(&json).unwrap();
+        assert!(back.host_network() && !back.host_pid() && !back.host_ipc());
+        // A state blob written before this field existed still loads (serde default).
+        let legacy: SandboxState = serde_json::from_str(
+            r#"{"id":"x","name":null,"pause_pid":1,"ns_name":"n","veth_host":"","container_ip":"1.2.3.4"}"#,
+        )
+        .unwrap();
+        assert!(!legacy.namespaces.host_network());
+    }
 }


### PR DESCRIPTION
Closes #395. Behavior-preserving prep before HostNetwork (#394) and PodPID, addressing the "hodge-podge of conditions" the namespace handling was drifting into.

## Problem
Namespace sharing (each of network/pid/ipc is `POD | CONTAINER | NODE`) was encoded three different ways, and the CRI `NamespaceOption` was read in three places:
- `CriSandbox` stored `pid_namespace_mode: i32` + `ipc_namespace_mode: i32` (network not captured)
- the pause took an ad-hoc `--host-ipc` flag
- `CreateContainer`/`StartContainer` re-derived `--no-pid-ns`/`--no-ipc-ns` from the i32s
- `RunPodSandbox` read `namespace_options.ipc` separately for the pause

## Change (data model only — mechanics unchanged)
- `NsMode { Pod, Container, Node }` + `NamespaceModes { network, pid, ipc }` (with `from_cri` and `host_network()/host_ipc()/host_pid()` helpers) in `pelagos::sandbox`, mirrored in pelagos-cri.
  - pelagos-cri deliberately does **not** link the runtime lib (it's a lean shim that shells out), so the type is duplicated; the two stay compatible through the sandbox-state JSON contract, pinned by `test_namespace_modes_serde_contract` (the wire form is the unit-variant strings `"Pod"/"Container"/"Node"`).
- `CriSandbox`: the two i32 fields → one `namespaces: NamespaceModes`.
- `RunPodSandbox` reads the `NamespaceOption` **once**; pause `--host-ipc` and `CreateContainer`'s `--no-*-ns` derive from the struct.
- pelagos `SandboxState` gains `namespaces` (`#[serde(default)]`), written by `write_pelagos_sandbox_state` — the field #394's `with_sandbox` NET-skip will consult.

Per-namespace mechanics (IPC skips unshare, NET skips CNI/setns, PID is the fork-init) genuinely differ and are intentionally **not** merged — only the representation is unified.

## Validation (behavior-preserving)
- New unit tests: `from_cri` mapping, host-helpers, and the serde contract + legacy-state-loads check.
- `cargo test --lib` (385) + `cargo test -p pelagos-cri` (33) green; clippy `-D warnings` clean.
- HostIpc integration test passes; **ipc2 critest `HostIpc is true` 1/1** on the refactor build.

## Note
`CriSandbox`/`SandboxState` serialized shape changes (ephemeral `/run` state); in-flight sandboxes across the upgrade fall back to defaults — fine for a runtime that recreates sandboxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)