### PR TITLE
feat(cri): HostNetwork pods share the host network namespace (#394)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -5307,3 +5307,17 @@ System V IPC objects stay invisible inside the pod — exactly the critest "Host
 failure (`Expected '' to contain '6'`) this fixes. The pause is what `RunPodSandbox` spawns
 to hold pod namespaces open; CreateContainer passes `--host-ipc` to it when the sandbox's
 `namespace_options.ipc == NODE`.
+
+## `issue_347_no_host_destruction::test_sandbox_pause_host_net_shares_host_namespace`
+**Requires root** (spawns pauses; creates a named netns).
+CRI hostNetwork conformance (#394 / #352). Spawns the internal `sandbox __pause__` process
+with `--host-net` (and a normal one that joins a named netns) and compares each pause's
+`/proc/<pid>/ns/net` inode against the host's `/proc/self/ns/net`. Asserts the inode
+**equals** the host's with `--host-net` (the pause stays in the host network namespace,
+`hostNetwork: true`) and **differs** for the normal pause (which `setns`-joins its own
+netns). Failure of the equal case means a hostNetwork pod's pause got an isolated netns, so
+containers joining the sandbox would not share the host network — the critest "HostNetwork
+is true" behaviour this implements. `RunPodSandbox` takes a dedicated hostNetwork branch
+(skip CNI/netns, report the node IP, spawn the pause with `--host-net`); `with_sandbox()`
+reads `SandboxState.namespaces.host_network()` to skip the container's NET join so it stays
+in the host netns too; `StopPodSandbox` auto-skips CNI teardown because `netns` is empty.

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -816,11 +816,52 @@ impl RuntimeService for RuntimeSvc {
             .unwrap_or_default();
         // hostIPC (#386): the pause skips unshare(IPC) so the pod shares host IPC.
         let host_ipc = namespaces.host_ipc();
+        // hostNetwork (#394): the pod uses the host network namespace — no CNI,
+        // no netns; the pause stays in host net and containers skip the NET join.
+        let host_network = namespaces.host_network();
 
-        // Try CNI networking first; fall back to pelagos native if no config is present.
-        let (sandbox_id, netns, ip, cni_conf, pause_pid) = if let Some(conf_path) =
-            cni::find_cni_conf()
-        {
+        // hostNetwork takes a dedicated branch (no CNI); otherwise try CNI first
+        // and fall back to pelagos native bridge networking.
+        let (sandbox_id, netns, ip, cni_conf, pause_pid) = if host_network {
+            // ── HostNetwork path: no CNI, no netns; share the host network ──
+            let id = generate_id();
+            let ip = node_primary_ipv4();
+
+            // Pause: --host-net keeps it in host net (skips the netns setns);
+            // --host-ipc additionally keeps host IPC. ns_name is unused by the
+            // pause in this mode, so pass an empty placeholder.
+            let mut pause_argv: Vec<&str> = vec!["sandbox", "__pause__", "", "--host-net"];
+            if host_ipc {
+                pause_argv.push("--host-ipc");
+            }
+            let pause_pid = spawn_sandbox_pause(&bin, &id, &pause_argv).await?;
+
+            // Store ns_name="" so StopPodSandbox skips CNI/netns teardown.
+            state::write_pelagos_sandbox_state(
+                &id,
+                Some(&meta.name),
+                pause_pid,
+                "",
+                &ip,
+                namespaces,
+            )
+            .map_err(|e| Status::internal(format!("write sandbox state: {}", e)))?;
+
+            // Apply the pod hostname into the pause's UTS namespace once unshared.
+            // Skip sysctls: a hostNetwork pod has no private netns, so net sysctls
+            // would target the host; UTS/host sysctls apply by definition.
+            if !sandbox_hostname.is_empty() && wait_for_pause_ns_unshare(pause_pid).await {
+                apply_pod_hostname(pause_pid, &sandbox_hostname).await;
+            }
+
+            log::info!(
+                "hostNetwork sandbox {} created: host network namespace, ip={}",
+                id,
+                ip
+            );
+
+            (id, String::new(), ip, String::new(), pause_pid)
+        } else if let Some(conf_path) = cni::find_cni_conf() {
             // ── CNI path ───────────────────────────────────────────────────
             let id = generate_id();
             let ns_name = format!("pcri-{}", &id[..12]);
@@ -897,55 +938,7 @@ impl RuntimeService for RuntimeSvc {
             if host_ipc {
                 pause_argv.push("--host-ipc");
             }
-            let pause_pid = if scope::systemd_available() {
-                let unit = scope::sandbox_unit(&id);
-                // A re-run for the same sandbox id would collide with a lingering
-                // unit; clear any stale one first (best effort).
-                scope::stop_unit(&unit).await;
-                let argv = scope::build_service_argv(&unit, &bin, &pause_argv);
-                let out = tokio::process::Command::new(&argv[0])
-                    .args(&argv[1..])
-                    .output()
-                    .await
-                    .map_err(|e| Status::internal(format!("systemd-run pause: {}", e)))?;
-                if !out.status.success() {
-                    return Err(Status::internal(format!(
-                        "systemd-run pause failed: {}",
-                        String::from_utf8_lossy(&out.stderr).trim()
-                    )));
-                }
-                // MainPID is populated asynchronously once systemd forks the unit.
-                let mut pid = 0;
-                for _ in 0..40 {
-                    if let Some(p) = scope::service_main_pid(&unit).await {
-                        pid = p;
-                        break;
-                    }
-                    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-                }
-                if pid <= 0 {
-                    scope::stop_unit(&unit).await;
-                    return Err(Status::internal(format!(
-                        "pause unit {} did not report a MainPID",
-                        unit
-                    )));
-                }
-                pid
-            } else {
-                let pause = std::process::Command::new(&bin)
-                    .args(&pause_argv)
-                    .stdin(std::process::Stdio::null())
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null())
-                    .spawn()
-                    .map_err(|e| Status::internal(format!("spawn pause process: {}", e)))?;
-                let pid = pause.id() as i32;
-                // Intentionally leaked — killed explicitly on StopPodSandbox.
-                std::mem::forget(pause);
-                // Brief pause for the process to enter namespaces before containers join.
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                pid
-            };
+            let pause_pid = spawn_sandbox_pause(&bin, &id, &pause_argv).await?;
 
             // Write pelagos-format sandbox state so `pelagos run --sandbox` works.
             state::write_pelagos_sandbox_state(
@@ -2749,6 +2742,85 @@ fn resolve_container_argv(
         Vec::new()
     };
     (entrypoint, cmd)
+}
+
+// ── Sandbox pause spawn + host networking helpers ─────────────────────────────
+
+/// Spawn the sandbox pause process and return its PID.
+///
+/// Under systemd the pause runs as a transient service under `pelagos.slice`
+/// (created by PID 1) so it survives a `pelagos-cri` restart and the sandbox is
+/// re-adopted rather than torn down (#336). The pause blocks forever, so it must
+/// be a backgrounded *service* (not a `--scope`, which would block); its real PID
+/// is the unit's MainPID. Off systemd we fall back to a plain leaked child
+/// (killed explicitly on StopPodSandbox). `pause_argv` carries the namespace
+/// flags (`--host-ipc` / `--host-net`).
+async fn spawn_sandbox_pause(bin: &str, id: &str, pause_argv: &[&str]) -> Result<i32, Status> {
+    if scope::systemd_available() {
+        let unit = scope::sandbox_unit(id);
+        // A re-run for the same sandbox id would collide with a lingering unit;
+        // clear any stale one first (best effort).
+        scope::stop_unit(&unit).await;
+        let argv = scope::build_service_argv(&unit, bin, pause_argv);
+        let out = tokio::process::Command::new(&argv[0])
+            .args(&argv[1..])
+            .output()
+            .await
+            .map_err(|e| Status::internal(format!("systemd-run pause: {}", e)))?;
+        if !out.status.success() {
+            return Err(Status::internal(format!(
+                "systemd-run pause failed: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            )));
+        }
+        // MainPID is populated asynchronously once systemd forks the unit.
+        let mut pid = 0;
+        for _ in 0..40 {
+            if let Some(p) = scope::service_main_pid(&unit).await {
+                pid = p;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        if pid <= 0 {
+            scope::stop_unit(&unit).await;
+            return Err(Status::internal(format!(
+                "pause unit {} did not report a MainPID",
+                unit
+            )));
+        }
+        Ok(pid)
+    } else {
+        let pause = std::process::Command::new(bin)
+            .args(pause_argv)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map_err(|e| Status::internal(format!("spawn pause process: {}", e)))?;
+        let pid = pause.id() as i32;
+        // Intentionally leaked — killed explicitly on StopPodSandbox.
+        std::mem::forget(pause);
+        // Brief pause for the process to enter namespaces before containers join.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        Ok(pid)
+    }
+}
+
+/// The node's primary IPv4 address — reported as the sandbox IP for hostNetwork
+/// pods (whose pod IP is the node IP). Uses the UDP-connect trick: connecting a
+/// UDP socket sends no packets but makes the kernel pick the source address that
+/// would route to the target, i.e. the node's primary interface. Falls back to
+/// loopback if there is no route (e.g. an isolated test host).
+fn node_primary_ipv4() -> String {
+    use std::net::UdpSocket;
+    UdpSocket::bind("0.0.0.0:0")
+        .and_then(|s| {
+            s.connect("8.8.8.8:53")?;
+            s.local_addr()
+        })
+        .map(|a| a.ip().to_string())
+        .unwrap_or_else(|_| "127.0.0.1".to_string())
 }
 
 // ── Pod-level settings applied to the pause namespaces (#354/#355) ─────────────

--- a/src/cli/sandbox.rs
+++ b/src/cli/sandbox.rs
@@ -43,6 +43,10 @@ pub enum SandboxCmd {
         /// Don't unshare IPC — the pod shares the host IPC namespace (hostIPC: true).
         #[clap(long = "host-ipc")]
         host_ipc: bool,
+        /// Don't join a netns — the pod shares the host network namespace
+        /// (hostNetwork: true). `ns_name` is ignored for the network join.
+        #[clap(long = "host-net")]
+        host_net: bool,
     },
 }
 
@@ -53,7 +57,11 @@ pub fn cmd_sandbox(cmd: SandboxCmd) -> Result<(), Box<dyn std::error::Error>> {
         SandboxCmd::Create { name } => cmd_sandbox_create(name.as_deref()),
         SandboxCmd::Ls { json } => cmd_sandbox_ls(json),
         SandboxCmd::Rm { id } => cmd_sandbox_rm(&id),
-        SandboxCmd::Pause { ns_name, host_ipc } => cmd_sandbox_pause(&ns_name, host_ipc),
+        SandboxCmd::Pause {
+            ns_name,
+            host_ipc,
+            host_net,
+        } => cmd_sandbox_pause(&ns_name, host_ipc, host_net),
     }
 }
 
@@ -121,30 +129,42 @@ fn cmd_sandbox_rm(id: &str) -> Result<(), Box<dyn std::error::Error>> {
 /// the pause does **not** unshare IPC, so `/proc/<pause>/ns/ipc` is the host IPC
 /// namespace.  Containers join that namespace via `with_sandbox()`, making host
 /// System V IPC objects visible inside the pod (CRI conformance #386 / #352).
-fn cmd_sandbox_pause(ns_name: &str, host_ipc: bool) -> Result<(), Box<dyn std::error::Error>> {
-    // Join the named network namespace.
-    let netns_path = format!("/run/netns/{}", ns_name);
-    let netns_c = std::ffi::CString::new(netns_path.as_bytes())
-        .map_err(|e| format!("invalid netns path: {}", e))?;
+///
+/// When `host_net` is set (pod `hostNetwork: true`, `namespace_options.network ==
+/// NODE`) the pause does **not** `setns` into a netns — it stays in the host
+/// network namespace, and `with_sandbox()` skips the NET join so containers stay
+/// in the host netns too (CRI conformance #394 / #352).
+fn cmd_sandbox_pause(
+    ns_name: &str,
+    host_ipc: bool,
+    host_net: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Join the named network namespace — unless this is a hostNetwork pod, in
+    // which case there is no named netns and the pause stays in the host netns.
+    if !host_net {
+        let netns_path = format!("/run/netns/{}", ns_name);
+        let netns_c = std::ffi::CString::new(netns_path.as_bytes())
+            .map_err(|e| format!("invalid netns path: {}", e))?;
 
-    let fd = unsafe { libc::open(netns_c.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC) };
-    if fd < 0 {
-        return Err(format!(
-            "open netns '{}': {}",
-            netns_path,
-            std::io::Error::last_os_error()
-        )
-        .into());
-    }
-    let rc = unsafe { libc::setns(fd, libc::CLONE_NEWNET) };
-    unsafe { libc::close(fd) };
-    if rc != 0 {
-        return Err(format!(
-            "setns netns '{}': {}",
-            netns_path,
-            std::io::Error::last_os_error()
-        )
-        .into());
+        let fd = unsafe { libc::open(netns_c.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC) };
+        if fd < 0 {
+            return Err(format!(
+                "open netns '{}': {}",
+                netns_path,
+                std::io::Error::last_os_error()
+            )
+            .into());
+        }
+        let rc = unsafe { libc::setns(fd, libc::CLONE_NEWNET) };
+        unsafe { libc::close(fd) };
+        if rc != 0 {
+            return Err(format!(
+                "setns netns '{}': {}",
+                netns_path,
+                std::io::Error::last_os_error()
+            )
+            .into());
+        }
     }
 
     // Unshare UTS (pod hostname) and — unless the pod requested host IPC — IPC,

--- a/src/container.rs
+++ b/src/container.rs
@@ -1622,14 +1622,26 @@ impl Command {
             ));
         }
 
-        let net_ns = state.net_ns_path();
         let ipc_ns = state.ipc_ns_path();
         let uts_ns = state.uts_ns_path();
 
-        Ok(self
-            .with_namespace_join(net_ns, Namespace::NET)
+        // IPC and UTS are always joined (the pause holds the pod's — or, for
+        // hostIPC, the host's — IPC/UTS namespace open).
+        let mut cmd = self
             .with_namespace_join(ipc_ns, Namespace::IPC)
-            .with_namespace_join(uts_ns, Namespace::UTS))
+            .with_namespace_join(uts_ns, Namespace::UTS);
+
+        // NET: for a hostNetwork pod there is no named netns and the pause stays
+        // in the host network namespace. The container already inherits the host
+        // netns (it does not unshare NET and `--sandbox` skips standard net
+        // setup), so we must NOT join anything — joining the empty
+        // `/run/netns/` path would fail. For a normal pod, join the sandbox's
+        // named netns so the container gets the pod IP (#394).
+        if !state.namespaces.host_network() {
+            cmd = cmd.with_namespace_join(state.net_ns_path(), Namespace::NET);
+        }
+
+        Ok(cmd)
     }
 
     /// Automatically mount /proc filesystem after chroot.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -28707,4 +28707,95 @@ mod issue_347_no_host_destruction {
             host_ipc_inode
         );
     }
+
+    /// test_sandbox_pause_host_net_shares_host_namespace
+    ///
+    /// Requires: root (spawns pauses; creates a named netns).
+    ///
+    /// Spawns the internal `sandbox __pause__` process with `--host-net` (and a
+    /// normal one that joins a named netns) and compares each pause's
+    /// `/proc/<pid>/ns/net` inode against the host's `/proc/self/ns/net`.
+    ///
+    /// Asserts the inode **equals** the host's with `--host-net` (the pause stays
+    /// in the host network namespace, `hostNetwork: true`) and **differs** for the
+    /// normal pause (which `setns`-joins its own netns). Failure of the equal case
+    /// means a hostNetwork pod's pause got an isolated netns, so containers joining
+    /// the sandbox would not share the host network — the CRI "HostNetwork is true"
+    /// conformance behaviour this implements (#394 / #352). `with_sandbox()` reads
+    /// `SandboxState.namespaces.host_network()` to skip the NET join so containers
+    /// stay in the host netns too.
+    #[test]
+    fn test_sandbox_pause_host_net_shares_host_namespace() {
+        if !is_root() {
+            eprintln!("Skipping test_sandbox_pause_host_net_shares_host_namespace: requires root");
+            return;
+        }
+        use std::os::unix::fs::MetadataExt;
+
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+        let host_net_inode = std::fs::metadata("/proc/self/ns/net")
+            .expect("stat /proc/self/ns/net")
+            .ino();
+
+        // host-net pause: --host-net skips the netns setns, so no netns is needed.
+        let mut host_child = std::process::Command::new(bin)
+            .args(["sandbox", "__pause__", "", "--host-net"])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn host-net pause");
+
+        // normal pause: needs a named netns to setns into.
+        let ns = format!("pel-hnet-{}", std::process::id());
+        let _ = std::process::Command::new("ip")
+            .args(["netns", "del", &ns])
+            .status();
+        assert!(
+            std::process::Command::new("ip")
+                .args(["netns", "add", &ns])
+                .status()
+                .expect("ip netns add")
+                .success(),
+            "ip netns add {} failed",
+            ns
+        );
+        let mut priv_child = std::process::Command::new(bin)
+            .args(["sandbox", "__pause__", &ns])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn netns pause");
+
+        // Allow the pauses to (not) setns and unshare.
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        let host_pause_inode = std::fs::metadata(format!("/proc/{}/ns/net", host_child.id()))
+            .expect("stat host-net pause ns/net")
+            .ino();
+        let priv_pause_inode = std::fs::metadata(format!("/proc/{}/ns/net", priv_child.id()))
+            .expect("stat netns pause ns/net")
+            .ino();
+
+        // Tear down before asserting so a failure still cleans up.
+        let _ = host_child.kill();
+        let _ = priv_child.kill();
+        let _ = host_child.wait();
+        let _ = priv_child.wait();
+        let _ = std::process::Command::new("ip")
+            .args(["netns", "del", &ns])
+            .status();
+
+        assert_eq!(
+            host_pause_inode, host_net_inode,
+            "pause --host-net should keep the host network namespace (inode {}), got {}",
+            host_net_inode, host_pause_inode
+        );
+        assert_ne!(
+            priv_pause_inode, host_net_inode,
+            "normal pause should join its own netns, but its inode matches the host's ({})",
+            host_net_inode
+        );
+    }
 }


### PR DESCRIPTION
Closes #394. Second of the three #352 host-namespace specs (after HostIpc #386), built on the #395 namespace-modes refactor. Guarded skip-CNI / host-netns branch — normal pods are untouched.

## Problem
critest *"runtime should support HostNetwork is true"* requires a pod with `hostNetwork: true` (`namespace_options.network == NODE`) to run its containers in the **host** network namespace (host interfaces/IP visible, pod IP == node IP). pelagos-cri ignored the network mode entirely — every pod got a CNI netns.

## Change
- **`RunPodSandbox`** takes a dedicated hostNetwork branch: skip `create_netns`/`cni_add`, report the node's primary IPv4 (UDP-connect trick) as the sandbox IP, spawn the pause with `--host-net`, and persist `netns=""` so `StopPodSandbox` auto-skips CNI/netns teardown.
- **Pause `--host-net`**: skips the `setns(netns)`, staying in host net.
- **`with_sandbox()`** reads `SandboxState.namespaces.host_network()` and skips the container's NET join — the container already inherits host net (no NET unshare; `--sandbox` skips standard net setup), so it stays in the host netns.
- **Refactor bonus**: the ~50-line pause-spawn (systemd unit vs leaked child) is factored into `spawn_sandbox_pause()`, shared by the CNI and hostNetwork branches instead of duplicated.

Normal pods (`network == POD`) keep the exact CNI path, guarded by the `network == NODE` branch.

## Tests
- `test_sandbox_pause_host_net_shares_host_namespace`: the `--host-net` pause's `/proc/<pid>/ns/net` inode **equals** the host's; a normal pause's **differs**. Passing.
- lib tests (385) + clippy `-D warnings` clean.

## ⏳ Pending: ipc2 critest verification
`HostNetwork is true` on ipc2 is **not yet run** (held for explicit go-ahead, since hostNetwork runs the container in the host net namespace). Will verify on ipc2 with the kubelet stopped before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)