### PR TITLE
feat(cri): PodPID — pod containers share one PID namespace (#398)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -5321,3 +5321,15 @@ is true" behaviour this implements. `RunPodSandbox` takes a dedicated hostNetwor
 (skip CNI/netns, report the node IP, spawn the pause with `--host-net`); `with_sandbox()`
 reads `SandboxState.namespaces.host_network()` to skip the container's NET join so it stays
 in the host netns too; `StopPodSandbox` auto-skips CNI teardown because `netns` is empty.
+
+## `issue_347_no_host_destruction::test_sandbox_pause_pod_pid_forks_init`
+**Requires root** (unshares a PID namespace; forks).
+CRI shareProcessNamespace / PodPID conformance (#398 / #352). Spawns the internal
+`sandbox __pause__` with `--pod-pid` (+`--host-net` to avoid needing a netns) and asserts the
+spawned process forks exactly one child — the **PID-1 init of a new PID namespace** (its
+`/proc/<child>/ns/pid` inode differs from the host's) — and that killing that PID-1 child
+**cascades**: the supervising parent's `waitpid` returns and it exits. This is the machinery
+behind the critest "PodPID" spec: the pause is PID 1 of a shared pod PID namespace that
+containers join via `with_sandbox()` (`SandboxState.namespaces.shared_pid()` adds a PID join;
+`CreateContainer` passes `--no-pid-ns` so the container does not unshare its own), so the
+container is never PID 1 and `cat /proc/1/cmdline` shows the pause, not the workload.

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -5333,3 +5333,19 @@ behind the critest "PodPID" spec: the pause is PID 1 of a shared pod PID namespa
 containers join via `with_sandbox()` (`SandboxState.namespaces.shared_pid()` adds a PID join;
 `CreateContainer` passes `--no-pid-ns` so the container does not unshare its own), so the
 container is never PID 1 and `cat /proc/1/cmdline` shows the pause, not the workload.
+
+## `issue_347_no_host_destruction::test_sandbox_pause_pod_pid_drains_with_shared_grandchild`
+**Requires root** and `nsenter` (util-linux); skipped if either is missing.
+Regression guard for the PodPID teardown deadlock (#399 / #400). Spawns the `--pod-pid` pause,
+then uses `nsenter --pid` to join the pause's PID namespace and leave **lingering grandchildren**
+(backgrounded `sleep`s whose launcher exits) — mimicking a container's worker processes that
+outlive their master and get reparented to the pause. It then SIGTERMs the pause's PID-1 init
+(what `StopPodSandbox` does) and asserts the pause **drains within ~3s**: the namespace collapse
+SIGKILLs and reaps the lingering grandchildren and the supervising parent exits. **Why it matters:**
+`pelagos-cri` SIGTERMs the pause and *drains it to full exit before* asking systemd to stop the
+pause's transient unit. If the pause could not collapse promptly with shared processes present,
+the subsequent `systemctl stop` would block host **PID 1** uninterruptibly in `cgroup_drain_dying`
+(waiting for the pause cgroup to empty) and wedge the entire node — ICMP still answers but every
+`fork`/SSH-session hangs. A failure here means the namespace-collapse invariant the drain relies on
+is broken. (The systemd-ordering half — drain-before-`systemctl stop` — is covered end-to-end by
+the critest `NamespaceOption` conformance bucket, which hung indefinitely before this fix.)

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -1073,6 +1073,7 @@ impl RuntimeService for RuntimeSvc {
     ) -> Result<Response<StopPodSandboxResponse>, Status> {
         let sandbox_id = request.into_inner().pod_sandbox_id;
         let bin = self.bin().await;
+        log::debug!("StopPodSandbox {} BEGIN", sandbox_id);
 
         let containers_to_stop: Vec<(String, MyContainerState)> = {
             let st = self.state.inner.lock().await;
@@ -1085,7 +1086,17 @@ impl RuntimeService for RuntimeSvc {
 
         for (pelagos_name, cstate) in &containers_to_stop {
             if *cstate == MyContainerState::Running {
+                log::debug!(
+                    "StopPodSandbox {} step=stop-container {}",
+                    sandbox_id,
+                    pelagos_name
+                );
                 let _ = run_pelagos(&bin, &["stop", pelagos_name]).await;
+                log::debug!(
+                    "StopPodSandbox {} step=stop-container {} DONE",
+                    sandbox_id,
+                    pelagos_name
+                );
             }
         }
 
@@ -1097,27 +1108,92 @@ impl RuntimeService for RuntimeSvc {
         if let Some(ref sb) = sandbox {
             if !sb.netns.is_empty() {
                 // ── CNI teardown ───────────────────────────────────────────────
+                // ORDER MATTERS, and the killer subtlety is systemd, not the network.
+                //
+                // The pause is PID 1 of the pod's PID namespace. Killing it collapses
+                // that namespace: the kernel SIGKILLs and reaps every process sharing
+                // it (the pause runs `zap_pid_ns_processes`). For a
+                // shareProcessNamespace (pid=POD) pod a container's workers outlive
+                // `pelagos stop` — the master dying does not reap them; they are
+                // reparented to the pause — so this collapse has real work to do.
+                //
+                // If we ask systemd to stop the pause's transient unit WHILE that
+                // collapse is in flight, systemd (host PID 1) blocks UNINTERRUPTIBLY
+                // in `cgroup_drain_dying` waiting for the pause cgroup to empty — but
+                // the pause can't leave the cgroup until its exit completes, and that
+                // exit deadlocks against the very cgroup teardown systemd is holding.
+                // PID 1 stuck in D wedges the ENTIRE host: ICMP still answers but every
+                // fork/SSH-session hangs (#399 PodPID teardown / #400). Confirmed via
+                // live `ps -o stat,wchan` capture of the hung node.
+                //
+                // So: SIGTERM the pause and WAIT for it to fully exit (drain) FIRST.
+                // Only once it is gone — cgroup already empty — is it safe to let
+                // systemd reap the unit. If the pause refuses to die, SKIP the systemd
+                // stop entirely: leaking a transient unit (it self-collects via
+                // --collect once it eventually dies) is infinitely preferable to
+                // hanging PID 1. Network teardown happens last, on a quiesced netns.
                 let netns_path = format!("/run/netns/{}", sb.netns);
+                let mut pause_drained = true;
+                if sb.pause_pid > 0 {
+                    log::debug!(
+                        "StopPodSandbox {} step=kill-pause pid={}",
+                        sandbox_id,
+                        sb.pause_pid
+                    );
+                    let _ = std::process::Command::new("kill")
+                        .args(["-TERM", &sb.pause_pid.to_string()])
+                        .output();
+                    pause_drained = false;
+                    // Bounded drain (~5s): poll until the pause is gone (ESRCH).
+                    for _ in 0..100 {
+                        if unsafe { libc::kill(sb.pause_pid, 0) } != 0 {
+                            pause_drained = true;
+                            break; // pause gone, pod PID ns fully collapsed
+                        }
+                        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                    }
+                    log::debug!(
+                        "StopPodSandbox {} step=kill-pause DONE drained={}",
+                        sandbox_id,
+                        pause_drained
+                    );
+                }
+                // Tear down the transient pause service (#336) — but ONLY after the
+                // pause has actually exited, so systemd's cgroup teardown finds an
+                // empty cgroup and cannot block PID 1. Skip it on a stuck pause.
+                if scope::systemd_available() {
+                    if pause_drained {
+                        log::debug!("StopPodSandbox {} step=stop_unit", sandbox_id);
+                        scope::stop_unit(&scope::sandbox_unit(&sandbox_id)).await;
+                        log::debug!("StopPodSandbox {} step=stop_unit DONE", sandbox_id);
+                    } else {
+                        log::warn!(
+                            "StopPodSandbox {} pause {} did not exit within drain window; \
+                             skipping `systemctl stop` to avoid wedging PID 1 — the transient \
+                             unit will self-collect (--collect) once the pause dies",
+                            sandbox_id,
+                            sb.pause_pid
+                        );
+                    }
+                }
                 if !sb.cni_conf.is_empty() {
                     let cap_args = cni::port_mapping_cap_args(&sb.port_mappings);
+                    log::debug!(
+                        "StopPodSandbox {} step=cni_del netns={}",
+                        sandbox_id,
+                        sb.netns
+                    );
                     cni::cni_del(
                         &sandbox_id,
                         &netns_path,
                         std::path::Path::new(&sb.cni_conf),
                         &cap_args,
                     );
+                    log::debug!("StopPodSandbox {} step=cni_del DONE", sandbox_id);
                 }
-                if sb.pause_pid > 0 {
-                    let _ = std::process::Command::new("kill")
-                        .args(["-TERM", &sb.pause_pid.to_string()])
-                        .output();
-                }
-                // Tear down the transient pause service (#336); harmless if the
-                // pause was launched as a plain child on a non-systemd host.
-                if scope::systemd_available() {
-                    scope::stop_unit(&scope::sandbox_unit(&sandbox_id)).await;
-                }
+                log::debug!("StopPodSandbox {} step=delete_netns", sandbox_id);
                 cni::delete_netns(&sb.netns);
+                log::debug!("StopPodSandbox {} step=delete_netns DONE", sandbox_id);
                 state::remove_pelagos_sandbox_state(&sandbox_id);
             } else {
                 // ── Pelagos native teardown ────────────────────────────────────
@@ -1130,6 +1206,7 @@ impl RuntimeService for RuntimeSvc {
             s.state = SandboxState::NotReady;
             let _ = state::save_sandbox(s);
         }
+        log::debug!("StopPodSandbox {} END", sandbox_id);
 
         Ok(Response::new(StopPodSandboxResponse {}))
     }

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -819,6 +819,9 @@ impl RuntimeService for RuntimeSvc {
         // hostNetwork (#394): the pod uses the host network namespace — no CNI,
         // no netns; the pause stays in host net and containers skip the NET join.
         let host_network = namespaces.host_network();
+        // shareProcessNamespace (#398): the pause forks a PID-1 init holding a
+        // shared pod PID namespace that containers join.
+        let pod_pid = namespaces.shared_pid();
 
         // hostNetwork takes a dedicated branch (no CNI); otherwise try CNI first
         // and fall back to pelagos native bridge networking.
@@ -828,13 +831,17 @@ impl RuntimeService for RuntimeSvc {
             let ip = node_primary_ipv4();
 
             // Pause: --host-net keeps it in host net (skips the netns setns);
-            // --host-ipc additionally keeps host IPC. ns_name is unused by the
-            // pause in this mode, so pass an empty placeholder.
+            // --host-ipc additionally keeps host IPC; --pod-pid makes it a PID-1
+            // init for a shared pod PID namespace. ns_name is unused by the pause
+            // in this mode, so pass an empty placeholder.
             let mut pause_argv: Vec<&str> = vec!["sandbox", "__pause__", "", "--host-net"];
             if host_ipc {
                 pause_argv.push("--host-ipc");
             }
-            let pause_pid = spawn_sandbox_pause(&bin, &id, &pause_argv).await?;
+            if pod_pid {
+                pause_argv.push("--pod-pid");
+            }
+            let pause_pid = spawn_sandbox_pause(&bin, &id, &pause_argv, pod_pid).await?;
 
             // Store ns_name="" so StopPodSandbox skips CNI/netns teardown.
             state::write_pelagos_sandbox_state(
@@ -932,13 +939,16 @@ impl RuntimeService for RuntimeSvc {
             // The pause blocks forever, so it must be a backgrounded *service*
             // (not a `--scope`, which would block); its real PID is the unit's
             // MainPID. Off systemd we fall back to a plain leaked child.
-            // pause argv: hostIPC pods append --host-ipc so the pause keeps the
-            // host IPC namespace instead of unsharing a private one (#386).
+            // pause argv: --host-ipc keeps host IPC (#386); --pod-pid makes the
+            // pause a PID-1 init for a shared pod PID namespace (#398).
             let mut pause_argv: Vec<&str> = vec!["sandbox", "__pause__", &ns_name];
             if host_ipc {
                 pause_argv.push("--host-ipc");
             }
-            let pause_pid = spawn_sandbox_pause(&bin, &id, &pause_argv).await?;
+            if pod_pid {
+                pause_argv.push("--pod-pid");
+            }
+            let pause_pid = spawn_sandbox_pause(&bin, &id, &pause_argv, pod_pid).await?;
 
             // Write pelagos-format sandbox state so `pelagos run --sandbox` works.
             state::write_pelagos_sandbox_state(
@@ -1696,7 +1706,7 @@ impl RuntimeService for RuntimeSvc {
             sandbox_dns_searches,
             sandbox_dns_options,
             sandbox_cgroup_parent,
-            sandbox_host_pid,
+            sandbox_ns,
         ) = {
             let st = self.state.inner.lock().await;
             st.sandboxes
@@ -1707,7 +1717,7 @@ impl RuntimeService for RuntimeSvc {
                         s.dns_searches.clone(),
                         s.dns_options.clone(),
                         s.cgroup_parent.clone(),
-                        s.namespaces.host_pid(),
+                        s.namespaces,
                     )
                 })
                 .unwrap_or_default()
@@ -1724,9 +1734,12 @@ impl RuntimeService for RuntimeSvc {
             args.push("--dns-option".into());
             args.push(opt.clone());
         }
-        // NODE PID namespace mode (hostPID: true): run in the host PID namespace so
-        // the SPIRE agent can attest workloads via SO_PEERCRED (PID 0 is never returned).
-        if sandbox_host_pid {
+        // The container must not unshare its own PID namespace when the pod uses
+        // the host PID namespace (hostPID/NODE — for SPIRE SO_PEERCRED attestation)
+        // or a shared pod PID namespace (shareProcessNamespace/POD — #398). In the
+        // shared case `with_sandbox` then joins the pod's PID namespace; in the
+        // host case the container simply stays in the host PID namespace.
+        if sandbox_ns.host_pid() || sandbox_ns.shared_pid() {
             args.push("--no-pid-ns".into());
         }
 
@@ -2746,7 +2759,45 @@ fn resolve_container_argv(
 
 // ── Sandbox pause spawn + host networking helpers ─────────────────────────────
 
-/// Spawn the sandbox pause process and return its PID.
+/// Spawn the sandbox pause and return the PID that **holds the pod namespaces**
+/// (the one containers join via `with_sandbox()`).
+///
+/// For a shared-PID pod (`pod_pid`, `--pod-pid`) the pause forks a PID-1 init
+/// child that actually holds the pod PID namespace; the spawned (MainPID) process
+/// is its parent/supervisor. We resolve and return the **child** pid in that case
+/// via `/proc/<parent>/task/<parent>/children`. Otherwise the spawned pid is the
+/// namespace holder.
+async fn spawn_sandbox_pause(
+    bin: &str,
+    id: &str,
+    pause_argv: &[&str],
+    pod_pid: bool,
+) -> Result<i32, Status> {
+    let parent = spawn_sandbox_pause_proc(bin, id, pause_argv).await?;
+    if !pod_pid {
+        return Ok(parent);
+    }
+    // The PID-1 init is the parent's only child; poll until it appears.
+    for _ in 0..80 {
+        if let Ok(s) = std::fs::read_to_string(format!("/proc/{}/task/{}/children", parent, parent))
+        {
+            if let Some(child) = s
+                .split_whitespace()
+                .next()
+                .and_then(|p| p.parse::<i32>().ok())
+            {
+                return Ok(child);
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    Err(Status::internal(format!(
+        "pod-pid pause {} did not fork a PID-1 init child",
+        parent
+    )))
+}
+
+/// Spawn the pause process and return the spawned (MainPID/parent) PID.
 ///
 /// Under systemd the pause runs as a transient service under `pelagos.slice`
 /// (created by PID 1) so it survives a `pelagos-cri` restart and the sandbox is
@@ -2754,8 +2805,8 @@ fn resolve_container_argv(
 /// be a backgrounded *service* (not a `--scope`, which would block); its real PID
 /// is the unit's MainPID. Off systemd we fall back to a plain leaked child
 /// (killed explicitly on StopPodSandbox). `pause_argv` carries the namespace
-/// flags (`--host-ipc` / `--host-net`).
-async fn spawn_sandbox_pause(bin: &str, id: &str, pause_argv: &[&str]) -> Result<i32, Status> {
+/// flags (`--host-ipc` / `--host-net` / `--pod-pid`).
+async fn spawn_sandbox_pause_proc(bin: &str, id: &str, pause_argv: &[&str]) -> Result<i32, Status> {
     if scope::systemd_available() {
         let unit = scope::sandbox_unit(id);
         // A re-run for the same sandbox id would collide with a lingering unit;

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -46,19 +46,36 @@ impl NsMode {
     }
 }
 
+/// Default PID namespace mode: `Container`, not `Pod` — PID is per-container
+/// unless a pod sets `shareProcessNamespace` (mirrors `pelagos::sandbox`; #398).
+fn default_pid_mode() -> NsMode {
+    NsMode::Container
+}
+
 /// Network / PID / IPC namespace sharing modes for a sandbox, read from the pod's
 /// CRI `NamespaceOption` exactly once and carried through sandbox state.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct NamespaceModes {
     /// Network namespace mode (`hostNetwork: true` ⇒ `Node`).
     #[serde(default)]
     pub network: NsMode,
-    /// PID namespace mode (`hostPID: true` ⇒ `Node`).
-    #[serde(default)]
+    /// PID namespace mode: `Pod` (shared), `Container` (per-container, default),
+    /// or `Node` (`hostPID`).
+    #[serde(default = "default_pid_mode")]
     pub pid: NsMode,
     /// IPC namespace mode (`hostIPC: true` ⇒ `Node`).
     #[serde(default)]
     pub ipc: NsMode,
+}
+
+impl Default for NamespaceModes {
+    fn default() -> Self {
+        NamespaceModes {
+            network: NsMode::Pod,
+            pid: default_pid_mode(),
+            ipc: NsMode::Pod,
+        }
+    }
 }
 
 impl NamespaceModes {
@@ -71,9 +88,6 @@ impl NamespaceModes {
         }
     }
     /// True when the pod shares the host network namespace.
-    // Consumed by the HostNetwork branch (#394); the `network` mode is already
-    // captured and persisted here so that work only adds the call site.
-    #[allow(dead_code)]
     pub fn host_network(&self) -> bool {
         self.network.is_host()
     }
@@ -84,6 +98,11 @@ impl NamespaceModes {
     /// True when the pod shares the host PID namespace.
     pub fn host_pid(&self) -> bool {
         self.pid.is_host()
+    }
+    /// True when the pod containers share a single pod PID namespace
+    /// (`shareProcessNamespace`, explicit CRI `pid == POD`; #398).
+    pub fn shared_pid(&self) -> bool {
+        matches!(self.pid, NsMode::Pod)
     }
 }
 

--- a/scripts/cri-conformance-398.sh
+++ b/scripts/cri-conformance-398.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Focused critest conformance run for #398 (PodPID — shared pod PID namespace).
+#   sudo bash scripts/cri-conformance-398.sh /tmp/cri-398.result
+set -u
+SOCK="unix:///run/pelagos/cri.sock"
+OUT="${1:-/tmp/cri-398.result}"
+FOCUS='PodPID'
+: > "$OUT"
+echo "# critest focus: $FOCUS" >> "$OUT"
+echo "# pelagos-cri: $(systemctl is-active pelagos-cri 2>/dev/null)" >> "$OUT"
+echo "# pelagos: $(/usr/local/bin/pelagos --version 2>/dev/null)" >> "$OUT"
+echo "# started: $(date -u +%FT%TZ)" >> "$OUT"
+echo "----------------------------------------" >> "$OUT"
+critest --runtime-endpoint "$SOCK" --ginkgo.focus="$FOCUS" >> "$OUT" 2>&1
+rc=$?
+echo "----------------------------------------" >> "$OUT"
+echo "# critest exit: $rc" >> "$OUT"
+exit "$rc"

--- a/scripts/cri-podpid-livestate-diag.sh
+++ b/scripts/cri-podpid-livestate-diag.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Like cri-podpid-teardown-diag.sh but CAPTURES LIVE PROCESS STATE during the
+# StopPodSandbox teardown — to identify exactly which process wedges into
+# uninterruptible (D) state and what it is blocked on (wchan). Writes everything
+# to persistent disk so it survives the connectivity wedge.
+#
+#   sudo bash scripts/cri-podpid-livestate-diag.sh
+set -u
+SOCK="unix:///run/pelagos/cri.sock"
+CRICTL="crictl --runtime-endpoint $SOCK --image-endpoint $SOCK"
+WORK="/home/cb/podpid-diag"; mkdir -p "$WORK"
+CAP="$WORK/livestate.log"; : > "$CAP"
+NGINX="registry.k8s.io/e2e-test-images/nginx:1.14-2"
+
+snap(){ # label -> append a process+net snapshot
+  { echo "===== SNAP $1 @ $(date +%T.%N) =====";
+    echo "-- D-state (uninterruptible) procs --";
+    ps -eo pid,ppid,stat,wchan:40,comm,args | awk 'NR==1 || $3 ~ /D/';
+    echo "-- pause / nginx / pelagos procs (stat,wchan) --";
+    ps -eo pid,ppid,stat,wchan:40,comm,args | grep -iE 'pause|nginx|pelagos|crictl' | grep -v 'grep\|awk';
+    echo "-- conntrack count: $(conntrack -C 2>/dev/null || echo n/a) --";
+  } >> "$CAP" 2>&1; }
+
+cat > "$WORK/pod.json" <<'JSON'
+{ "metadata": { "name": "podpid-live-sb", "namespace": "default", "uid": "podpid-live-uid", "attempt": 1 },
+  "log_directory": "/tmp",
+  "linux": { "security_context": { "namespace_options": { "network": 0, "pid": 0, "ipc": 0 } } } }
+JSON
+cat > "$WORK/ctr.json" <<JSON
+{ "metadata": { "name": "podpid-live-nginx", "attempt": 1 },
+  "image": { "image": "$NGINX" }, "log_path": "podpid-live-nginx.log",
+  "linux": { "security_context": { "namespace_options": { "network": 0, "pid": 0, "ipc": 0 } } } }
+JSON
+
+$CRICTL pull "$NGINX" >/dev/null 2>&1 || true
+POD=$($CRICTL runp "$WORK/pod.json") || { echo "runp FAILED" >>"$CAP"; exit 1; }
+CTR=$($CRICTL create "$POD" "$WORK/ctr.json" "$WORK/pod.json") && $CRICTL start "$CTR"
+echo "POD=$POD CTR=$CTR" >> "$CAP"
+sleep 1
+snap "running"
+echo "proc1: $($CRICTL exec "$CTR" cat /proc/1/cmdline 2>&1 | tr '\0' ' ')" >> "$CAP"
+
+# Launch the teardown in the background, then snapshot rapidly while it runs.
+( timeout 120 $CRICTL stopp "$POD" > "$WORK/stopp.out" 2>&1; echo "stopp rc=$? @ $(date +%T)" >> "$WORK/stopp.out" ) &
+STOPP=$!
+for i in $(seq 1 20); do snap "teardown+${i}"; sleep 1; done
+wait $STOPP 2>/dev/null
+
+{ echo "===== StopPodSandbox step journal =====";
+  journalctl -u pelagos-cri -b0 --no-pager -o cat 2>/dev/null | grep StopPodSandbox | tail -16;
+  echo "===== stopp.out ====="; cat "$WORK/stopp.out" 2>/dev/null; } >> "$CAP"
+echo "DONE — see $CAP" >> "$CAP"
+timeout 30 $CRICTL rmp -f "$POD" >/dev/null 2>&1 || true

--- a/scripts/cri-podpid-teardown-diag.sh
+++ b/scripts/cri-podpid-teardown-diag.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Surgical reproduction of the PodPID StopPodSandbox teardown hang, driven by
+# crictl (NOT the full critest suite — one pod, controlled teardown). Mirrors the
+# critest "PodPID" spec: a shared-PID pod sandbox + one nginx container, both with
+# namespace pid=POD, then `crictl stopp` (= StopPodSandbox) with a timeout.
+#
+# pelagos-cri must be the INSTRUMENTED build (logs StopPodSandbox step=... lines).
+# Everything is written to persistent disk + the journal so it survives the
+# connectivity loss the CNI teardown tends to trigger on this node.
+#
+#   sudo bash scripts/cri-podpid-teardown-diag.sh 2>&1 | tee /home/cb/podpid-diag.out
+set -u
+SOCK="unix:///run/pelagos/cri.sock"
+CRICTL="crictl --runtime-endpoint $SOCK --image-endpoint $SOCK"
+WORK="/home/cb/podpid-diag"
+NGINX="registry.k8s.io/e2e-test-images/nginx:1.14-2"
+mkdir -p "$WORK"
+
+echo "=== pelagos-cri version + instrumentation check ==="
+systemctl is-active pelagos-cri
+journalctl -u pelagos-cri -n1 --no-pager -o cat 2>/dev/null | head -1
+
+cat > "$WORK/pod.json" <<'JSON'
+{
+  "metadata": { "name": "podpid-diag-sb", "namespace": "default", "uid": "podpid-diag-uid", "attempt": 1 },
+  "log_directory": "/tmp",
+  "linux": {
+    "security_context": {
+      "namespace_options": { "network": 0, "pid": 0, "ipc": 0 }
+    }
+  }
+}
+JSON
+
+cat > "$WORK/ctr.json" <<JSON
+{
+  "metadata": { "name": "podpid-diag-nginx", "attempt": 1 },
+  "image": { "image": "$NGINX" },
+  "log_path": "podpid-diag-nginx.log",
+  "linux": {
+    "security_context": {
+      "namespace_options": { "network": 0, "pid": 0, "ipc": 0 }
+    }
+  }
+}
+JSON
+
+echo "=== ensure nginx image present ==="
+$CRICTL pull "$NGINX" >/dev/null 2>&1 || echo "(pull failed — may already be cached)"
+
+echo "=== RunPodSandbox (pid=POD) ==="
+POD=$($CRICTL runp "$WORK/pod.json") || { echo "runp FAILED"; exit 1; }
+echo "POD=$POD"
+
+echo "=== CreateContainer + StartContainer (pid=POD) ==="
+CTR=$($CRICTL create "$POD" "$WORK/ctr.json" "$WORK/pod.json") || { echo "create FAILED"; $CRICTL stopp "$POD"; $CRICTL rmp "$POD"; exit 1; }
+$CRICTL start "$CTR" || echo "start FAILED"
+echo "CTR=$CTR"
+sleep 1
+echo "=== verify shared PID ns: cat /proc/1/cmdline (should be the pause, NOT nginx) ==="
+$CRICTL exec "$CTR" cat /proc/1/cmdline 2>&1 | tr '\0' ' '; echo
+
+# Mark a journal cursor so we can dump exactly the StopPodSandbox logs.
+CURSOR=$(journalctl -u pelagos-cri -n0 --show-cursor 2>/dev/null | grep -o 'cursor: .*' | sed 's/cursor: //')
+
+echo "=== StopPodSandbox (crictl stopp) — TIMED, this is the suspect ==="
+t0=$(date +%s)
+timeout 60 $CRICTL stopp "$POD"
+RC=$?
+t1=$(date +%s)
+echo "stopp exit=$RC  elapsed=$((t1-t0))s   (124 == HUNG)"
+
+echo "=== StopPodSandbox step log (last step printed without a matching DONE = the hang) ==="
+if [ -n "$CURSOR" ]; then
+  journalctl -u pelagos-cri --after-cursor "$CURSOR" --no-pager -o cat 2>/dev/null | grep -E "StopPodSandbox" | tee "$WORK/stop-steps.log"
+else
+  journalctl -u pelagos-cri -n 60 --no-pager -o cat 2>/dev/null | grep -E "StopPodSandbox" | tee "$WORK/stop-steps.log"
+fi
+
+echo "=== cleanup (best effort) ==="
+timeout 30 $CRICTL rmp -f "$POD" 2>/dev/null
+echo "=== DONE rc=$RC ==="

--- a/scripts/podpid-cni-teardown-repro.sh
+++ b/scripts/podpid-cni-teardown-repro.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Reproduces the StopPodSandbox teardown hang for a shared-PID pod whose
+# container ALSO joined a non-host (CNI-style) network namespace.
+#
+# The host-net PodPID repro (podpid-local-repro.sh) skipped the NET-ns join; the
+# passing CNI critest specs skipped the PID-ns join. This exercises BOTH at once —
+# the only combination critest's PodPID spec hits that nothing else does:
+#   container joins  /run/netns/<name> (NET) + pod PID ns (PID) + pause IPC,
+# then `pelagos stop` (what StopPodSandbox runs first).
+#
+# The netns is a throwaway `ip netns` with only `lo` — NO flannel/bridge/veth/
+# Tailscale churn, so it cannot disturb host networking (safe on omen). Still run
+# caged:
+#   sudo systemd-run --scope -p MemoryMax=1500M -p TasksMax=400 -p CPUQuota=60% \
+#        --quiet timeout 120 bash scripts/podpid-cni-teardown-repro.sh
+set -u
+BIN="${BIN:-./target/debug/pelagos}"
+RT=/run/pelagos
+ID="podpidcni$$"
+SBDIR="$RT/sandboxes/$ID"
+CNAME="podpidcnic$$"
+NETNS="pcnirepro$$"
+IMG="${IMG:-alpine}"
+# CMD: the container workload. Default a do-nothing sleep; override with a real
+# listening/forking daemon (e.g. CMD='redis-server --port 6390') to mimic nginx.
+CMD="${CMD:-sleep 600}"
+PAUSE_PARENT=""; PAUSE_CHILD=""
+
+cleanup(){
+  echo "--- cleanup ---"
+  timeout 10 "$BIN" rm -f "$CNAME" >/dev/null 2>&1
+  [ -n "$PAUSE_CHILD"  ] && kill -KILL "$PAUSE_CHILD"  2>/dev/null
+  [ -n "$PAUSE_PARENT" ] && kill -KILL "$PAUSE_PARENT" 2>/dev/null
+  ip netns del "$NETNS" 2>/dev/null
+  rm -rf "$SBDIR"
+  echo "cleanup done"
+}
+trap cleanup EXIT
+
+echo "=== 0. create throwaway named netns (lo only) ==="
+ip netns add "$NETNS"
+ip netns exec "$NETNS" ip link set lo up
+echo "created /run/netns/$NETNS"
+
+echo "=== 1. spawn pod-pid pause INTO the netns (sandbox __pause__ <ns> --pod-pid) ==="
+# Exactly like the real CNI path: the pause joins /run/netns/<name>, unshares
+# IPC+UTS, then (--pod-pid) unshares PID and forks a PID-1 init — all INSIDE the
+# CNI netns. This is the fidelity gap the host-net repro missed.
+setsid "$BIN" sandbox __pause__ "$NETNS" --pod-pid >/dev/null 2>&1 < /dev/null &
+PAUSE_PARENT=$!
+sleep 1
+PAUSE_CHILD=$(awk '{print $1}' "/proc/$PAUSE_PARENT/task/$PAUSE_PARENT/children" 2>/dev/null)
+echo "pause parent=$PAUSE_PARENT  child(PID-1)=$PAUSE_CHILD"
+[ -z "$PAUSE_CHILD" ] && { echo "FAIL: pause did not fork a PID-1 child"; exit 1; }
+
+echo "=== 2. write sandbox state: network=Pod (join named netns) + pid=Pod (shared) ==="
+mkdir -p "$SBDIR"
+cat > "$SBDIR/state.json" <<JSON
+{"id":"$ID","name":"$ID","pause_pid":$PAUSE_CHILD,"ns_name":"$NETNS","veth_host":"","container_ip":"","namespaces":{"network":"Pod","pid":"Pod","ipc":"Pod"}}
+JSON
+echo "wrote $SBDIR/state.json (ns_name=$NETNS)"
+
+echo "=== 3. run --detach joining named-netns + pod-pid (timeout 25) ==="
+timeout 25 "$BIN" run --detach --name "$CNAME" --sandbox "$ID" --no-pid-ns "$IMG" $CMD
+RC=$?
+echo "run --detach exit=$RC"
+if [ $RC -eq 124 ]; then echo ">>> HANG AT START (netns-join + pod-pid)"; exit 0; fi
+if [ $RC -ne 0 ]; then echo ">>> run --detach FAILED (not a hang)"; exit 0; fi
+sleep 1
+echo "container netns: $(timeout 5 "$BIN" exec "$CNAME" sh -c 'readlink /proc/self/ns/net' 2>&1 | tr -d '\n')"
+
+echo "=== 4. graceful 'pelagos stop' — what StopPodSandbox runs FIRST (timeout 30) ==="
+t0=$(date +%s)
+timeout 30 "$BIN" stop "$CNAME"
+RC=$?
+t1=$(date +%s)
+echo "stop exit=$RC  elapsed=$((t1-t0))s"
+if [ $RC -eq 124 ]; then echo ">>> CONFIRMED: stop of a CNI+pod-pid container HANGS"; fi
+
+echo "=== DONE ==="

--- a/scripts/podpid-forking-teardown-repro.sh
+++ b/scripts/podpid-forking-teardown-repro.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Mimics nginx's process model in a shared pod PID ns: a master that forks worker
+# children. In a SHARED pid ns the workers are reparented to the pause (PID-1)
+# when the master dies — they are NOT killed by the kernel (unlike a normal pod
+# where the container's main IS PID-1). This tests whether `pelagos stop` leaves
+# lingering workers in the sandbox netns and whether teardown then blocks.
+#
+# Run caged:
+#   sudo systemd-run --scope -p MemoryMax=1500M -p TasksMax=400 -p CPUQuota=60% \
+#        --quiet timeout 120 bash scripts/podpid-forking-teardown-repro.sh
+set -u
+BIN="${BIN:-./target/debug/pelagos}"
+RT=/run/pelagos
+ID="podpidfork$$"
+SBDIR="$RT/sandboxes/$ID"
+CNAME="podpidforkc$$"
+NETNS="pforkrepro$$"
+IMG="${IMG:-alpine}"
+PAUSE_PARENT=""; PAUSE_CHILD=""
+
+cleanup(){
+  echo "--- cleanup ---"
+  timeout 10 "$BIN" rm -f "$CNAME" >/dev/null 2>&1
+  for p in $(ip netns pids "$NETNS" 2>/dev/null); do kill -KILL "$p" 2>/dev/null; done
+  [ -n "$PAUSE_CHILD"  ] && kill -KILL "$PAUSE_CHILD"  2>/dev/null
+  [ -n "$PAUSE_PARENT" ] && kill -KILL "$PAUSE_PARENT" 2>/dev/null
+  ip netns del "$NETNS" 2>/dev/null
+  rm -rf "$SBDIR"
+  echo "cleanup done"
+}
+trap cleanup EXIT
+
+ip netns add "$NETNS"; ip netns exec "$NETNS" ip link set lo up
+echo "netns /run/netns/$NETNS created"
+
+setsid "$BIN" sandbox __pause__ "$NETNS" --pod-pid >/dev/null 2>&1 < /dev/null &
+PAUSE_PARENT=$!; sleep 1
+PAUSE_CHILD=$(awk '{print $1}' "/proc/$PAUSE_PARENT/task/$PAUSE_PARENT/children" 2>/dev/null)
+echo "pause parent=$PAUSE_PARENT child(PID-1)=$PAUSE_CHILD"
+[ -z "$PAUSE_CHILD" ] && { echo "FAIL no pause child"; exit 1; }
+
+mkdir -p "$SBDIR"
+cat > "$SBDIR/state.json" <<JSON
+{"id":"$ID","name":"$ID","pause_pid":$PAUSE_CHILD,"ns_name":"$NETNS","veth_host":"","container_ip":"","namespaces":{"network":"Pod","pid":"Pod","ipc":"Pod"}}
+JSON
+
+# Master forks two workers that IGNORE SIGTERM (worst case: like a worker mid-request),
+# then the master execs a foreground process. `pelagos stop` SIGTERMs the master.
+WORKLOAD='trap "" TERM; (trap "" TERM; while :; do sleep 1; done) & (trap "" TERM; while :; do sleep 1; done) & exec sleep 600'
+echo "=== run --detach: master + 2 SIGTERM-ignoring workers (timeout 25) ==="
+timeout 25 "$BIN" run --detach --name "$CNAME" --sandbox "$ID" --no-pid-ns "$IMG" sh -c "$WORKLOAD"
+RC=$?
+echo "run exit=$RC"; [ $RC -ne 0 ] && { echo "run FAILED/HUNG"; exit 0; }
+sleep 1
+echo "procs in netns BEFORE stop: $(ip netns pids "$NETNS" 2>/dev/null | tr '\n' ' ')"
+
+echo "=== pelagos stop (timeout 30) ==="
+t0=$(date +%s); timeout 30 "$BIN" stop "$CNAME"; RC=$?; t1=$(date +%s)
+echo "stop exit=$RC elapsed=$((t1-t0))s  $([ $RC -eq 124 ] && echo '>>> STOP HUNG')"
+echo "procs in netns AFTER stop: $(ip netns pids "$NETNS" 2>/dev/null | tr '\n' ' ')"
+
+echo "=== probe production teardown steps with lingering workers ==="
+echo "kill -TERM pause child (step 3)..."
+kill -TERM "$PAUSE_CHILD" 2>/dev/null; sleep 1
+echo "procs in netns after kill-pause: $(ip netns pids "$NETNS" 2>/dev/null | tr '\n' ' ')"
+echo "ip netns del (delete_netns step) — TIMED:"
+t0=$(date +%s); timeout 20 ip netns del "$NETNS"; RC=$?; t1=$(date +%s)
+echo "ip netns del exit=$RC elapsed=$((t1-t0))s  $([ $RC -eq 124 ] && echo '>>> delete_netns HUNG')"
+NETNS=""  # already deleted
+echo "=== DONE ==="

--- a/scripts/podpid-local-repro.sh
+++ b/scripts/podpid-local-repro.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# SAFE local repro of the PodPID hang (#398 / #399).
+#
+# Sets up a shared-PID pod sandbox (pause `--pod-pid`), runs a detached container
+# that joins it, then execs into it (`cat /proc/1/cmdline`) — mirroring what the
+# critest "PodPID" spec does — to find which step hangs.
+#
+# SAFETY: every pelagos op is wrapped in `timeout`, and this is meant to be run
+# INSIDE a resource cage so a hang/leak/fork-bomb can't harm the host:
+#   sudo systemd-run --scope -p MemoryMax=1500M -p TasksMax=400 -p CPUQuota=60% \
+#        --quiet timeout 120 bash scripts/podpid-local-repro.sh
+set -u
+BIN="${BIN:-./target/debug/pelagos}"
+RT=/run/pelagos
+ID="podpidrepro$$"
+SBDIR="$RT/sandboxes/$ID"
+CNAME="podpidc$$"
+IMG="${IMG:-alpine}"
+PAUSE_PARENT=""; PAUSE_CHILD=""
+
+cleanup(){
+  echo "--- cleanup ---"
+  timeout 10 "$BIN" rm -f "$CNAME" >/dev/null 2>&1
+  [ -n "$PAUSE_CHILD"  ] && kill -KILL "$PAUSE_CHILD"  2>/dev/null
+  [ -n "$PAUSE_PARENT" ] && kill -KILL "$PAUSE_PARENT" 2>/dev/null
+  pkill -KILL -f "exec $CNAME" 2>/dev/null
+  rm -rf "$SBDIR"
+  echo "cleanup done"
+}
+trap cleanup EXIT
+
+echo "host pid-ns: $(readlink /proc/self/ns/pid)"
+
+echo "=== 1. spawn pod-pid pause (--host-net --pod-pid) ==="
+setsid "$BIN" sandbox __pause__ "" --host-net --pod-pid >/dev/null 2>&1 < /dev/null &
+PAUSE_PARENT=$!
+sleep 1
+PAUSE_CHILD=$(awk '{print $1}' "/proc/$PAUSE_PARENT/task/$PAUSE_PARENT/children" 2>/dev/null)
+echo "pause parent=$PAUSE_PARENT  child(PID-1)=$PAUSE_CHILD"
+[ -z "$PAUSE_CHILD" ] && { echo "FAIL: pause did not fork a PID-1 child"; exit 1; }
+echo "pause-child pid-ns: $(readlink /proc/$PAUSE_CHILD/ns/pid)  (differs from host = good)"
+
+echo "=== 2. write sandbox state (pid=Pod -> shared pod PID ns) ==="
+mkdir -p "$SBDIR"
+cat > "$SBDIR/state.json" <<JSON
+{"id":"$ID","name":"$ID","pause_pid":$PAUSE_CHILD,"ns_name":"","veth_host":"","container_ip":"","namespaces":{"network":"Node","pid":"Pod","ipc":"Pod"}}
+JSON
+echo "wrote $SBDIR/state.json"
+
+echo "=== 3. run --detach container joining the pod-pid sandbox (timeout 25) ==="
+# --no-pid-ns matches the CRI flow for shared-PID pods: the container must NOT
+# unshare its own PID ns; with_sandbox joins the pod PID ns instead (#398).
+timeout 25 "$BIN" run --detach --name "$CNAME" --sandbox "$ID" --no-pid-ns "$IMG" sleep 600
+RC=$?
+echo "run --detach exit=$RC  (124 = HUNG at START)"
+if [ $RC -eq 124 ]; then echo ">>> HANG IS AT CONTAINER START"; exit 0; fi
+if [ $RC -ne 0 ]; then echo ">>> run --detach FAILED (not a hang) — stopping"; exit 0; fi
+
+sleep 1
+echo "container row: $(timeout 8 "$BIN" ps -a 2>/dev/null | grep "$CNAME" || echo '(not listed)')"
+
+echo "=== 4. exec into the pod-pid container: cat /proc/1/cmdline (timeout 25) ==="
+OUT=$(timeout 25 "$BIN" exec "$CNAME" cat /proc/1/cmdline 2>&1)
+RC=$?
+echo "exec exit=$RC  (124 = HUNG at EXEC)"
+echo "exec output (NUL->space): $(printf '%s' "$OUT" | tr '\0' ' ')"
+if [ $RC -eq 124 ]; then echo ">>> HANG IS AT EXEC (cat /proc/1/cmdline)"; fi
+
+echo "=== DONE (no hang at start or exec if we got here) ==="

--- a/scripts/podpid-local-repro.sh
+++ b/scripts/podpid-local-repro.sh
@@ -66,4 +66,10 @@ echo "exec exit=$RC  (124 = HUNG at EXEC)"
 echo "exec output (NUL->space): $(printf '%s' "$OUT" | tr '\0' ' ')"
 if [ $RC -eq 124 ]; then echo ">>> HANG IS AT EXEC (cat /proc/1/cmdline)"; fi
 
-echo "=== DONE (no hang at start or exec if we got here) ==="
+echo "=== 5. graceful 'pelagos stop' (what StopPodSandbox does — timeout 20) ==="
+timeout 20 "$BIN" stop "$CNAME"
+RC=$?
+echo "stop exit=$RC  (124 = HUNG at STOP — this is the StopPodSandbox teardown hang)"
+if [ $RC -eq 124 ]; then echo ">>> CONFIRMED: graceful stop of a shared-PID container HANGS"; fi
+
+echo "=== DONE ==="

--- a/scripts/podpid-systemd-teardown-repro.sh
+++ b/scripts/podpid-systemd-teardown-repro.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Isolates the StopPodSandbox teardown hang for a shared-PID (pod-pid) sandbox.
+#
+# Mirrors pelagos-cri EXACTLY: the pause runs as a transient systemd *service*
+# with `--property=KillMode=mixed` (build_service_argv), then StopPodSandbox does
+#   1. kill -TERM <pause_pid==PID-1 child>     (runtime.rs line ~41-43)
+#   2. systemctl stop <unit>                   (runtime.rs line ~49)
+# We TIME each step. The host-net repro used a plain setsid pause (no unit), so it
+# never exercised KillMode=mixed — this does.
+#
+# Run caged:
+#   sudo systemd-run --scope -p MemoryMax=500M -p TasksMax=200 -p CPUQuota=50% \
+#        --quiet timeout 150 bash scripts/podpid-systemd-teardown-repro.sh
+set -u
+BIN="${BIN:-$PWD/target/debug/pelagos}"
+UNIT="pelagos-sbx-podpidteardown$$.service"
+
+cleanup(){ systemctl stop "$UNIT" >/dev/null 2>&1; systemctl reset-failed "$UNIT" >/dev/null 2>&1; }
+trap cleanup EXIT
+
+echo "=== 1. start pod-pid pause as a systemd service (KillMode=mixed, exactly like pelagos-cri) ==="
+systemd-run --collect --slice=pelagos.slice --unit="$UNIT" \
+  --property=KillMode=mixed --quiet -- \
+  "$BIN" sandbox __pause__ "" --host-net --pod-pid
+sleep 0.5
+MAIN=$(systemctl show -p MainPID --value "$UNIT")
+echo "unit=$UNIT  MainPID(parent)=$MAIN"
+[ -z "$MAIN" ] || [ "$MAIN" = 0 ] && { echo "FAIL: no MainPID"; exit 1; }
+CHILD=""
+for _ in $(seq 1 40); do
+  CHILD=$(awk '{print $1}' "/proc/$MAIN/task/$MAIN/children" 2>/dev/null)
+  [ -n "$CHILD" ] && break; sleep 0.025
+done
+echo "PID-1 child(pause_pid in state)=$CHILD"
+[ -z "$CHILD" ] && { echo "FAIL: no PID-1 child"; exit 1; }
+
+echo "=== 2. kill -TERM pause_pid (the child)  [runtime.rs:41-43] ==="
+t0=$(date +%s.%N)
+kill -TERM "$CHILD" 2>/dev/null
+# give it a moment, then observe whether parent+child actually died
+for _ in $(seq 1 40); do
+  kill -0 "$CHILD" 2>/dev/null || break; sleep 0.025
+done
+t1=$(date +%s.%N)
+CH_ALIVE=$(kill -0 "$CHILD" 2>/dev/null && echo YES || echo no)
+PA_ALIVE=$(kill -0 "$MAIN"  2>/dev/null && echo YES || echo no)
+printf "after SIGTERM->child (%.2fs): child_alive=%s parent_alive=%s\n" "$(echo "$t1-$t0"|bc)" "$CH_ALIVE" "$PA_ALIVE"
+[ "$CH_ALIVE" = YES ] && echo ">>> child IGNORED SIGTERM (PID-1 handler not firing from host?)"
+[ "$PA_ALIVE" = YES ] && [ "$CH_ALIVE" = no ] && echo ">>> child died but PARENT still alive (parent waitpid loop stuck?)"
+
+echo "=== 3. systemctl stop \$UNIT  [runtime.rs:49] — TIMED ==="
+t0=$(date +%s.%N)
+timeout 120 systemctl stop "$UNIT"
+RC=$?
+t1=$(date +%s.%N)
+printf "systemctl stop exit=%s  elapsed=%.2fs\n" "$RC" "$(echo "$t1-$t0"|bc)"
+if [ "$RC" = 124 ]; then echo ">>> stop_unit HUNG (>120s)"; fi
+# A ~90s elapsed == hit TimeoutStopSec then SIGKILL == THE BUG
+echo "=== DONE ==="

--- a/src/cli/sandbox.rs
+++ b/src/cli/sandbox.rs
@@ -47,6 +47,10 @@ pub enum SandboxCmd {
         /// (hostNetwork: true). `ns_name` is ignored for the network join.
         #[clap(long = "host-net")]
         host_net: bool,
+        /// Become PID 1 of a shared pod PID namespace (shareProcessNamespace:
+        /// true) by unsharing PID and forking an init child.
+        #[clap(long = "pod-pid")]
+        pod_pid: bool,
     },
 }
 
@@ -61,7 +65,8 @@ pub fn cmd_sandbox(cmd: SandboxCmd) -> Result<(), Box<dyn std::error::Error>> {
             ns_name,
             host_ipc,
             host_net,
-        } => cmd_sandbox_pause(&ns_name, host_ipc, host_net),
+            pod_pid,
+        } => cmd_sandbox_pause(&ns_name, host_ipc, host_net, pod_pid),
     }
 }
 
@@ -134,10 +139,18 @@ fn cmd_sandbox_rm(id: &str) -> Result<(), Box<dyn std::error::Error>> {
 /// NODE`) the pause does **not** `setns` into a netns — it stays in the host
 /// network namespace, and `with_sandbox()` skips the NET join so containers stay
 /// in the host netns too (CRI conformance #394 / #352).
+///
+/// When `pod_pid` is set (pod `shareProcessNamespace: true`,
+/// `namespace_options.pid == POD`) the pause becomes the PID-1 init of a shared
+/// pod PID namespace: it `unshare(CLONE_NEWPID)`s and forks, the **child** is
+/// PID 1 (reaps zombies, exits on SIGTERM) and the **parent** supervises it
+/// (so the systemd MainPID stays stable, preserving #336 restart-survival).
+/// Containers join `/proc/<child>/ns/pid` via `with_sandbox()` (#398 / #352).
 fn cmd_sandbox_pause(
     ns_name: &str,
     host_ipc: bool,
     host_net: bool,
+    pod_pid: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Join the named network namespace — unless this is a hostNetwork pod, in
     // which case there is no named netns and the pause stays in the host netns.
@@ -181,6 +194,39 @@ fn cmd_sandbox_pause(
         return Err(format!("unshare UTS/IPC: {}", std::io::Error::last_os_error()).into());
     }
 
+    // Shared pod PID namespace (shareProcessNamespace). A process can't put
+    // *itself* into a new PID namespace — unshare(CLONE_NEWPID) only places future
+    // children there — so we unshare and fork: the child is PID 1 of the pod PID
+    // namespace, the parent supervises it (keeping the spawned/MainPID stable).
+    if pod_pid {
+        let rc = unsafe { libc::unshare(libc::CLONE_NEWPID) };
+        if rc != 0 {
+            return Err(format!("unshare PID: {}", std::io::Error::last_os_error()).into());
+        }
+        let child = unsafe { libc::fork() };
+        if child < 0 {
+            return Err(format!("fork pod-pid init: {}", std::io::Error::last_os_error()).into());
+        }
+        if child == 0 {
+            // ── Child: PID 1 of the pod PID namespace (the real pause/init) ──
+            // run_pid1_init_loop() diverges (it is the init's forever-loop).
+            run_pid1_init_loop();
+        }
+        // ── Parent: supervise the PID-1 child; exit when it does so the systemd
+        // unit / leaked child cleanly finishes (teardown SIGKILLs the cgroup,
+        // which includes the child; killing PID 1 tears the pod PID ns down). ──
+        let mut status: libc::c_int = 0;
+        loop {
+            let r = unsafe { libc::waitpid(child, &mut status, 0) };
+            if r == child
+                || (r < 0 && std::io::Error::last_os_error().raw_os_error() != Some(libc::EINTR))
+            {
+                break;
+            }
+        }
+        return Ok(());
+    }
+
     // Block until terminated. `pause()` returns on ANY caught signal — a stray
     // SIGCHLD/SIGURG/SIGWINCH or a handler the runtime installs — so calling it
     // once would let the first such signal exit the pause, orphaning the
@@ -190,6 +236,38 @@ fn cmd_sandbox_pause(
     // real termination signal (SIGTERM from `pelagos sandbox rm` / systemd
     // KillMode, which terminates the process regardless) ends the pause.
     loop {
+        unsafe { libc::pause() };
+    }
+}
+
+/// PID-1 init loop for a shared pod PID namespace (#398). Runs in the pause's
+/// child after `unshare(CLONE_NEWPID)` + `fork`. PID 1 has two init duties:
+///   - **Reap** orphaned zombies (pod container processes are reparented here on
+///     exit) — otherwise they accumulate in the pod PID namespace.
+///   - **Exit on SIGTERM** — the kernel ignores default-action signals for PID 1,
+///     so without a handler `systemctl stop` could only SIGKILL it after the stop
+///     timeout. A SIGTERM handler makes teardown prompt (and, since PID 1 exiting
+///     tears the namespace down, also kills any lingering container processes).
+fn run_pid1_init_loop() -> ! {
+    use nix::sys::signal::{signal, SigHandler, Signal};
+
+    extern "C" fn on_term(_: libc::c_int) {
+        // PID 1 exiting collapses the pod PID namespace.
+        unsafe { libc::_exit(0) };
+    }
+    // A no-op SIGCHLD handler ensures `pause()` returns so we can reap.
+    extern "C" fn on_chld(_: libc::c_int) {}
+
+    unsafe {
+        let _ = signal(Signal::SIGTERM, SigHandler::Handler(on_term));
+        let _ = signal(Signal::SIGCHLD, SigHandler::Handler(on_chld));
+    }
+
+    loop {
+        // Reap every dead child without blocking.
+        let mut status: libc::c_int = 0;
+        while unsafe { libc::waitpid(-1, &mut status, libc::WNOHANG) } > 0 {}
+        // Sleep until the next signal (SIGCHLD to reap, SIGTERM to exit).
         unsafe { libc::pause() };
     }
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -1641,6 +1641,16 @@ impl Command {
             cmd = cmd.with_namespace_join(state.net_ns_path(), Namespace::NET);
         }
 
+        // PID: for a shared-PID pod (shareProcessNamespace) join the pod PID
+        // namespace held by the pause's PID-1 child, so containers see each
+        // other's processes and the pause is PID 1. The caller must NOT also
+        // unshare PID (CreateContainer passes --no-pid-ns); the spawn's existing
+        // setns(CLONE_NEWPID)+fork path puts the container into the pod PID ns as
+        // a non-1 PID. Container/Node PID modes don't join here (#398).
+        if state.namespaces.shared_pid() {
+            cmd = cmd.with_namespace_join(state.pid_ns_path(), Namespace::PID);
+        }
+
         Ok(cmd)
     }
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -87,22 +87,43 @@ impl NsMode {
     }
 }
 
+/// Default PID namespace mode: `Container` (per-container isolation), **not**
+/// `Pod`. This matches Kubernetes/CRI semantics — network and IPC are pod-shared
+/// by default, but the PID namespace is per-container unless a pod explicitly
+/// sets `shareProcessNamespace` (CRI `pid == POD`). Using `Container` as the
+/// default means an absent `NamespaceOption` (and legacy sandbox state) never
+/// accidentally enables PID sharing (#398).
+fn default_pid_mode() -> NsMode {
+    NsMode::Container
+}
+
 /// The network / PID / IPC namespace sharing modes for a sandbox.
 ///
 /// Read from the CRI `NamespaceOption` exactly once (in `RunPodSandbox`) and
 /// carried through sandbox state, so the pause, container join, and teardown all
 /// consult one source of truth rather than re-deriving from scattered fields.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct NamespaceModes {
     /// Network namespace mode (`hostNetwork: true` ⇒ `Node`).
     #[serde(default)]
     pub network: NsMode,
-    /// PID namespace mode (`hostPID: true` ⇒ `Node`).
-    #[serde(default)]
+    /// PID namespace mode: `Pod` (shared, `shareProcessNamespace`), `Container`
+    /// (per-container, the default), or `Node` (`hostPID: true`).
+    #[serde(default = "default_pid_mode")]
     pub pid: NsMode,
     /// IPC namespace mode (`hostIPC: true` ⇒ `Node`).
     #[serde(default)]
     pub ipc: NsMode,
+}
+
+impl Default for NamespaceModes {
+    fn default() -> Self {
+        NamespaceModes {
+            network: NsMode::Pod,
+            pid: default_pid_mode(),
+            ipc: NsMode::Pod,
+        }
+    }
 }
 
 impl NamespaceModes {
@@ -117,6 +138,12 @@ impl NamespaceModes {
     /// True when the pod shares the host PID namespace.
     pub fn host_pid(&self) -> bool {
         self.pid.is_host()
+    }
+    /// True when the pod containers share a single pod PID namespace
+    /// (`shareProcessNamespace: true`, explicit CRI `pid == POD`). The pause is
+    /// PID 1 of that namespace and containers join it (#398).
+    pub fn shared_pid(&self) -> bool {
+        matches!(self.pid, NsMode::Pod)
     }
 }
 
@@ -175,6 +202,13 @@ impl SandboxState {
     /// Returns `/proc/<pause_pid>/ns/uts` path.
     pub fn uts_ns_path(&self) -> PathBuf {
         PathBuf::from(format!("/proc/{}/ns/uts", self.pause_pid))
+    }
+
+    /// Returns `/proc/<pause_pid>/ns/pid` path. For a shared-PID sandbox the
+    /// `pause_pid` is the PID-1 child of the pod PID namespace, so containers
+    /// joining this path land in the pod's PID namespace (#398).
+    pub fn pid_ns_path(&self) -> PathBuf {
+        PathBuf::from(format!("/proc/{}/ns/pid", self.pause_pid))
     }
 
     /// Returns true if the pause process is still alive.
@@ -386,9 +420,20 @@ mod tests {
         assert!(m.host_network());
         assert!(!m.host_pid());
         assert!(m.host_ipc());
-        // Default (all Pod) = fully isolated, the pre-refactor behaviour.
+        assert!(m.shared_pid()); // pid == Pod ⇒ shared
+                                 // Default: net/ipc are pod-shared, but PID defaults to Container
+                                 // (per-container isolation) — NOT shared — so an absent NamespaceOption
+                                 // never accidentally enables shareProcessNamespace (#398).
         let d = NamespaceModes::default();
         assert!(!d.host_network() && !d.host_pid() && !d.host_ipc());
+        assert!(!d.shared_pid());
+        assert!(matches!(d.pid, NsMode::Container));
+        // shared_pid only for an EXPLICIT pid == POD.
+        let shared = NamespaceModes {
+            pid: NsMode::Pod,
+            ..Default::default()
+        };
+        assert!(shared.shared_pid() && !shared.host_pid());
     }
 
     #[test]
@@ -406,11 +451,23 @@ mod tests {
         assert_eq!(json, r#"{"network":"Node","pid":"Container","ipc":"Pod"}"#);
         let back: NamespaceModes = serde_json::from_str(&json).unwrap();
         assert!(back.host_network() && !back.host_pid() && !back.host_ipc());
-        // A state blob written before this field existed still loads (serde default).
+        // A state blob written before this field existed still loads (serde
+        // default) and — critically — does NOT enable PID sharing: the `pid`
+        // field defaults to Container, so legacy sandboxes stay isolated (#398).
         let legacy: SandboxState = serde_json::from_str(
             r#"{"id":"x","name":null,"pause_pid":1,"ns_name":"n","veth_host":"","container_ip":"1.2.3.4"}"#,
         )
         .unwrap();
         assert!(!legacy.namespaces.host_network());
+        assert!(!legacy.namespaces.shared_pid());
+        assert!(matches!(legacy.namespaces.pid, NsMode::Container));
+        // Explicit pid==POD round-trips and is detected as shared.
+        let shared = NamespaceModes {
+            pid: NsMode::Pod,
+            ..Default::default()
+        };
+        let back: NamespaceModes =
+            serde_json::from_str(&serde_json::to_string(&shared).unwrap()).unwrap();
+        assert!(back.shared_pid());
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -28798,4 +28798,83 @@ mod issue_347_no_host_destruction {
             host_net_inode
         );
     }
+
+    /// test_sandbox_pause_pod_pid_forks_init
+    ///
+    /// Requires: root (unshares a PID namespace; forks).
+    ///
+    /// Spawns the pause with `--pod-pid` (+`--host-net` to avoid needing a netns).
+    /// Asserts the spawned process forks exactly one child — the PID-1 init of a
+    /// **new** PID namespace (its `/proc/<child>/ns/pid` inode differs from the
+    /// host's) — and that killing that PID-1 child cascades: the parent's
+    /// `waitpid` returns and it exits. This is the shareProcessNamespace machinery
+    /// (#398 / #352): the pause becomes PID 1 of a shared pod PID namespace that
+    /// containers join via `with_sandbox()`, so the container is never PID 1.
+    #[test]
+    fn test_sandbox_pause_pod_pid_forks_init() {
+        if !is_root() {
+            eprintln!("Skipping test_sandbox_pause_pod_pid_forks_init: requires root");
+            return;
+        }
+        use std::os::unix::fs::MetadataExt;
+
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+        let host_pid_ns = std::fs::metadata("/proc/self/ns/pid")
+            .expect("stat /proc/self/ns/pid")
+            .ino();
+
+        let mut parent = std::process::Command::new(bin)
+            .args(["sandbox", "__pause__", "", "--host-net", "--pod-pid"])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn pod-pid pause");
+
+        // Wait for the parent to unshare PID + fork the init child.
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        let children = std::fs::read_to_string(format!(
+            "/proc/{}/task/{}/children",
+            parent.id(),
+            parent.id()
+        ))
+        .unwrap_or_default();
+        let child_pid: i32 = children
+            .split_whitespace()
+            .next()
+            .and_then(|p| p.parse().ok())
+            .expect("pod-pid pause should fork a PID-1 init child");
+
+        let child_pid_ns = std::fs::metadata(format!("/proc/{}/ns/pid", child_pid))
+            .expect("stat init child ns/pid")
+            .ino();
+
+        // Kill the PID-1 child; it should cascade — the parent waitpid()s on it
+        // and exits. Poll try_wait() for up to ~1.5s without hanging.
+        let _ = unsafe { libc::kill(child_pid, libc::SIGKILL) };
+        let mut parent_exited = false;
+        for _ in 0..30 {
+            if let Ok(Some(_)) = parent.try_wait() {
+                parent_exited = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        // Best-effort teardown if the cascade assertion is about to fail.
+        let _ = parent.kill();
+        let _ = parent.wait();
+
+        assert_ne!(
+            child_pid_ns, host_pid_ns,
+            "pod-pid pause child should be PID 1 of a NEW pid namespace, \
+             but its inode matches the host's ({})",
+            host_pid_ns
+        );
+        assert!(
+            parent_exited,
+            "killing the PID-1 init child should cascade — the supervising parent should exit"
+        );
+    }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -28877,4 +28877,113 @@ mod issue_347_no_host_destruction {
             "killing the PID-1 init child should cascade — the supervising parent should exit"
         );
     }
+
+    /// test_sandbox_pause_pod_pid_drains_with_shared_grandchild
+    ///
+    /// Requires: root, `nsenter` (util-linux).
+    ///
+    /// Regression guard for the PodPID teardown deadlock (#399 / #400). A real
+    /// shareProcessNamespace pod has *other* processes in the pause's PID
+    /// namespace — a container whose worker children outlive their master and get
+    /// reparented to the pause. When the sandbox is torn down, the pause (PID 1)
+    /// must collapse the namespace and exit *promptly*: `pelagos-cri` SIGTERMs the
+    /// pause and then drains (waits for it to exit) BEFORE asking systemd to reap
+    /// the pause's transient unit. If the pause could not drain with a lingering
+    /// shared process present, the subsequent `systemctl stop` would block host
+    /// PID 1 uninterruptibly in `cgroup_drain_dying` and wedge the whole node.
+    ///
+    /// This asserts the runtime-level invariant the drain depends on: with a
+    /// grandchild joined into the pause's PID namespace (mimicking an orphaned
+    /// worker), SIGTERM-ing the pause's PID-1 init still tears the namespace down
+    /// and the pause exits within a bounded window — it never hangs. (The
+    /// systemd-ordering half of the fix is covered end-to-end by the critest
+    /// `NamespaceOption`/`PodPID` conformance bucket.)
+    #[test]
+    fn test_sandbox_pause_pod_pid_drains_with_shared_grandchild() {
+        if !is_root() {
+            eprintln!(
+                "Skipping test_sandbox_pause_pod_pid_drains_with_shared_grandchild: requires root"
+            );
+            return;
+        }
+        let nsenter_ok = std::process::Command::new("nsenter")
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !nsenter_ok {
+            eprintln!(
+                "Skipping test_sandbox_pause_pod_pid_drains_with_shared_grandchild: nsenter not found"
+            );
+            return;
+        }
+
+        let bin = env!("CARGO_BIN_EXE_pelagos");
+
+        // 1. Pod-pid pause: parent unshares PID + forks a PID-1 init child.
+        let mut parent = std::process::Command::new(bin)
+            .args(["sandbox", "__pause__", "", "--host-net", "--pod-pid"])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn pod-pid pause");
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        let child_pid: i32 = std::fs::read_to_string(format!(
+            "/proc/{}/task/{}/children",
+            parent.id(),
+            parent.id()
+        ))
+        .unwrap_or_default()
+        .split_whitespace()
+        .next()
+        .and_then(|p| p.parse().ok())
+        .expect("pod-pid pause should fork a PID-1 init child");
+
+        // 2. Join the pause's PID namespace and leave a lingering grandchild
+        //    behind (a backgrounded sleep), mimicking an orphaned container
+        //    worker reparented to the pause. `nsenter --pid` makes the spawned
+        //    command's children land in the pause's PID namespace.
+        let _joiner = std::process::Command::new("nsenter")
+            .args([
+                &format!("--pid=/proc/{}/ns/pid", child_pid),
+                "--",
+                "sh",
+                "-c",
+                "sleep 600 & sleep 600 & exit 0",
+            ])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        std::thread::sleep(std::time::Duration::from_millis(300));
+
+        // 3. SIGTERM the PID-1 init (what StopPodSandbox does). It must collapse
+        //    the namespace (SIGKILL + reap the lingering grandchildren) and exit
+        //    promptly — the parent waitpid()s on it and returns. Poll, bounded.
+        let _ = unsafe { libc::kill(child_pid, libc::SIGTERM) };
+        let mut drained = false;
+        for _ in 0..60 {
+            if let Ok(Some(_)) = parent.try_wait() {
+                drained = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        // Best-effort cleanup before asserting.
+        let _ = unsafe { libc::kill(child_pid, libc::SIGKILL) };
+        let _ = parent.kill();
+        let _ = parent.wait();
+
+        assert!(
+            drained,
+            "pod-pid pause with a lingering shared grandchild must drain within ~3s \
+             when its PID-1 init is signalled — a stuck collapse here is what wedges \
+             host PID 1 during StopPodSandbox (#399/#400)"
+        );
+    }
 }


### PR DESCRIPTION
Closes #398. Final #352 host-namespace spec (after HostIpc #386, HostNetwork #394), built on the #395 namespace-modes refactor. Approved approach: pause forks into a PID-1 init, keeping systemd restart-survival.

## ⚠️ Status: implemented + locally verified; **ipc2 critest pending**
The end-to-end `critest PodPID` run on ipc2 is **not yet confirmed** — omen↔ipc2 SSH connectivity dropped right after deploy (ipc2 is healthy: kernel pings, sshd responds to the bastion; it's a network/Tailscale issue, not a host wedge — HostIpc/HostNetwork exercised the same paths fine). **Do not merge until the ipc2 critest is confirmed.**

## Problem
critest *"PodPID"* sets `namespace_options.pid == POD` (shareProcessNamespace) on the sandbox + container, runs one nginx container, and asserts `cat /proc/1/cmdline` does **not** contain "master process" — the container must not be PID 1; the **pause** is PID 1 of a shared pod PID namespace.

## Change
- **Pause `--pod-pid`**: after net/ipc/uts setup, `unshare(CLONE_NEWPID)` + fork. The **child** is PID 1 (reaps zombies; SIGTERM→exit) and the **parent** supervises (`waitpid`) so the systemd MainPID stays stable (preserves #336).
- **RunPodSandbox**: passes `--pod-pid`, resolves the PID-1 **child** (the ns holder) via `/proc/<parent>/task/<parent>/children`, stores it as `pause_pid`.
- **`with_sandbox()`**: joins `/proc/<child>/ns/pid` when shared-PID; `CreateContainer` passes `--no-pid-ns` for POD too, so the container doesn't unshare its own PID — the existing `setns(CLONE_NEWPID)`+fork (container.rs "Case B") lands it in the pod PID ns as a non-1 PID.

## Safety guard
`pid` defaults to **Container** (not Pod) — matching Kubernetes (PID is per-container unless `shareProcessNamespace`). So an absent `NamespaceOption` and legacy sandbox state never accidentally share PID; **only an explicit `pid == POD` shares**. Normal pods (Container) and hostPID pods (Node) are unchanged.

## Tests
- Unit: `NamespaceModes` default / serde contract / `shared_pid` (incl. legacy-state-stays-isolated).
- Integration `test_sandbox_pause_pod_pid_forks_init`: the `--pod-pid` pause forks a PID-1 init in a **new** PID namespace, and killing that PID 1 cascades to the supervising parent. **Passing.**
- ipc2 critest `PodPID` → **pending** (see status above); expect NamespaceOption bucket → 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)