### PR TITLE
fix(cri): exec/attach/portforward streaming no longer hangs (#339 follow-up)

### DIFF
--- a/pelagos-cri/src/streaming.rs
+++ b/pelagos-cri/src/streaming.rs
@@ -232,11 +232,14 @@ async fn handle_exec(
     let handler = Arc::clone(&config.handler);
     let conn = spdystream_rs::connection::Connection::serve(tcp, move |s| handler(s)).await?;
 
-    // Wait until we have all expected streams (or timeout).
-    tokio::time::timeout(Duration::from_secs(10), state.wait_ready()).await??;
-
-    // Spawn the subprocess and relay I/O.
-    let run_result = state.run(Arc::clone(&conn)).await;
+    // Wait until we have all expected streams (or timeout), then run. On
+    // timeout/error we must STILL close the connection below — the old `??` here
+    // returned early and left the SPDY connection open, hanging the client (#339).
+    let run_result = match tokio::time::timeout(Duration::from_secs(10), state.wait_ready()).await {
+        Ok(Ok(())) => state.run(Arc::clone(&conn)).await,
+        Ok(Err(e)) => Err(e),
+        Err(elapsed) => Err(Box::new(elapsed) as Box<dyn std::error::Error + Send + Sync>),
+    };
 
     // Always close the SPDY connection so the client's sockets are released even
     // when it doesn't close from its side (critest leaves exec/attach streams
@@ -305,13 +308,18 @@ impl ExecState {
             // and stderr (id=5), but they are dispatched to different worker tasks
             // so there is a real (if unlikely) race.
             let stdin_ok = !self.pending.stdin || self.stdin_stream.lock().await.is_some();
+            // With a TTY there is NO separate stderr stream (it is merged into
+            // stdout), so don't wait for one — otherwise tty execs block here until
+            // the 10s timeout and then hang the client (#339).
+            let stderr_ok = self.pending.tty || has_stderr;
             // error stream uses a different worker than stdout/stderr so it
             // may not have arrived yet; wait for it since we need it for exit code.
             let has_error = self.error_stream.lock().await.is_some();
             log::debug!(
-                "wait_ready: stdout={has_stdout} stderr={has_stderr} stdin_ok={stdin_ok} error={has_error}"
+                "wait_ready: stdout={has_stdout} stderr={has_stderr} stdin_ok={stdin_ok} error={has_error} tty={}",
+                self.pending.tty
             );
-            if has_stdout && has_stderr && stdin_ok && has_error {
+            if has_stdout && stderr_ok && stdin_ok && has_error {
                 return Ok(());
             }
             notified.await;
@@ -325,12 +333,18 @@ impl ExecState {
         use tokio::io::AsyncWriteExt;
         use tokio::process::Command;
 
-        // Build: pelagos exec <name> [--] <cmd...>
-        let mut args = vec![
-            "exec".to_string(),
-            self.pending.container_name.clone(),
-            "--".to_string(),
-        ];
+        // Build: pelagos exec [-i] <name> -- <cmd...>
+        // For tty=true we pass `-i`, which makes `pelagos exec` allocate a real PTY
+        // for the container command (controlling TTY via setsid+TIOCSCTTY) and merge
+        // its stdout+stderr onto that PTY. We feed it pipes; its InteractiveSession
+        // skips raw-mode when its own stdin isn't a TTY, so the SPDY bytes pass
+        // through unchanged and the container still sees an actual terminal.
+        let mut args = vec!["exec".to_string()];
+        if self.pending.tty {
+            args.push("-i".to_string());
+        }
+        args.push(self.pending.container_name.clone());
+        args.push("--".to_string());
         args.extend_from_slice(&self.pending.cmd);
 
         let mut child = Command::new(&self.pelagos_bin)
@@ -341,12 +355,19 @@ impl ExecState {
                 std::process::Stdio::null()
             })
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
+            // With a TTY the inner PTY merges stderr into stdout; only `pelagos
+            // exec`'s own diagnostic stderr would arrive here, so drop it. Without
+            // a TTY, capture stderr for the separate SPDY stderr stream.
+            .stderr(if self.pending.tty {
+                std::process::Stdio::null()
+            } else {
+                std::process::Stdio::piped()
+            })
             .spawn()?;
 
         let mut child_stdin = child.stdin.take();
         let child_stdout = child.stdout.take().expect("stdout piped");
-        let child_stderr = child.stderr.take().expect("stderr piped");
+        let child_stderr = child.stderr.take(); // None when tty (stderr → null)
 
         // Keep Arcs for FIN sending after relay tasks complete.
         let stdout_stream = self.stdout_stream.lock().await.clone();
@@ -362,12 +383,14 @@ impl ExecState {
             None
         };
 
-        // Relay stderr: child → SPDY stream (data only; FIN sent explicitly below)
-        let stderr_task = if let Some(ref spdy_err) = stderr_stream {
-            let t = tokio::spawn(relay_read_to_spdy_data(child_stderr, Arc::clone(spdy_err)));
-            Some(t)
-        } else {
-            None
+        // Relay stderr: child → SPDY stream (non-tty only; tty merged it into
+        // stdout, so child_stderr is None there).
+        let stderr_task = match (child_stderr, stderr_stream.as_ref()) {
+            (Some(child_stderr), Some(spdy_err)) => Some(tokio::spawn(relay_read_to_spdy_data(
+                child_stderr,
+                Arc::clone(spdy_err),
+            ))),
+            _ => None,
         };
 
         // Relay stdin: SPDY stream → child

--- a/pelagos-cri/src/streaming.rs
+++ b/pelagos-cri/src/streaming.rs
@@ -494,73 +494,91 @@ async fn handle_port_forward(
 
     let pod_ip = Arc::new(pending.pod_ip.clone());
 
-    let config = ServerConfig::new(move |stream: Arc<Stream>| {
-        let pod_ip = Arc::clone(&pod_ip);
-        Box::pin(async move {
-            // kubelet sets header "port" with the target port number.
-            let port = stream
-                .headers
-                .get("port")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|s| s.parse::<u16>().ok())
-                .unwrap_or(0);
+    // Signalled when a data stream's relay finishes. We must NOT close the SPDY
+    // connection until then: closing immediately (the old bug) dropped the client
+    // before it even opened its data stream → critest "lost connection to pod".
+    let done = Arc::new(tokio::sync::Notify::new());
 
-            if port == 0 {
-                log::warn!("portforward: missing or invalid port header");
-                stream
-                    .reset(spdystream_rs::frame::RstStatus::ProtocolError)
-                    .await
-                    .ok();
-                return;
-            }
+    let config = ServerConfig::new({
+        let done = Arc::clone(&done);
+        move |stream: Arc<Stream>| {
+            let pod_ip = Arc::clone(&pod_ip);
+            let done = Arc::clone(&done);
+            Box::pin(async move {
+                // The portforward.k8s.io protocol opens TWO streams per port: an
+                // "error" side-channel and the actual "data" stream. Only the data
+                // stream carries bytes to/from the pod; relaying on the error stream
+                // (as the old code did, since it ignored streamType) double-connects
+                // to the pod and corrupts the forward.
+                let stream_type = stream
+                    .headers
+                    .get("streamType")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("")
+                    .to_string();
+                let port = stream
+                    .headers
+                    .get("port")
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|s| s.parse::<u16>().ok())
+                    .unwrap_or(0);
 
-            stream.send_reply(http::HeaderMap::new(), false).await.ok();
+                stream.send_reply(http::HeaderMap::new(), false).await.ok();
 
-            let addr = format!("{pod_ip}:{port}");
-            log::debug!("portforward: connecting to {addr}");
-
-            match TcpStream::connect(&addr).await {
-                Ok(target) => {
-                    relay_spdy_tcp(stream, target).await;
+                // Error stream: accept it but leave it idle (no relay).
+                if stream_type == "error" {
+                    return;
                 }
-                Err(e) => {
-                    log::warn!("portforward: connect {addr} failed: {e}");
+
+                if port == 0 {
+                    log::warn!("portforward: missing or invalid port header");
                     stream
-                        .reset(spdystream_rs::frame::RstStatus::Cancel)
+                        .reset(spdystream_rs::frame::RstStatus::ProtocolError)
                         .await
                         .ok();
+                    done.notify_one();
+                    return;
                 }
-            }
-        })
+
+                let addr = format!("{pod_ip}:{port}");
+                log::debug!("portforward: connecting to {addr}");
+
+                match TcpStream::connect(&addr).await {
+                    Ok(target) => relay_spdy_tcp(stream, target).await,
+                    Err(e) => {
+                        log::warn!("portforward: connect {addr} failed: {e}");
+                        stream
+                            .reset(spdystream_rs::frame::RstStatus::Cancel)
+                            .await
+                            .ok();
+                    }
+                }
+                done.notify_one();
+            })
+        }
     });
 
     // HTTP upgrade already done; serve SPDY directly without re-parsing it.
     let handler = Arc::clone(&config.handler);
     let conn = spdystream_rs::connection::Connection::serve(tcp, move |s| handler(s)).await?;
+
+    // Keep the connection alive until a data relay completes (bounded so a client
+    // that never opens a data stream can't wedge us), then close to release the
+    // client's sockets.
+    let _ = tokio::time::timeout(Duration::from_secs(60), done.notified()).await;
     let _ = conn.close().await;
     Ok(())
 }
 
 /// Bidirectional relay between a SPDY stream and a TCP connection.
-async fn relay_spdy_tcp(stream: Arc<spdystream_rs::Stream>, mut tcp: TcpStream) {
+async fn relay_spdy_tcp(stream: Arc<spdystream_rs::Stream>, tcp: TcpStream) {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-    let (mut tcp_read, mut tcp_write) = tcp.split();
+    let (mut tcp_read, mut tcp_write) = tcp.into_split();
 
-    // SPDY → TCP
-    let stream_to_tcp = {
-        let stream = Arc::clone(&stream);
-        async move {
-            while let Ok(Some(data)) = stream.read_data().await {
-                if tcp_write.write_all(&data).await.is_err() {
-                    break;
-                }
-            }
-        }
-    };
-
-    // TCP → SPDY
-    let tcp_to_stream = {
+    // pod → client. AUTHORITATIVE: once the pod closes its side, the forward is
+    // finished; we propagate that as a SPDY half-close (FIN) to the client.
+    let pod_to_client = {
         let stream = Arc::clone(&stream);
         async move {
             let mut buf = vec![0u8; 32 * 1024];
@@ -579,5 +597,28 @@ async fn relay_spdy_tcp(stream: Arc<spdystream_rs::Stream>, mut tcp: TcpStream) 
         }
     };
 
-    tokio::join!(stream_to_tcp, tcp_to_stream);
+    // client → pod. Best-effort; propagate the client's half-close to the pod by
+    // shutting down the pod-side write half when the client stops sending.
+    let client_to_pod = async move {
+        while let Ok(Some(data)) = stream.read_data().await {
+            if tcp_write.write_all(&data).await.is_err() {
+                break;
+            }
+        }
+        let _ = tcp_write.shutdown().await;
+    };
+
+    // THE #339 PORT-FORWARD HANG: the old code `tokio::join!`-ed both directions,
+    // so the forward only completed when BOTH closed. But port-forward clients
+    // (kubelet/critest) read the pod's reply and never half-close their otherwise
+    // idle write stream, so client→pod blocked forever and the forward hung
+    // ("lost connection to pod"). The pod→client direction is authoritative — the
+    // moment the pod closes we finish and FIN the client, regardless of whether
+    // the client ever closes its write half. If the client closes first, we keep
+    // draining the pod's response to completion.
+    tokio::pin!(pod_to_client);
+    tokio::select! {
+        _ = &mut pod_to_client => {}
+        _ = client_to_pod => { pod_to_client.await; }
+    }
 }

--- a/scripts/cri-conformance-focus.sh
+++ b/scripts/cri-conformance-focus.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Run a FOCUSED subset of critest against pelagos-cri — fast dev loop for one area.
+#
+#   sudo bash scripts/cri-conformance-focus.sh 'Streaming'                 # exec+attach+portforward
+#   sudo bash scripts/cri-conformance-focus.sh 'portforward'              # just portforward
+#   sudo bash scripts/cri-conformance-focus.sh 'NamespaceOption'         # the namespace bucket
+#   sudo bash scripts/cri-conformance-focus.sh 'SecurityContext' /home/cb/sc.result
+#
+# Arg 1: a ginkgo focus regex (matched against the full spec name).
+# Arg 2: result file (default ./cri-focus.result).
+#
+# critest is ginkgo-based, so --ginkgo.focus runs ONLY matching specs — turning a
+# ~15-min full sweep into a few-second iteration loop. Pair with --ginkgo.dry-run
+# (uncomment below) to just LIST which specs a regex would match.
+set -u
+SOCK="unix:///run/pelagos/cri.sock"
+FOCUS="${1:?usage: $0 <ginkgo-focus-regex> [result-file]}"
+OUT="${2:-./cri-focus.result}"
+BIN_VER="$(/usr/local/bin/pelagos --version 2>/dev/null || echo unknown)"
+
+: > "$OUT"
+{
+  echo "# critest focus: ${FOCUS}"
+  echo "# host: $(hostname)  pelagos: ${BIN_VER}"
+  echo "# started: $(date -u +%FT%TZ)"
+  echo "----------------------------------------"
+} >> "$OUT"
+
+# To list (not run) the matching specs, add: --ginkgo.dry-run
+critest --runtime-endpoint "$SOCK" --image-endpoint "$SOCK" \
+        --ginkgo.focus="$FOCUS" >> "$OUT" 2>&1
+rc=$?
+
+echo "----------------------------------------" >> "$OUT"
+echo "# critest exit: ${rc}" >> "$OUT"
+exit "$rc"

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -95,8 +95,15 @@ impl InteractiveSession {
 }
 
 /// Core relay loop: forwards bytes between stdin/stdout and the PTY master.
+///
+/// Exit condition is exactly one thing: the PTY **master** closing, which means
+/// the container process (the slave side) exited. stdin reaching EOF does NOT end
+/// the relay — the container may still be producing output — it only means "no
+/// more input", so we stop polling stdin (a closed/EOF fd is perpetually readable
+/// and would otherwise spin the loop at 100% CPU).
 fn relay_loop(master_fd: RawFd) -> io::Result<()> {
     let mut buf = [0u8; 4096];
+    let mut stdin_open = true;
 
     loop {
         // Handle any pending window resize before blocking on poll
@@ -109,10 +116,14 @@ fn relay_loop(master_fd: RawFd) -> io::Result<()> {
         let stdin_bfd = unsafe { std::os::fd::BorrowedFd::borrow_raw(libc::STDIN_FILENO) };
         let master_bfd = unsafe { std::os::fd::BorrowedFd::borrow_raw(master_fd) };
 
-        let mut fds = [
-            PollFd::new(stdin_bfd, PollFlags::POLLIN),
-            PollFd::new(master_bfd, PollFlags::POLLIN),
-        ];
+        // Only poll stdin while it is still open; once it EOFs we drop it from the
+        // set so the loop never busy-spins on a perpetually-readable closed fd.
+        let mut fds: Vec<PollFd> = Vec::with_capacity(2);
+        if stdin_open {
+            fds.push(PollFd::new(stdin_bfd, PollFlags::POLLIN));
+        }
+        fds.push(PollFd::new(master_bfd, PollFlags::POLLIN));
+        let master_idx = fds.len() - 1;
 
         // Short timeout so we can check WINCH_RECEIVED even if no I/O arrives
         // PollTimeout::from(100i16) = 100ms
@@ -126,21 +137,31 @@ fn relay_loop(master_fd: RawFd) -> io::Result<()> {
         }
 
         // stdin → master (user keystrokes go into the container)
-        if let Some(revents) = fds[0].revents() {
-            if revents.contains(PollFlags::POLLIN) {
-                let n = unsafe {
-                    libc::read(libc::STDIN_FILENO, buf.as_mut_ptr() as *mut _, buf.len())
-                };
-                if n > 0 {
-                    unsafe {
-                        libc::write(master_fd, buf.as_ptr() as *const _, n as usize);
+        if stdin_open {
+            if let Some(revents) = fds[0].revents() {
+                if revents.contains(PollFlags::POLLIN) {
+                    let n = unsafe {
+                        libc::read(libc::STDIN_FILENO, buf.as_mut_ptr() as *mut _, buf.len())
+                    };
+                    if n > 0 {
+                        unsafe {
+                            libc::write(master_fd, buf.as_ptr() as *const _, n as usize);
+                        }
+                    } else {
+                        // EOF (n == 0) or error: no more input. Stop polling stdin
+                        // but KEEP relaying the container's output until it exits.
+                        stdin_open = false;
                     }
+                }
+                if revents.intersects(PollFlags::POLLHUP | PollFlags::POLLERR) {
+                    stdin_open = false;
                 }
             }
         }
 
-        // master → stdout (container output comes to the user's screen)
-        if let Some(revents) = fds[1].revents() {
+        // master → stdout (container output comes to the user's screen). This is
+        // the sole exit condition: when the master closes, the container exited.
+        if let Some(revents) = fds[master_idx].revents() {
             if revents.contains(PollFlags::POLLIN) {
                 let n = unsafe { libc::read(master_fd, buf.as_mut_ptr() as *mut _, buf.len()) };
                 if n > 0 {
@@ -148,12 +169,10 @@ fn relay_loop(master_fd: RawFd) -> io::Result<()> {
                         libc::write(libc::STDOUT_FILENO, buf.as_ptr() as *const _, n as usize);
                     }
                 } else {
-                    // n == 0 or n < 0: slave closed its end (container exited)
-                    // On Linux, reading from a PTY master after all slaves close returns EIO
+                    // n == 0 / EIO: all slaves closed — container exited.
                     break;
                 }
             }
-            // POLLHUP/POLLERR: slave side closed — container exited
             if revents.intersects(PollFlags::POLLHUP | PollFlags::POLLERR) {
                 break;
             }


### PR DESCRIPTION
Follow-up to #339 (closed). #339 fixed ExecSync timeout killing the whole container; this PR fixes the **streaming** half — exec / port-forward hanging — plus a PTY busy-loop.

## Fixes

### Port-forward (`f9dab48`)
SPDY relay closed the connection right after `serve()` — before the client opened its data stream — causing "lost connection to pod". It also relayed the error side-channel as if it were data (ignoring `streamType`). Now keeps the conn alive until the data relay completes, half-closes correctly, and only relays the data stream.
- **critest `--focus=portforward` → 2 Passed in 5s** (was hang/fail).

### Exec hang + tty (`45fcd96`)
`wait_ready` required a stderr stream that tty execs never open (a tty merges stderr→stdout), so it blocked to the 10s timeout. And `handle_exec` returned via `??` *before* `conn.close()`, hanging the client ~3min. Now `wait_ready` is tty-aware and the conn is **always** closed. tty execs run `pelagos exec -i` (real PTY w/ controlling tty).
- **critest `--focus='should support exec'` → 3 Passed | 1 Failed in 33s** (was a ~3min hang).

### PTY busy-loop (`d4560a9`)
`relay_loop` polled stdin unconditionally; a closed/EOF fd reads as perpetually readable → 100% CPU spin + ambiguous exit. Now drops stdin from the poll set on EOF; the sole exit condition is PTY master close (container exit).

## Known remaining (tracked as follow-ups)
- **exec `tty=true`+`stdin=true`** — `pelagos exec -i` does not exit when the container command exits while stdin is held open (waits for stdin EOF). This is the 1 failing exec case above.
- **attach** — `--focus=attach` fails fast (untouched; reuses `handle_exec`).

Verified on test node ipc6 via `scripts/cri-conformance-focus.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)