### PR TITLE
feat(cri): implement container attach (#403)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -5349,3 +5349,17 @@ the subsequent `systemctl stop` would block host **PID 1** uninterruptibly in `c
 `fork`/SSH-session hangs. A failure here means the namespace-collapse invariant the drain relies on
 is broken. (The systemd-ordering half — drain-before-`systemctl stop` — is covered end-to-end by
 the critest `NamespaceOption` conformance bucket, which hung indefinitely before this fix.)
+
+## `stats::test_run_stdin_fifo`
+**Requires root** and the Alpine rootfs; skipped if either is missing.
+Covers the new `pelagos run --detach --stdin` path that underpins CRI `attach` (#403). Starts a
+detached `/bin/sh` loop (`while read line; do echo "got:$line"; done`), then asserts three things:
+(1) a **named-pipe** `stdin` FIFO is created at `/run/pelagos/containers/<name>/stdin`; (2) a line
+written to that FIFO after launch is read by the running shell and echoed (`got:ping123` appears in
+the container's `stdout.log`) — proving input reaches the live process post-launch; and (3) the
+container is **still running** afterward, i.e. it did not see stdin EOF and exit at startup (the
+watcher holds an `O_RDWR` keeper fd on the FIFO). **Why it matters:** CRI attach delivers the
+client's stdin by writing to this FIFO; if the FIFO is absent, not wired to the container's stdin,
+or EOFs immediately, an attached interactive container would either never receive input or exit
+before it could be attached to. A failure here breaks `kubectl attach` / the critest attach
+conformance spec at the runtime layer.

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -1642,6 +1642,8 @@ impl RuntimeService for RuntimeSvc {
             stop_signal,
             hugepage_limits,
             selinux_label,
+            stdin: config.stdin,
+            tty: config.tty,
         };
 
         {
@@ -1677,6 +1679,15 @@ impl RuntimeService for RuntimeSvc {
             "--sandbox".into(),
             container.sandbox_id.clone(),
         ];
+
+        // Keep the container's stdin open on a FIFO when it was created with
+        // `stdin: true`, so a later CRI `attach` can deliver input to the running
+        // process (#403). Without this the detached container's stdin is
+        // /dev/null and an interactive process (e.g. a shell) would see EOF and
+        // exit immediately.
+        if container.stdin {
+            args.push("--stdin".into());
+        }
 
         for (k, v) in &container.envs {
             args.push("--env".into());

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -312,6 +312,13 @@ pub struct CriContainer {
     /// SELinux label "user:role:type:level" (empty = not set).
     #[serde(default)]
     pub selinux_label: String,
+    /// Container was created with `stdin: true` — keep its stdin open on a FIFO
+    /// (`pelagos run --stdin`) so a later `attach` can deliver input (#403).
+    #[serde(default)]
+    pub stdin: bool,
+    /// Container was created with `tty: true` (CRI ContainerConfig.tty).
+    #[serde(default)]
+    pub tty: bool,
 }
 
 fn default_oom_score_unset() -> i32 {

--- a/pelagos-cri/src/streaming.rs
+++ b/pelagos-cri/src/streaming.rs
@@ -170,8 +170,14 @@ async fn handle_connection(
     send_upgrade_response_with_protocol(&mut tcp, protocol.as_deref()).await?;
 
     match (kind, pending) {
-        ("exec" | "attach", Pending::Exec(p)) => {
+        ("exec", Pending::Exec(p)) => {
             handle_exec(tcp, p, pelagos_bin).await?;
+        }
+        // Attach is NOT exec-with-empty-command: it wires the client's streams to
+        // the ALREADY-RUNNING container's stdio (stdin FIFO + tailing the raw
+        // stdout/stderr logs), so it has its own handler (#403).
+        ("attach", Pending::Exec(p)) => {
+            handle_attach(tcp, p).await?;
         }
         ("portforward", Pending::PortForward(p)) => {
             handle_port_forward(tcp, p).await?;
@@ -268,6 +274,110 @@ async fn handle_exec(
 
     run_result?;
     Ok(())
+}
+
+// ── Attach handler ──────────────────────────────────────────────────────────────
+
+/// Handle a CRI `attach`: wire the client's SPDY streams to the ALREADY-RUNNING
+/// container's stdio. Unlike exec, attach spawns no process — it relays the
+/// client's stdin into the container's persistent stdin FIFO and tails the
+/// container's raw stdout/stderr logs back to the client. It runs until the
+/// client detaches (closes the connection) (#403).
+async fn handle_attach(
+    tcp: TcpStream,
+    pending: PendingExec,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    use spdystream_rs::server::ServerConfig;
+    use spdystream_rs::Stream;
+
+    let container_dir = format!("/run/pelagos/containers/{}", pending.container_name);
+    log::info!(
+        "streaming attach: container={} dir={} stdin={} stdout={} stderr={} tty={}",
+        pending.container_name,
+        container_dir,
+        pending.stdin,
+        pending.stdout,
+        pending.stderr,
+        pending.tty
+    );
+
+    let state = Arc::new(ExecState::new(pending, String::new()));
+
+    let config = ServerConfig::new({
+        let state = Arc::clone(&state);
+        move |stream: Arc<Stream>| {
+            let state = Arc::clone(&state);
+            Box::pin(async move {
+                let stream_type = stream
+                    .headers
+                    .get("streamType")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("")
+                    .to_string();
+                log::debug!(
+                    "attach stream: id={} type={stream_type:?}",
+                    stream.stream_id
+                );
+                stream.send_reply(http::HeaderMap::new(), false).await.ok();
+                state.register_stream(stream_type, stream).await;
+            })
+        }
+    });
+
+    let handler = Arc::clone(&config.handler);
+    let conn = spdystream_rs::connection::Connection::serve(tcp, move |s| handler(s)).await?;
+
+    let run_result = match tokio::time::timeout(Duration::from_secs(10), state.wait_ready()).await {
+        Ok(Ok(())) => {
+            state.run_attach(Arc::clone(&conn), container_dir).await;
+            Ok(())
+        }
+        Ok(Err(e)) => Err(e),
+        Err(elapsed) => Err(Box::new(elapsed) as Box<dyn std::error::Error + Send + Sync>),
+    };
+
+    // run_attach already blocked on the client closing; this is the backstop
+    // GoAway+close (mirrors handle_exec / #402).
+    let _ = conn.close().await;
+    run_result?;
+    Ok(())
+}
+
+/// Tail `path` from `start_off`, streaming newly-appended bytes to `stream` as
+/// SPDY DATA frames until `cancel` fires. Polls at 50 ms — fast enough for an
+/// interactive attach without busy-spinning.
+async fn tail_file_to_spdy(
+    path: String,
+    start_off: u64,
+    stream: Arc<spdystream_rs::Stream>,
+    cancel: Arc<tokio::sync::Notify>,
+) {
+    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+    let mut offset = start_off;
+    loop {
+        if let Ok(mut f) = tokio::fs::File::open(&path).await {
+            if f.seek(std::io::SeekFrom::Start(offset)).await.is_ok() {
+                let mut buf = vec![0u8; 16 * 1024];
+                loop {
+                    match f.read(&mut buf).await {
+                        Ok(0) => break,
+                        Ok(n) => {
+                            offset += n as u64;
+                            let data = Bytes::copy_from_slice(&buf[..n]);
+                            if stream.write_data(data, false).await.is_err() {
+                                return;
+                            }
+                        }
+                        Err(_) => break,
+                    }
+                }
+            }
+        }
+        tokio::select! {
+            _ = cancel.notified() => return,
+            _ = tokio::time::sleep(Duration::from_millis(50)) => {}
+        }
+    }
 }
 
 /// Holds per-exec mutable state collected as SPDY streams arrive.
@@ -492,6 +602,129 @@ impl ExecState {
         // crictl's error-stream goroutine: if crictl processes GoAway before
         // it reads the error DATA frame, it may report exit code 0.
         Ok(())
+    }
+
+    /// Relay an attach: client stdin → the container's stdin FIFO, and the
+    /// container's raw stdout/stderr logs → the client's stdout/stderr streams.
+    /// Runs until the client detaches (closes the connection). Unlike `run()`
+    /// there is no child process and no exit code — the error stream just FINs.
+    async fn run_attach(
+        &self,
+        conn: Arc<spdystream_rs::connection::Connection>,
+        container_dir: String,
+    ) {
+        use tokio::io::AsyncWriteExt;
+
+        let stdin_stream = self.stdin_stream.lock().await.clone();
+        let stdout_stream = self.stdout_stream.lock().await.clone();
+        let stderr_stream = self.stderr_stream.lock().await.clone();
+        let error_stream = self.error_stream.lock().await.clone();
+
+        // Capture the current log sizes UP FRONT (before relaying any stdin) so
+        // the tailers stream only output produced from the attach point onward —
+        // matching `kubectl attach` semantics — and so the echo of any command
+        // the client sends can't be missed by a late offset read.
+        let stdout_path = format!("{container_dir}/stdout.log");
+        let stderr_path = format!("{container_dir}/stderr.log");
+        let stdout_off = tokio::fs::metadata(&stdout_path)
+            .await
+            .map(|m| m.len())
+            .unwrap_or(0);
+        let stderr_off = tokio::fs::metadata(&stderr_path)
+            .await
+            .map(|m| m.len())
+            .unwrap_or(0);
+
+        let cancel = Arc::new(tokio::sync::Notify::new());
+        // Fires when the client half-closes its stdin stream (it has sent all
+        // input). For an interactive `/bin/sh` this is the cue that the output
+        // for the just-sent input is about to be produced and the attach can be
+        // finalized — kubelet/critest attach with StdinOnce expect the stream to
+        // complete after the input is delivered, not stay open forever (#403).
+        let stdin_closed = Arc::new(tokio::sync::Notify::new());
+
+        // stdin: client stream → container stdin FIFO. Opening O_WRONLY succeeds
+        // because the container (and the watcher's keeper fd) hold the read side
+        // open; writes flow straight to the running process.
+        let stdin_task = match (self.pending.stdin, stdin_stream) {
+            (true, Some(spdy_in)) => {
+                let fifo = format!("{container_dir}/stdin");
+                let stdin_closed = Arc::clone(&stdin_closed);
+                Some(tokio::spawn(async move {
+                    let mut f = match tokio::fs::OpenOptions::new().write(true).open(&fifo).await {
+                        Ok(f) => f,
+                        Err(e) => {
+                            log::warn!("attach: open stdin fifo {fifo}: {e}");
+                            return;
+                        }
+                    };
+                    while let Ok(Some(data)) = spdy_in.read_data().await {
+                        if f.write_all(&data).await.is_err() {
+                            break;
+                        }
+                        let _ = f.flush().await;
+                    }
+                    // Client closed its stdin stream — signal finalization.
+                    stdin_closed.notify_waiters();
+                }))
+            }
+            _ => None,
+        };
+
+        // stdout/stderr: tail the raw container logs → client streams.
+        let stdout_task = stdout_stream.clone().map(|s| {
+            tokio::spawn(tail_file_to_spdy(
+                stdout_path,
+                stdout_off,
+                s,
+                Arc::clone(&cancel),
+            ))
+        });
+        let stderr_task = stderr_stream.clone().map(|s| {
+            tokio::spawn(tail_file_to_spdy(
+                stderr_path,
+                stderr_off,
+                s,
+                Arc::clone(&cancel),
+            ))
+        });
+
+        // Attach ends when the client detaches (closes the connection) OR, for a
+        // one-shot stdin attach, shortly after the client closes its stdin
+        // stream: the input has been delivered, so we give the container a brief
+        // moment to flush the resulting output, then finalize by FIN-ing the
+        // streams. Without this the streams would stay open forever (the FIFO
+        // keeper prevents the container from EOF-exiting), the client would
+        // never see stdout completion, and the attach would hang (#403).
+        tokio::select! {
+            _ = conn.wait_closed() => {}
+            _ = stdin_closed.notified(), if self.pending.stdin => {
+                tokio::time::sleep(Duration::from_millis(400)).await;
+            }
+        }
+
+        // Stop the relays.
+        cancel.notify_waiters();
+        if let Some(t) = stdin_task {
+            t.abort();
+        }
+        if let Some(t) = stdout_task {
+            let _ = t.await;
+        }
+        if let Some(t) = stderr_task {
+            let _ = t.await;
+        }
+
+        // Best-effort FINs (the client is already detaching).
+        if let Some(ref s) = error_stream {
+            s.write_data(Bytes::new(), true).await.ok();
+        }
+        if let Some(ref s) = stdout_stream {
+            s.write_data(Bytes::new(), true).await.ok();
+        }
+        if let Some(ref s) = stderr_stream {
+            s.write_data(Bytes::new(), true).await.ok();
+        }
     }
 }
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,5 +1,6 @@
 //! `pelagos run` — create and start a container.
 
+use std::os::unix::ffi::OsStrExt;
 use std::sync::atomic::{AtomicI32, Ordering};
 
 /// PID of the container process being watched.  Written once after spawn,
@@ -57,6 +58,13 @@ pub struct RunArgs {
     /// Pelagos has no "stdin without PTY" mode; `-t` is a no-op alias. (pelagos#149)
     #[clap(long = "tty", short = 't')]
     pub tty: bool,
+
+    /// Keep the container's stdin open on a persistent FIFO (`--detach` only) so a
+    /// later `attach` can deliver input to the running process. Without it a
+    /// detached container's stdin is /dev/null. Used by the CRI runtime for
+    /// containers created with `stdin: true`.
+    #[clap(long = "stdin")]
+    pub stdin: bool,
 
     /// Network mode (repeatable for multi-network): none, loopback, bridge, pasta, or named
     /// First value is primary; additional values attach secondary bridge interfaces.
@@ -448,6 +456,7 @@ pub fn cmd_run(mut args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
             attach_stdout,
             attach_stderr,
             upper_dir: persistent_upper,
+            keep_stdin: args.stdin,
         })
     } else if args.interactive {
         run_interactive(
@@ -1471,6 +1480,9 @@ struct DetachedArgs {
     attach_stdout: bool,
     attach_stderr: bool,
     upper_dir: Option<PathBuf>,
+    /// Wire the container's stdin to a persistent FIFO (`<dir>/stdin`) instead of
+    /// /dev/null so a later `attach` can write to the running process.
+    keep_stdin: bool,
 }
 
 fn run_detached(a: DetachedArgs) -> Result<(), Box<dyn std::error::Error>> {
@@ -1485,6 +1497,7 @@ fn run_detached(a: DetachedArgs) -> Result<(), Box<dyn std::error::Error>> {
         attach_stdout,
         attach_stderr,
         upper_dir,
+        keep_stdin,
     } = a;
     // Create container directory before fork so parent and child both see it.
     std::fs::create_dir_all(containers_dir())?;
@@ -1493,6 +1506,19 @@ fn run_detached(a: DetachedArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     let stdout_log = dir.join("stdout.log");
     let stderr_log = dir.join("stderr.log");
+    let stdin_fifo = dir.join("stdin");
+
+    // For an attachable container (`--stdin`), create a FIFO that becomes the
+    // container's stdin. The watcher holds an O_RDWR "keeper" fd open for the
+    // container's lifetime so the FIFO never reaches EOF (the process keeps
+    // waiting for input) and so the container's O_RDONLY open below does not
+    // block. A later `attach` opens the FIFO O_WRONLY and writes the client's
+    // stdin into the running process.
+    if keep_stdin {
+        let c = std::ffi::CString::new(stdin_fifo.as_os_str().as_bytes())?;
+        // mkfifo; ignore EEXIST so a restart/reuse of the dir is harmless.
+        unsafe { libc::mkfifo(c.as_ptr(), 0o600) };
+    }
 
     let state = ContainerState {
         name: name.clone(),
@@ -1594,11 +1620,31 @@ fn run_detached(a: DetachedArgs) -> Result<(), Box<dyn std::error::Error>> {
                 let _ = write_state(&early);
             }
 
-            // Set up piped stdio so we can relay to log files.
-            cmd = cmd
-                .stdin(Stdio::Null)
-                .stdout(Stdio::Piped)
-                .stderr(Stdio::Piped);
+            // Set up piped stdout/stderr so we can relay to log files.
+            cmd = cmd.stdout(Stdio::Piped).stderr(Stdio::Piped);
+
+            // stdin: /dev/null by default; for an attachable container open the
+            // FIFO. The watcher holds an O_RDWR "keeper" fd for the whole
+            // container lifetime so the FIFO never EOFs and the container's
+            // O_RDONLY open does not block; `_stdin_keeper` keeps it alive until
+            // the watcher exits (which closes it). The O_RDONLY read end becomes
+            // the container's stdin (fd 0) and must NOT be O_CLOEXEC so it
+            // survives the exec into the container.
+            let _stdin_keeper = if keep_stdin {
+                let c = std::ffi::CString::new(stdin_fifo.as_os_str().as_bytes())
+                    .expect("fifo path has no NUL");
+                let keeper = unsafe { libc::open(c.as_ptr(), libc::O_RDWR | libc::O_CLOEXEC) };
+                let child_stdin = unsafe { libc::open(c.as_ptr(), libc::O_RDONLY) };
+                if keeper < 0 || child_stdin < 0 {
+                    eprintln!("pelagos watcher: open stdin fifo failed");
+                    unsafe { libc::_exit(1) };
+                }
+                cmd = cmd.stdin(Stdio::Fd(child_stdin));
+                keeper
+            } else {
+                cmd = cmd.stdin(Stdio::Null);
+                -1
+            };
 
             let mut child = match cmd.spawn() {
                 Ok(c) => c,

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -110,6 +110,7 @@ fn spawn_config_to_run_args(
         rm: false,
         interactive: false,
         tty: false,
+        stdin: false,
         network: sc.network,
         publish: sc.publish,
         nat: sc.nat,

--- a/src/container.rs
+++ b/src/container.rs
@@ -829,14 +829,27 @@ pub enum Stdio {
     /// Creates a pipe between parent and child. The parent can read/write
     /// through the pipe to communicate with the child.
     Piped,
+
+    /// Use an already-open file descriptor as the stream.
+    ///
+    /// Ownership of the fd is transferred to the spawned process (the
+    /// underlying `std::process::Command` dup2's it onto the target stdio slot
+    /// and closes the original after spawn). Used to wire a container's stdin to
+    /// a persistent FIFO so a CRI `attach` can deliver input to the running
+    /// process after launch.
+    Fd(std::os::unix::io::RawFd),
 }
 
 impl From<Stdio> for process::Stdio {
     fn from(stdio: Stdio) -> Self {
+        use std::os::unix::io::FromRawFd;
         match stdio {
             Stdio::Inherit => process::Stdio::inherit(),
             Stdio::Null => process::Stdio::null(),
             Stdio::Piped => process::Stdio::piped(),
+            // Safety: the caller guarantees `fd` is a valid, owned descriptor it
+            // no longer uses; `Stdio` takes ownership and closes it after spawn.
+            Stdio::Fd(fd) => unsafe { process::Stdio::from_raw_fd(fd) },
         }
     }
 }
@@ -5708,21 +5721,9 @@ impl Command {
             let extra_args: Vec<std::ffi::OsString> =
                 self.inner.get_args().map(|a| a.to_owned()).collect();
 
-            let stdin = match self.stdio_in {
-                Stdio::Inherit => std::process::Stdio::inherit(),
-                Stdio::Null => std::process::Stdio::null(),
-                Stdio::Piped => std::process::Stdio::piped(),
-            };
-            let stdout = match self.stdio_out {
-                Stdio::Inherit => std::process::Stdio::inherit(),
-                Stdio::Null => std::process::Stdio::null(),
-                Stdio::Piped => std::process::Stdio::piped(),
-            };
-            let stderr = match self.stdio_err {
-                Stdio::Inherit => std::process::Stdio::inherit(),
-                Stdio::Null => std::process::Stdio::null(),
-                Stdio::Piped => std::process::Stdio::piped(),
-            };
+            let stdin: std::process::Stdio = self.stdio_in.into();
+            let stdout: std::process::Stdio = self.stdio_out.into();
+            let stderr: std::process::Stdio = self.stdio_err.into();
 
             let inner =
                 crate::wasm::spawn_wasm(&prog_path, &extra_args, &wasi, stdin, stdout, stderr)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3249,6 +3249,95 @@ mod stats {
             name
         );
     }
+
+    /// `pelagos run --detach --stdin` must wire the container's stdin to a
+    /// persistent FIFO at `/run/pelagos/containers/<name>/stdin` so that input
+    /// written to the FIFO after launch reaches the running process, and the
+    /// container does NOT EOF-exit while idle (the watcher holds the FIFO open).
+    /// This is the runtime foundation for CRI `attach` (#403): a failure here
+    /// means an interactive container either never receives attached input or
+    /// exits immediately at startup.
+    #[test]
+    fn test_run_stdin_fifo() {
+        if !is_root() {
+            eprintln!("Skipping test_run_stdin_fifo: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping test_run_stdin_fifo: alpine-rootfs not found");
+            return;
+        };
+
+        let name = format!("test-stdin-{}", std::process::id());
+
+        // A shell that echoes each stdin line with a marker prefix.
+        let start = std::process::Command::new(env!("CARGO_BIN_EXE_pelagos"))
+            .args([
+                "run",
+                "--detach",
+                "--stdin",
+                "--name",
+                &name,
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "/bin/sh",
+                "-c",
+                "while read line; do echo \"got:$line\"; done",
+            ])
+            .output()
+            .expect("pelagos run --stdin");
+        assert!(
+            start.status.success(),
+            "pelagos run --stdin failed: {}",
+            String::from_utf8_lossy(&start.stderr)
+        );
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        let fifo = format!("/run/pelagos/containers/{name}/stdin");
+        let stdout_log = format!("/run/pelagos/containers/{name}/stdout.log");
+
+        // The stdin FIFO must exist and be a named pipe.
+        let is_fifo = std::fs::metadata(&fifo)
+            .map(|m| {
+                use std::os::unix::fs::FileTypeExt;
+                m.file_type().is_fifo()
+            })
+            .unwrap_or(false);
+
+        // Write a line to the FIFO; the container should echo it.
+        if is_fifo {
+            use std::io::Write;
+            if let Ok(mut f) = std::fs::OpenOptions::new().write(true).open(&fifo) {
+                let _ = f.write_all(b"ping123\n");
+                let _ = f.flush();
+            }
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+
+        let log = std::fs::read_to_string(&stdout_log).unwrap_or_default();
+
+        // Container must still be running (it did not EOF-exit while idle).
+        let ps = std::process::Command::new(env!("CARGO_BIN_EXE_pelagos"))
+            .args(["ps"])
+            .output()
+            .expect("pelagos ps");
+        let running = String::from_utf8_lossy(&ps.stdout).contains(&name);
+
+        // Clean up regardless of assertions.
+        let _ = std::process::Command::new(env!("CARGO_BIN_EXE_pelagos"))
+            .args(["rm", "--force", &name])
+            .output();
+
+        assert!(is_fifo, "stdin FIFO not created at {fifo}");
+        assert!(
+            log.contains("got:ping123"),
+            "container did not echo FIFO stdin; stdout.log = {log:?}"
+        );
+        assert!(
+            running,
+            "container with --stdin EOF-exited while idle (should stay running)"
+        );
+    }
 }
 
 mod networking {


### PR DESCRIPTION
Fixes #403.

## Problem
CRI `attach` was implemented as exec-with-empty-command: `runtime::attach` registered a `PendingExec { cmd: vec![] }` routed through `handle_exec`, which ran `pelagos exec <name> --` with no command → clap exits **code 2** → critest's `runtime should support attach [Conformance]` failed fast with "command terminated with exit code 2".

Attach must instead wire the client's streams to the **already-running container's** stdio. That requires a writable stdin path into a live container, which pelagos lacked (detached containers run with `stdin = /dev/null`).

## What this adds (end to end)

**Runtime (`pelagos run`)**
- New `Stdio::Fd(RawFd)` so a container's stdin can be an inherited descriptor.
- New `pelagos run --detach --stdin`: creates a persistent FIFO at `/run/pelagos/containers/<name>/stdin`, wires the container's stdin to its read end, and holds an `O_RDWR` "keeper" fd in the watcher so the FIFO never EOFs (the process keeps waiting for input) and the `O_RDONLY` open doesn't block.

**pelagos-cri**
- Persist `stdin`/`tty` from `ContainerConfig`; pass `--stdin` to `pelagos run` when `stdin: true`.
- Dedicated `handle_attach` / `ExecState::run_attach`: relay the client's stdin stream → the FIFO, and tail the container's raw `stdout.log`/`stderr.log` → the client's stdout/stderr streams.
- **Finalize the streams shortly after the client closes its stdin stream.** kubelet/critest attach with `StdinOnce` close stdin and then wait for stdout completion; without the FIN the streams stay open forever (the keeper prevents the container from EOF-exiting) and the attach hangs. Long-lived attach still falls back to client-driven close.

## Diagnosis
Confirmed on ipc6 with frame-level capture (`scripts/spdy-pcap-decode.py`): the container echoed "hello" to `stdout.log` and the server sent `DATA stream=5 "hello"`, but both `crictl attach` and critest hung — because the stdout stream was never FIN'd after the `StdinOnce` client closed stdin. Finalizing on stdin-close fixes it.

## Verification (ipc6, cri-tools v1.36.0)
| Check | Before | After |
|---|---|---|
| `should support attach` | Failed (exit 2) | **1 Passed**, 5.9s |
| full `Streaming` bucket | 4/5 | **5 Passed \| 0 Failed**, 12.2s |
| `crictl attach -i` (manual) | hang, no output | returns `hello`, exit 0 |

No regressions to exec/portforward.

## Tests
Adds `stats::test_run_stdin_fifo` (root): starts `--detach --stdin` with an echoing shell, asserts the stdin FIFO is created, post-launch input is echoed to `stdout.log`, and the container stays running (doesn't EOF-exit). Documented in `docs/INTEGRATION_TESTS.md`. Conformance itself is verified via critest on a real node (as with #339/#401/#404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)