### PR TITLE
infra(build): pelagos-built builder image (rust + protoc), drop host-cached protoc

### DIFF
--- a/k8s/build/README.md
+++ b/k8s/build/README.md
@@ -39,12 +39,33 @@ for the duration of a critest sweep and always restarts + uncordons it afterward
 (restore runs even on failure/interrupt). Between sweeps ipc6 contributes its
 capacity to the cluster.
 
+## Builder image
+
+The Job runs in a **derived builder image** — `rust:1-bookworm` + a modern protoc
+baked in (`k8s/build/builder.Dockerfile`). protoc is a build dependency
+(pelagos-cri's tonic-build) that must be newer than Debian apt's (3.21, too old
+for the CRI api.proto's `debug_redact`); baking it into the image keeps it a
+versioned, pullable dependency instead of node-local host state.
+
+Built and hosted entirely with pelagos (dogfood), into the cluster Zot registry:
+```bash
+# on a cluster node (e.g. ipc4)
+sudo pelagos build -t 192.168.89.2:5004/pelagos-builder:rust-protoc-34.1 \
+  --file k8s/build/builder.Dockerfile k8s/build
+sudo pelagos image push --insecure 192.168.89.2:5004/pelagos-builder:rust-protoc-34.1
+```
+The Job's `image:` points at that ref. `192.168.*` is auto-treated as an insecure
+(HTTP) registry by pelagos's `oci_client_config`, so the pod pulls it with no
+extra config. Bump the protoc version → rebuild + re-push under a new tag and
+update `pelagos-build-job.yaml`.
+
 ## One-time setup
 
 ### Build node (ipc4)
 Node label `kubernetes.io/hostname=ipc4` already exists (k3s sets it); the Job's
 nodeAffinity uses it. hostPath dirs are auto-created (`DirectoryOrCreate`):
-`/srv/pelagos-build/{cache,staging}`. Nothing else to do — the Job runs as root.
+`/srv/pelagos-build/{cache,staging}` (cache = cargo/target/repo build data only —
+protoc now comes from the builder image). Nothing else to do — the Job runs as root.
 
 To target ipc5 instead, change the nodeAffinity value in `pelagos-build-job.yaml`.
 
@@ -82,7 +103,8 @@ node you're on), see `scripts/node-build-install.sh`.
 
 ## Status
 
-The manifests + units + driver are authored; the one-time setup above
-(systemd units on ipc6, ipc4->ipc6 SSH trust) still needs to be applied and the
-end-to-end Job run validated live. Until then, `scripts/node-build-install.sh`
-(build+install on a single node via SSH) is the working path.
+**Live and validated end-to-end.** One-time setup is applied (path-unit on ipc6,
+ipc4→{all nodes} SSH trust, builder image pushed to Zot 5004). `scripts/cluster-build.sh main`
+has been run start to finish: Job builds on ipc4 in the builder image (~15s
+incremental), delivers ipc4→ipc6 over LAN, the path-unit installs + restarts
+pelagos-cri. `scripts/node-build-install.sh` remains as a single-node fallback.

--- a/k8s/build/builder.Dockerfile
+++ b/k8s/build/builder.Dockerfile
@@ -1,0 +1,24 @@
+# Builder image for the cluster build Job: the Rust toolchain plus a modern
+# protoc baked in, so the Job needs NO host-cached protoc and NO runtime download
+# of it. Built with `pelagos build` and pushed with `pelagos image push` (dogfood)
+# to the cluster registry; the Job's pod pulls it like any other image.
+#
+#   pelagos build -t <registry>/pelagos-builder:rust-protoc-34.1 \
+#     --file k8s/build/builder.Dockerfile k8s/build
+#   pelagos image push <registry>/pelagos-builder:rust-protoc-34.1
+#
+# `rust:1-bookworm` resolves via the Zot docker.io mirror (registries.toml).
+FROM rust:1-bookworm
+
+# protoc must be new enough for the CRI api.proto's `debug_redact` option;
+# Debian apt's protoc (3.21) is too old. Match the dev box (omen) at 34.1.
+ARG PROTOC_VER=34.1
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends unzip; \
+    rm -rf /var/lib/apt/lists/*; \
+    curl -fsSL -o /tmp/protoc.zip \
+      "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VER}/protoc-${PROTOC_VER}-linux-x86_64.zip"; \
+    unzip -o /tmp/protoc.zip -d /usr/local; \
+    rm /tmp/protoc.zip; \
+    protoc --version

--- a/k8s/build/pelagos-build-job.yaml
+++ b/k8s/build/pelagos-build-job.yaml
@@ -37,7 +37,12 @@ spec:
         runAsUser: 0  # write the host-mounted cache/staging dirs as root
       containers:
         - name: build
-          image: rust:1-bookworm  # ships cargo + a C toolchain (cc/ld)
+          # Derived builder image (rust + protoc baked in), built with
+          # `pelagos build` and hosted in the cluster Zot registry. Replaces the
+          # old host-cached-protoc hack — the image is the versioned dependency
+          # contract. 192.168.x is auto-treated as an insecure (HTTP) registry by
+          # pelagos's oci_client_config, so no extra pull config is needed.
+          image: 192.168.89.2:5004/pelagos-builder:rust-protoc-34.1
           env:
             - name: GIT_REF
               value: "__GIT_REF__"          # branch/tag/sha to build
@@ -49,18 +54,7 @@ spec:
           args:
             - |
               set -euo pipefail
-              # pelagos-cri's tonic-build needs protoc, and recent enough to know
-              # `debug_redact` (used in the CRI api.proto) — Debian's apt protoc
-              # (3.21) is too old. Install a modern protoc once into the cache.
-              PROTOC_VER=34.1
-              export PROTOC=/cache/protoc/bin/protoc
-              if ! "$PROTOC" --version 2>/dev/null | grep -q "$PROTOC_VER"; then
-                mkdir -p /cache/protoc
-                curl -fsSL -o /tmp/protoc.zip \
-                  "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VER}/protoc-${PROTOC_VER}-linux-x86_64.zip"
-                (cd /cache/protoc && (command -v unzip >/dev/null || (apt-get update -qq && apt-get install -y -qq unzip)) && unzip -o -q /tmp/protoc.zip)
-              fi
-              "$PROTOC" --version
+              protoc --version   # baked into the builder image (on PATH)
               REPO=/cache/repo
               if [ -d "$REPO/.git" ]; then
                 git -C "$REPO" fetch --all -q


### PR DESCRIPTION
Addresses two architectural problems with the cluster build Job:
1. it host-cached the protoc **executable** on a node's filesystem (`/srv/pelagos-build/cache/protoc`) — mutable, node-local, invisible-dependency state that defeats k8s isolation/reproducibility;
2. it downloaded protoc at build time from GitHub's release CDN, which intermittently 404s.

## Fix — a derived builder image, built and hosted with pelagos
- **`k8s/build/builder.Dockerfile`**: `FROM rust:1-bookworm` + protoc 34.1 baked in (apt's 3.21 is too old for the CRI api.proto's `debug_redact`). The image *is* the versioned dependency contract.
- Built with **`pelagos build`** and pushed with **`pelagos image push --insecure`** to the cluster Zot registry (`192.168.89.2:5004/pelagos-builder:rust-protoc-34.1`) — fully dogfooded, no docker.
- The Job's `image:` now points at it; the **protoc-seed block and `/cache/protoc` mount are removed**. `192.168.*` is auto-treated as an insecure (HTTP) registry by pelagos's `oci_client_config`, so the pod pulls it with no extra config.
- The remaining `/cache` hostPath holds only cargo/target/repo **build data** (the defensible, CI-style cache), not executables.

## Validated end-to-end
- `pelagos build` produced the image (base via Zot docker.io mirror, RUN net via pasta, `protoc --version` → 34.1, "Successfully built … (6 layers)").
- `pelagos image push` → Zot 5004 (catalog/tags confirmed).
- Job run: pod pulls the builder from Zot over HTTP, `libprotoc 34.1` from the baked-in protoc (**no download**), builds `main` in ~18s, delivers ipc4→ipc6, path-unit installs + restarts pelagos-cri. `Succeeded exit=0`.

README updated with the builder-image build/push flow; status now "live and validated".

🤖 Generated with [Claude Code](https://claude.com/claude-code)