### PR TITLE
fix(cri): report real namespace modes in PodSandboxStatus (#410)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -5363,3 +5363,16 @@ client's stdin by writing to this FIFO; if the FIFO is absent, not wired to the 
 or EOFs immediately, an attached interactive container would either never receive input or exit
 before it could be attached to. A failure here breaks `kubectl attach` / the critest attach
 conformance spec at the runtime layer.
+
+## `pelagos-cri runtime::tests::test_pod_sandbox_status_reports_namespace_modes`
+**No root required.** Lives in `pelagos-cri/src/runtime.rs` (run with `cargo test -p pelagos-cri`).
+Regression test for #410. Inserts three in-memory sandboxes into a `RuntimeSvc` — a `hostNetwork`
+sandbox (`NamespaceModes::from_cri(2,1,0)`), a `hostIPC` sandbox (`from_cri(0,1,2)`), and a default
+sandbox — then calls the real `PodSandboxStatus` gRPC method and asserts the returned
+`linux.namespaces.options` echoes the **stored** modes: the hostNetwork sandbox reports
+`network == NODE(2)`, the hostIPC sandbox reports `ipc == NODE(2)` (and `network == POD(0)`), and the
+default sandbox reports `network == ipc == POD(0)`. **Why it matters:** `pod_sandbox_status`
+previously hardcoded these to `0` (POD). The kubelet's `podSandboxChanged` compares the reported
+network-namespace mode against the pod spec; reporting POD for a hostNetwork pod made it kill and
+recreate the sandbox on **every sync (~1/sec)** — an endless crash-loop that broke *all* host-network
+workloads (kube-vip, MetalLB, Multus). A failure here means hostNetwork pods are unschedulable.

--- a/pelagos-cri/src/runtime.rs
+++ b/pelagos-cri/src/runtime.rs
@@ -1274,10 +1274,15 @@ impl RuntimeService for RuntimeSvc {
             }),
             linux: Some(LinuxPodSandboxStatus {
                 namespaces: Some(Namespace {
+                    // Report the sandbox's ACTUAL namespace modes, not zeros. The
+                    // kubelet's `podSandboxChanged` compares these against the pod
+                    // spec; reporting POD (0) for a hostNetwork sandbox makes it
+                    // recreate the sandbox every sync — an endless crash-loop for
+                    // host-namespace pods (#410).
                     options: Some(NamespaceOption {
-                        network: 0,
-                        pid: 0,
-                        ipc: 0,
+                        network: sandbox.namespaces.network.to_cri(),
+                        pid: sandbox.namespaces.pid.to_cri(),
+                        ipc: sandbox.namespaces.ipc.to_cri(),
                         target_id: String::new(),
                         userns_options: None,
                     }),
@@ -3218,6 +3223,100 @@ async fn relay_logs_from_dir(container_dir: String, cri_log_path: String) {
 mod tests {
     use super::*;
     use tempfile::NamedTempFile;
+
+    /// A minimal in-memory `CriSandbox` carrying the given namespace modes.
+    #[cfg(test)]
+    fn sbx_with_namespaces(id: &str, namespaces: state::NamespaceModes) -> state::CriSandbox {
+        state::CriSandbox {
+            id: id.into(),
+            name: format!("{}-pod", id),
+            namespace: "default".into(),
+            uid: format!("uid-{}", id),
+            attempt: 0,
+            labels: Default::default(),
+            annotations: Default::default(),
+            created_at_ns: 0,
+            state: state::SandboxState::Running,
+            netns: String::new(),
+            ip: "192.168.1.10".into(),
+            cni_conf: String::new(),
+            pause_pid: 1,
+            log_directory: String::new(),
+            cgroup_parent: String::new(),
+            supplemental_groups: vec![],
+            dns_servers: vec![],
+            dns_searches: vec![],
+            dns_options: vec![],
+            namespaces,
+            port_mappings: vec![],
+        }
+    }
+
+    /// Regression test for #410: `pod_sandbox_status` must report the sandbox's
+    /// ACTUAL namespace modes, not hardcoded `POD`(0). When it reported `POD` for a
+    /// `hostNetwork` sandbox, the kubelet's `podSandboxChanged` saw a mismatch
+    /// against the pod spec and recreated the sandbox on every sync — an endless
+    /// ~1/sec crash-loop for every host-network pod (kube-vip, MetalLB, …).
+    #[tokio::test]
+    async fn test_pod_sandbox_status_reports_namespace_modes() {
+        let svc = RuntimeSvc {
+            state: AppState::new("pelagos".into()),
+            streaming_base_url: String::new(),
+            registry: Default::default(),
+        };
+        {
+            let mut st = svc.state.inner.lock().await;
+            // hostNetwork pod: network == NODE(2); pid CONTAINER(1); ipc POD(0).
+            st.sandboxes.insert(
+                "hostnet-410".into(),
+                sbx_with_namespaces("hostnet-410", state::NamespaceModes::from_cri(2, 1, 0)),
+            );
+            // hostIPC pod: ipc == NODE(2); network/pid default.
+            st.sandboxes.insert(
+                "hostipc-410".into(),
+                sbx_with_namespaces("hostipc-410", state::NamespaceModes::from_cri(0, 1, 2)),
+            );
+            // Default pod: all default (network POD, ipc POD).
+            st.sandboxes.insert(
+                "podnet-410".into(),
+                sbx_with_namespaces("podnet-410", state::NamespaceModes::default()),
+            );
+        }
+
+        async fn ns_of(svc: &RuntimeSvc, id: &str) -> NamespaceOption {
+            let resp = svc
+                .pod_sandbox_status(Request::new(PodSandboxStatusRequest {
+                    pod_sandbox_id: id.into(),
+                    verbose: false,
+                }))
+                .await
+                .expect("status ok")
+                .into_inner();
+            resp.status
+                .unwrap()
+                .linux
+                .unwrap()
+                .namespaces
+                .unwrap()
+                .options
+                .unwrap()
+        }
+
+        // hostNetwork sandbox MUST report network == NODE(2), or the kubelet
+        // crash-loops it (#410).
+        let host = ns_of(&svc, "hostnet-410").await;
+        assert_eq!(host.network, 2, "hostNetwork sandbox must report NODE(2)");
+
+        // hostIPC sandbox reports ipc == NODE(2).
+        let hipc = ns_of(&svc, "hostipc-410").await;
+        assert_eq!(hipc.ipc, 2, "hostIPC sandbox must report NODE(2) for ipc");
+        assert_eq!(hipc.network, 0, "hostIPC pod still has POD network");
+
+        // Default sandbox reports POD(0) for network and ipc.
+        let pod = ns_of(&svc, "podnet-410").await;
+        assert_eq!(pod.network, 0, "default sandbox reports POD(0) network");
+        assert_eq!(pod.ipc, 0, "default sandbox reports POD(0) ipc");
+    }
 
     #[test]
     fn test_resolve_apparmor() {

--- a/pelagos-cri/src/state.rs
+++ b/pelagos-cri/src/state.rs
@@ -40,6 +40,20 @@ impl NsMode {
         }
     }
 
+    /// Convert back to the CRI `NamespaceMode` i32 (`POD`=0, `CONTAINER`=1, `NODE`=2).
+    /// Inverse of [`NsMode::from_cri`]; used by `PodSandboxStatus` to report the
+    /// sandbox's namespace modes back to the kubelet. Reporting the wrong value
+    /// (e.g. `POD` for a `hostNetwork` sandbox) makes the kubelet's
+    /// `podSandboxChanged` check see a mismatch and recreate the sandbox on every
+    /// sync — an endless crash-loop for host-namespace pods (#410).
+    pub fn to_cri(self) -> i32 {
+        match self {
+            NsMode::Pod => 0,
+            NsMode::Container => 1,
+            NsMode::Node => 2,
+        }
+    }
+
     /// True if this is the host namespace (CRI `NODE`).
     pub fn is_host(self) -> bool {
         matches!(self, NsMode::Node)


### PR DESCRIPTION
Fixes #410.

## Problem

Every `hostNetwork: true` pod crash-restarts ~1×/second under pelagos-cri (observed on `0.65.39+107594a`). The container never fails — kubelet tears the sandbox down and recreates it on every sync. This breaks **all** host-network workloads: kube-vip, MetalLB's speaker, Multus, etc. (CNI pods are unaffected.)

## Root cause

`pod_sandbox_status()` hardcoded the returned `NamespaceOption` to `{network:0, pid:0, ipc:0}` (all POD), ignoring the modes the sandbox already stores in `CriSandbox.namespaces`. For a hostNetwork sandbox the stored `network` is `Node`(2); status reported `Pod`(0). kubelet's `podSandboxChanged` compares the reported network-namespace mode against the pod spec → mismatch every sync → kill + recreate → the pause unit is SIGTERM-stopped, the phantom-sandbox reaper reaps the now-dead-pause sandbox, and the loop repeats forever.

## Fix

- Add `NsMode::to_cri()` (inverse of the existing `from_cri`).
- Have `pod_sandbox_status` report `sandbox.namespaces.{network,pid,ipc}.to_cri()` instead of zeros.

## Evidence (reproduced live on the cluster)

| Pod | Config | Result |
|---|---|---|
| `sleep` | hostNetwork + NET_ADMIN/NET_RAW | churn ~1/s |
| `sleep` | **hostNetwork**, no caps | churn ~1/s |
| `sleep` | caps, **no** hostNetwork | **stable** |

Trigger is `hostNetwork`, independent of capabilities.

## Tests

- New regression test `test_pod_sandbox_status_reports_namespace_modes` (no root): asserts a hostNetwork sandbox reports `network==NODE(2)`, a hostIPC sandbox reports `ipc==NODE(2)`, and a default sandbox reports `POD(0)`. Documented in `docs/INTEGRATION_TESTS.md`.
- **Verified the test fails without the fix and passes with it.**
- `cargo test -p pelagos-cri` 34/34, `cargo test --lib` 385/385, `cargo fmt` + `cargo clippy` clean.

## Release

Regression-class — warrants a patch release since it breaks all host-network workloads. Unblocks the kube-vip HA control-plane VIP work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)