### PR TITLE
fix(cli): SIGKILL the whole container cgroup on stop/rm (#412)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -5376,3 +5376,17 @@ previously hardcoded these to `0` (POD). The kubelet's `podSandboxChanged` compa
 network-namespace mode against the pod spec; reporting POD for a hostNetwork pod made it kill and
 recreate the sandbox on **every sync (~1/sec)** — an endless crash-loop that broke *all* host-network
 workloads (kube-vip, MetalLB, Multus). A failure here means hostNetwork pods are unschedulable.
+
+## `issue_412_cgroup_kill_orphans::test_kill_cgroup_reaps_setsid_process_in_cgroup`
+**Requires root** and **cgroup v2** (skips otherwise). Guards the fix for the orphaned
+hostNetwork-container-process bug (#412). Creates a test cgroup under `/sys/fs/cgroup`,
+launches a shell that moves itself into it and backgrounds a **`setsid sleep`** (a
+process in its own, *different* session), then calls `pelagos::cgroup::kill_cgroup(name)`
+and asserts the cgroup drains to **empty**. **Why it matters:** the container stop/rm
+paths (`cmd_stop`, `cmd_rm`) SIGKILL only the single recorded `state.pid`; that misses
+forked/`setsid`'d descendants and processes reparented to init, which then survive as
+orphans holding resources (the MetalLB speaker held port 7946 across a restart → the next
+instance CrashLooped on `bind: address already in use`). `kill_cgroup` sweeps the whole
+cgroup (atomic `cgroup.kill`, or a `cgroup.procs` walk) so nothing survives. The test
+specifically verifies a **setsid session leader** — which a single-PID/process-group kill
+would leave alive — is reaped. A failure here means container teardown can leak orphans.

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -468,3 +468,59 @@ pub fn read_stats(cg: &Cgroup) -> io::Result<ResourceStats> {
 
     Ok(stats)
 }
+
+/// SIGKILL **every** process in a container's cgroup subtree (cgroup v2).
+///
+/// The per-container stop/rm paths signal only the single recorded `state.pid`,
+/// which misses forked or `setsid`'d descendants and processes reparented to init —
+/// leaving orphans that keep holding resources (e.g. a listening port), the root
+/// cause of the orphaned-hostNetwork-process bug (#412). Killing the whole cgroup
+/// catches them all regardless of reparenting, the way runc/containerd do.
+///
+/// `cgroup_name` is the path **relative to `/sys/fs/cgroup`** (as stored in the
+/// container state's `cgroup_name`). No-op if the cgroup is absent/unknown. Prefers
+/// the atomic `cgroup.kill` (kernel ≥ 5.14); otherwise walks `cgroup.procs` across
+/// the subtree until it drains.
+pub fn kill_cgroup(cgroup_name: &str) {
+    let dir = std::path::Path::new("/sys/fs/cgroup").join(cgroup_name.trim_start_matches('/'));
+    if !dir.is_dir() {
+        return;
+    }
+    // Atomic subtree kill (cgroup v2, kernel >= 5.14).
+    let kill_file = dir.join("cgroup.kill");
+    if kill_file.exists() && std::fs::write(&kill_file, "1").is_ok() {
+        return;
+    }
+    // Fallback: SIGKILL every pid in cgroup.procs across the subtree, retrying a few
+    // times since a shell can spawn a straggler while it is being torn down.
+    for _ in 0..20 {
+        let mut killed_any = false;
+        kill_cgroup_subtree(&dir, &mut killed_any);
+        if !killed_any {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+fn kill_cgroup_subtree(dir: &std::path::Path, killed_any: &mut bool) {
+    if let Ok(contents) = std::fs::read_to_string(dir.join("cgroup.procs")) {
+        for line in contents.lines() {
+            if let Ok(pid) = line.trim().parse::<i32>() {
+                // Never signal pid <= 1 (init / group-sentinel guard).
+                if pid > 1 {
+                    unsafe { libc::kill(pid, libc::SIGKILL) };
+                    *killed_any = true;
+                }
+            }
+        }
+    }
+    if let Ok(rd) = std::fs::read_dir(dir) {
+        for ent in rd.flatten() {
+            let p = ent.path();
+            if p.is_dir() {
+                kill_cgroup_subtree(&p, killed_any);
+            }
+        }
+    }
+}

--- a/src/cli/rm.rs
+++ b/src/cli/rm.rs
@@ -31,6 +31,11 @@ pub fn cmd_rm(name: &str, force: bool) -> Result<(), Box<dyn std::error::Error>>
                     }
                 }
             }
+            // Sweep the whole container cgroup so forked/`setsid`'d descendants (which
+            // the single-PID kill above misses) can't survive as orphans (#412).
+            if let Some(ref cg) = state.cgroup_name {
+                pelagos::cgroup::kill_cgroup(cg);
+            }
             // Wait for the watcher to finish cleanup (nftables/veth/overlay teardown)
             // before removing state.  The watcher exits shortly after the container dies.
             if state.watcher_pid > 0 {

--- a/src/cli/stop.rs
+++ b/src/cli/stop.rs
@@ -69,6 +69,13 @@ pub fn cmd_stop(name: &str, time: u64) -> Result<(), Box<dyn std::error::Error>>
         }
     }
 
+    // Belt-and-suspenders: the single-PID signals above miss forked/`setsid`'d
+    // descendants and processes reparented to init. SIGKILL the whole container
+    // cgroup so nothing survives as an orphan holding a port etc. (#412).
+    if let Some(ref cg) = state.cgroup_name {
+        pelagos::cgroup::kill_cgroup(cg);
+    }
+
     // Update state to exited.
     state.status = ContainerStatus::Exited;
     write_state(&state)?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -29076,3 +29076,96 @@ mod issue_347_no_host_destruction {
         );
     }
 }
+
+/// #412 — `pelagos::cgroup::kill_cgroup` must SIGKILL **every** process in a
+/// container's cgroup, including a `setsid`'d process in a *different session* that a
+/// single-PID (or process-group) kill would miss. This is the container-teardown
+/// hardening for the orphaned-hostNetwork-process bug: a process surviving a container
+/// restart kept holding its port (e.g. a MetalLB speaker on 7946), wedging every
+/// subsequent instance into CrashLoop.
+mod issue_412_cgroup_kill_orphans {
+    use std::time::Duration;
+
+    #[test]
+    fn test_kill_cgroup_reaps_setsid_process_in_cgroup() {
+        if !super::is_root() {
+            eprintln!("Skipping test_kill_cgroup_reaps_setsid_process_in_cgroup: requires root");
+            return;
+        }
+        if !std::path::Path::new("/sys/fs/cgroup/cgroup.controllers").exists() {
+            eprintln!("Skipping test_kill_cgroup_reaps_setsid_process_in_cgroup: needs cgroup v2");
+            return;
+        }
+
+        let name = format!("pelagos-killcg-test-{}", std::process::id());
+        let dir = format!("/sys/fs/cgroup/{}", name);
+        std::fs::create_dir_all(&dir).expect("create test cgroup");
+
+        // A shell moves itself into the test cgroup, backgrounds a `setsid sleep`
+        // (its own new session — precisely what a single-PID/pgroup kill misses), then
+        // `exec`s into a sleep. Both processes live in the test cgroup.
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(format!(
+                "echo $$ > {dir}/cgroup.procs; setsid sleep 300 >/dev/null 2>&1 & exec sleep 300"
+            ))
+            .spawn()
+            .expect("spawn test shell");
+
+        let read_pids = || -> Vec<i32> {
+            std::fs::read_to_string(format!("{dir}/cgroup.procs"))
+                .unwrap_or_default()
+                .lines()
+                .filter_map(|l| l.trim().parse().ok())
+                .collect()
+        };
+
+        // Wait until the cgroup holds both processes.
+        let mut pids = Vec::new();
+        for _ in 0..40 {
+            std::thread::sleep(Duration::from_millis(50));
+            pids = read_pids();
+            if pids.len() >= 2 {
+                break;
+            }
+        }
+        assert!(
+            pids.len() >= 2,
+            "cgroup should hold >=2 procs, got {:?}",
+            pids
+        );
+        // Sanity: at least one is a session leader in its own session (the setsid'd one),
+        // which a single-PID kill of the shell would not reap.
+        let has_setsid = pids.iter().any(|&p| unsafe { libc::getsid(p) } == p);
+        assert!(
+            has_setsid,
+            "expected a setsid session leader in the cgroup: {:?}",
+            pids
+        );
+
+        // The fix under test: kill the whole cgroup.
+        pelagos::cgroup::kill_cgroup(&name);
+
+        // Every process must be gone from the cgroup — no orphan survivors.
+        let mut remaining = pids.clone();
+        for _ in 0..60 {
+            std::thread::sleep(Duration::from_millis(50));
+            remaining = read_pids();
+            if remaining.is_empty() {
+                break;
+            }
+        }
+
+        // Clean up regardless of the assertion outcome.
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = std::fs::remove_dir(&dir);
+
+        assert!(
+            remaining.is_empty(),
+            "kill_cgroup left processes alive (orphans): {:?} — a single-PID kill would \
+             leave the setsid'd process holding its resources (#412)",
+            remaining
+        );
+    }
+}


### PR DESCRIPTION
## Summary
`cmd_stop` and `cmd_rm` signalled only the single `state.pid`, so forked / `setsid`'d descendants — and processes reparented to init — could survive as orphans holding resources. This is what left a MetalLB `speaker` orphan holding UDP 7946 during the ipc7-9 node-join churn that filed #412. The `exec` path already does robust session reaping via `kill_exec_wrapper`; the stop/rm paths did not.

## Fix
- Add `pelagos::cgroup::kill_cgroup(cgroup_name)` — prefers the atomic `cgroup.kill` (kernel ≥5.14), falls back to a recursive `cgroup.procs` SIGKILL sweep.
- Call it after the single-PID SIGKILL escalation in both `cmd_stop` and `cmd_rm`. Matches how runc/containerd tear a container down by its cgroup.

## Test
`issue_412_cgroup_kill_orphans::test_kill_cgroup_reaps_setsid_process_in_cgroup` (root + cgroup v2): puts a `setsid`'d process in a container cgroup and asserts `kill_cgroup` drains it empty. Verified to **guard** the fix — it fails when `kill_cgroup` is reduced to a single-PID kill. Documented in `docs/INTEGRATION_TESTS.md`.

## Verification
- `cargo fmt` / `cargo clippy` clean; **385/385 unit tests pass**; the #412 test passes and guards.
- Note: the full integration suite currently can't be run to completion on the dev host (omen, kernel 7.0.9) due to a **pre-existing** `pre_exec` spawn EINVAL that reproduces identically on clean `main` with this branch stashed — unrelated to this change. Definitive full-suite run belongs on a cluster node with a stable kernel.

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)