### PR TITLE
Integration suite: Ubuntu 26.04 cluster-node portability + unmask pre_exec DNS bind errors

### DIFF
--- a/docs/k8s-build/README.md
+++ b/docs/k8s-build/README.md
@@ -46,6 +46,39 @@ This directory is a **template**, not a turnkey deploy — replace the
    `pelagos-cri`, however you manage that (a script, a systemd `path` unit
    watching a drop directory, a second Job, etc.).
 
+## Running tests on the cluster
+
+pelagos has two test tiers with very different isolation needs:
+
+- **Unit tests** (`cargo test --lib`) are hermetic — no root, namespaces, or
+  cgroups. `build-job.yaml` runs them right after `cargo build` and **before**
+  populating `/out`, so a failing build never produces installable binaries. This
+  is the safe, default way to test in-cluster.
+
+- **Integration tests** (`cargo test --test integration_tests`) require **root**
+  and mutate **host** state: they create and tear down a bridge, veth pairs,
+  nftables tables, cgroups, and mount/network namespaces. Do **not** run them as
+  an ordinary pod on a working node — they will collide with that node's real
+  networking. Run them on a **dedicated node you've drained** (`kubectl cordon` +
+  stop the kubelet so its pod GC doesn't interfere), as a host `cargo test` over
+  SSH, and restore the node afterwards. Sketch:
+  ```bash
+  # compile while still in-cluster; then run the compiled binary as root
+  ssh "$NODE" 'cd pelagos && cargo test --test integration_tests --no-run'
+  kubectl cordon "$NODE"; ssh "$NODE" 'sudo systemctl stop kubelet'          # drain
+  EXE=$(ssh "$NODE" 'ls -t pelagos/target/debug/deps/integration_tests-* | grep -v "\.d$" | head -1')
+  ssh "$NODE" "sudo '$EXE'"                                                  # run as root
+  ssh "$NODE" 'sudo systemctl start kubelet'; kubectl uncordon "$NODE"       # always restore
+  ```
+  Run the compiled *binary* as root rather than `sudo cargo test` — many nodes'
+  sudo strips `-E`, and a root `cargo` can't find a toolchain installed under the
+  user's home. The node needs a Rust toolchain on the host (rustup) and
+  `build-essential`; protoc is not required (the integration tests don't compile
+  pelagos-cri). **If the node runs pelagos as its own CRI, stop that service too**
+  for the run (and restart it before the kubelet) — the suite and
+  `scripts/reset-test-env.sh` operate on `/run/pelagos`, the live runtime's dir,
+  and will otherwise wedge the node NotReady.
+
 ## Notes / adapt to taste
 
 - The build cache (`/cache`: git checkout + cargo registry + target dir) is a

--- a/docs/k8s-build/build-job.yaml
+++ b/docs/k8s-build/build-job.yaml
@@ -54,6 +54,14 @@ spec:
               fi
               echo "building $(git rev-parse --short HEAD)"
               cargo build --release -p pelagos -p pelagos-cri
+              # Gate the build on the unit tests: they're hermetic (no root,
+              # namespaces, or cgroups) so they run cleanly in the build pod, and
+              # `set -e` aborts before /out is populated if any fail. The
+              # privileged integration suite (`cargo test --test integration_tests`)
+              # is NOT run here — it needs root + host netns/nftables/cgroups and
+              # belongs on a dedicated, drained node (see README "Running tests").
+              echo "unit tests"
+              cargo test --release --lib -p pelagos -p pelagos-cri
               install -m0755 "$CARGO_TARGET_DIR/release/pelagos" \
                              "$CARGO_TARGET_DIR/release/pelagos-cri" /out/
               echo "built pelagos + pelagos-cri -> /out"

--- a/scripts/reset-test-env.sh
+++ b/scripts/reset-test-env.sh
@@ -87,4 +87,22 @@ grep -o '/run/pelagos/overlay-[^ ]*' /proc/mounts 2>/dev/null | while read -r mn
     umount -l "$mnt" 2>/dev/null && echo "  unmounted $mnt" || true
 done || true
 
+# A chroot container SIGKILL'd mid-run leaves its auto-injected bind mounts
+# (etc/resolv.conf, etc/hosts, dev/*, proc, sys, ca-certificates, mnt, shm) stacked
+# on the SHARED test rootfs. Their backing source (e.g. /run/pelagos/dns-*/resolv.conf)
+# then gets cleaned up, leaving a ghost mountpoint — the next container's bind onto
+# it fails with ENOENT (which pelagos masks as a bare "os error 22"). reset never
+# swept these, so they accumulated across runs and eventually broke every spawn
+# test on the dev box. Sweep any mount whose target is inside a *-rootfs dir,
+# deepest-first (so stacked/nested mounts unwind), repeated to clear stacks.
+echo "=== Unmounting leaked bind-mounts on test rootfs dirs ==="
+for pass in 1 2 3; do
+    # column 5 of mountinfo is the mount target; match test rootfs dirs by name.
+    awk '{print $5}' /proc/self/mountinfo 2>/dev/null \
+        | grep -E '/[^/]*-rootfs(/|$)' \
+        | awk '{ print length, $0 }' | sort -rn | cut -d' ' -f2- | while read -r mnt; do
+        umount -l "$mnt" 2>/dev/null && echo "  unmounted $mnt" || true
+    done
+done || true
+
 echo "=== Clean ==="

--- a/src/container.rs
+++ b/src/container.rs
@@ -4382,10 +4382,10 @@ impl Command {
                             ptr::null(),
                         );
                         if r != 0 {
-                            return Err(io::Error::other(format!(
-                                "dns bind mount: {}",
-                                io::Error::last_os_error()
-                            )));
+                            // Preserve the real errno (e.g. ENOENT when a leaked
+                            // bind mount left a ghost mountpoint on the shared
+                            // rootfs) instead of letting std mask it to EINVAL(22).
+                            return Err(pre_exec_err("dns bind mount", io::Error::last_os_error()));
                         }
                     }
 
@@ -6993,10 +6993,10 @@ impl Command {
                             ptr::null(),
                         );
                         if r != 0 {
-                            return Err(io::Error::other(format!(
-                                "dns bind mount: {}",
-                                io::Error::last_os_error()
-                            )));
+                            // Preserve the real errno (e.g. ENOENT when a leaked
+                            // bind mount left a ghost mountpoint on the shared
+                            // rootfs) instead of letting std mask it to EINVAL(22).
+                            return Err(pre_exec_err("dns bind mount", io::Error::last_os_error()));
                         }
                     }
 
@@ -8677,6 +8677,30 @@ pub struct DeviceNode {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // A pre_exec hook that fails with a real syscall errno (e.g. ENOENT when a
+    // leaked bind mount leaves a ghost mountpoint on the shared rootfs) must
+    // surface that errno to the parent, not let std mask it to EINVAL(22). This
+    // is the bug that made an ENOENT DNS bind read as "Invalid argument (os
+    // error 22)" and sent a debugging session chasing a phantom kernel problem.
+    #[test]
+    fn test_pre_exec_err_preserves_real_errno() {
+        let e = pre_exec_err("dns bind mount", io::Error::from_raw_os_error(libc::ENOENT));
+        assert_eq!(
+            e.raw_os_error(),
+            Some(libc::ENOENT),
+            "pre_exec_err must preserve ENOENT, not mask it to EINVAL"
+        );
+    }
+
+    // When the source error genuinely has no errno, pre_exec_err keeps the
+    // context message (the parent will still see EINVAL, but logs show why).
+    #[test]
+    fn test_pre_exec_err_keeps_context_when_no_errno() {
+        let e = pre_exec_err("some ctx", io::Error::other("boom"));
+        assert_eq!(e.raw_os_error(), None);
+        assert!(e.to_string().contains("some ctx: boom"));
+    }
 
     #[test]
     fn test_resolve_mount_target_follows_var_run_symlink() {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -28566,18 +28566,26 @@ mod issue_336_cri_restart_readopt {
         stop_unit(&parent_unit);
         stop_unit(&scope_unit);
 
-        // Carry the sentinels in the *binary name* (symlinks to sleep) rather than
-        // as args — `sleep 3600 <tag>` would be an invalid time interval. pgrep -f
-        // then matches each sleep's argv0 uniquely.
+        // Carry the sentinels in the *script path* (a tiny wrapper that runs sleep)
+        // rather than an argv0 symlink to sleep. An argv0 symlink breaks on
+        // multi-call coreutils — Ubuntu 26.04 ships uutils/coreutils, which
+        // dispatches on argv[0] and rejects an unknown applet name
+        // ("coreutils: unknown program '<tag>'"), so the child never starts. A
+        // wrapper runs the real sleep on any distro, and its path (bearing the
+        // sentinel) stays in the parent /bin/sh's cmdline for `pgrep -f`. It must
+        // NOT `exec` sleep — that would replace the shell and drop the sentinel
+        // from the process cmdline.
+        use std::os::unix::fs::PermissionsExt as _;
         let dir = tempfile::tempdir().expect("tempdir");
-        let sleep_bin = ["/bin/sleep", "/usr/bin/sleep"]
-            .into_iter()
-            .find(|p| std::path::Path::new(p).exists())
-            .expect("a sleep binary");
+        let write_sleeper = |path: &std::path::Path| {
+            std::fs::write(path, "#!/bin/sh\nsleep \"$@\"\n").expect("write sleeper");
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod sleeper");
+        };
         let sup_bin = dir.path().join(&sup_tag);
         let ctrl_bin = dir.path().join(&ctrl_tag);
-        std::os::unix::fs::symlink(sleep_bin, &sup_bin).expect("symlink sup sleep");
-        std::os::unix::fs::symlink(sleep_bin, &ctrl_bin).expect("symlink ctrl sleep");
+        write_sleeper(&sup_bin);
+        write_sleeper(&ctrl_bin);
 
         // The parent service's body, written to a temp script so the parent's own
         // command line does NOT contain the sentinels (keeping pgrep unambiguous).
@@ -28589,8 +28597,9 @@ mod issue_336_cri_restart_readopt {
                  {sup} 3600 &\n\
              # Control: stays in THIS service's cgroup, must die on stop.\n\
              {ctrl} 3600 &\n\
-             # Keep the service active until we stop it.\n\
-             exec {sleep_bin} 3600\n",
+             # Keep the service active until we stop it. (argv0 is 'sleep' here,
+             # so multi-call coreutils dispatches correctly; no sentinel needed.)\n\
+             exec sleep 3600\n",
             sup = sup_bin.to_str().unwrap(),
             ctrl = ctrl_bin.to_str().unwrap(),
         );


### PR DESCRIPTION
Fixes surfaced while standing up **cluster-side integration testing** (running the suite on the ipc k3s nodes instead of the dev box). Closes #414.

### 1. `fix(container)`: unmask pre_exec DNS bind errors
Both auto-DNS `resolv.conf` bind sites reported failures via `io::Error::other(format!(...))` → no `raw_os_error()` → `std` masks the real errno to `EINVAL(22)`. A ghost mountpoint (from a leaked bind mount on the shared rootfs) returns **ENOENT**, but the user saw `Invalid argument (os error 22)` — which sent a debugging session chasing a phantom "kernel regression." Routed both through the existing `pre_exec_err()` helper (preserves errno) + unit tests.

### 2. `test`: #336 supervisor test portable to uutils/coreutils
Ubuntu 26.04 ships **uutils/coreutils** (multi-call binary, dispatches on `argv[0]`). The test symlinked `sleep` under a sentinel name → `coreutils: unknown program '<tag>'` → child never starts → deterministic failure on cluster nodes. Now uses a wrapper-script path for the sentinel.

### 3. `test(infra)`: reset-test-env sweeps leaked rootfs mounts
The accumulated leaked bind mounts (from SIGKILL'd containers) that caused #1's ghost mountpoints were never swept. Now unmounts anything under a `*-rootfs` dir, deepest-first.

### 4. `docs(k8s-build)`: cluster build gates on unit tests + integration-suite-on-drained-node docs

## Verification
- `cargo fmt` / `cargo clippy` clean; unit tests pass (incl. the 2 new `pre_exec_err` tests).
- Full integration suite run on an Ubuntu 26.04 i5 cluster node (via the new cluster driver): **35 failures → green** after these fixes + node setup (pelagos group, pasta AppArmor unconfined, pelagos-dockerd built). The 2 residual failures were parallelism flakes that pass in isolation (noted in #414).

🤖 Generated with [Claude Code](https://claude.com/claude-code)