### PR TITLE
fix(cli): inject a default HOME env var (containerd/CRI parity) (#421)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -1446,6 +1446,19 @@ Runs a shell loop that forks an external command (`sleep 0`) five times. All fiv
 succeed and the container must print `FORKS_OK`. Failure indicates the double-fork mechanism
 in `pre_exec` (which makes the container process PID 1 in the new namespace) is broken.
 
+### `test_run_injects_default_home`
+**Requires:** root, rootfs
+
+Regression for #421. Spawns `pelagos run` (the binary) on the alpine rootfs executing
+`/usr/bin/env`, captures the container's output via `pelagos logs`, and asserts it contains
+`HOME=/root`. Verifies that pelagos injects a default `HOME` — resolved from the effective
+user's `/etc/passwd` home, falling back to `/root` for uid 0 — when neither the image config
+nor `--env` provides one, matching containerd/CRI behaviour.
+
+Failure indicates the default-HOME injection regressed: containers get no `HOME`, which
+silently breaks any tool that requires it (e.g. Go's `os.UserHomeDir`, tsnet / the Tailscale
+Kubernetes operator, which fatals with "neither $XDG_CONFIG_HOME nor $HOME are defined").
+
 ---
 
 ## Container Linking Tests

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -516,6 +516,46 @@ fn lookup_user_in_layers(
     ))
 }
 
+/// Resolve the default `HOME` for a container user, matching containerd/CRI
+/// behaviour: look the effective user up in the container's own `/etc/passwd`
+/// and use its home field; fall back to `/root` for uid 0 and `/` otherwise.
+///
+/// `user` is the effective user spec (numeric uid, `uid:gid`, or a name), or
+/// `None` for root. Used to inject a default `HOME` when neither the image
+/// config nor an explicit `--env`/pod env provides one (#421): pelagos does not
+/// otherwise set `HOME` the way containerd does, and some workloads (e.g. tsnet
+/// / anything using Go's `os.UserHomeDir`) fatal without it.
+pub fn home_dir_in_layers(user: Option<&str>, layer_dirs: &[std::path::PathBuf]) -> String {
+    // Effective uid: 0 unless a user spec resolves to a different one. An
+    // unresolvable spec falls back to root here — env defaulting must not fail
+    // the run; the real user resolution (with its hard errors) happens later.
+    let uid = match user {
+        None => 0,
+        Some(spec) => {
+            let name_or_uid = spec.split(':').next().unwrap_or(spec).trim();
+            resolve_uid_in_layers(name_or_uid, layer_dirs).unwrap_or(0)
+        }
+    };
+    // passwd format: name:password:uid:gid:gecos:home:shell — field 5 is home.
+    for layer_dir in layer_dirs.iter().rev() {
+        let passwd_path = layer_dir.join("etc/passwd");
+        if let Ok(contents) = std::fs::read_to_string(&passwd_path) {
+            for line in contents.lines() {
+                let fields: Vec<&str> = line.split(':').collect();
+                if fields.len() >= 6 && fields[2].parse::<u32>() == Ok(uid) && !fields[5].is_empty()
+                {
+                    return fields[5].to_string();
+                }
+            }
+        }
+    }
+    if uid == 0 {
+        "/root".to_string()
+    } else {
+        "/".to_string()
+    }
+}
+
 fn resolve_uid_in_layers(s: &str, layer_dirs: &[std::path::PathBuf]) -> Result<u32, String> {
     if let Ok(n) = s.parse::<u32>() {
         // u32::MAX == (uid_t)-1; setuid(-1) is EINVAL and in some implementations
@@ -775,6 +815,34 @@ pub fn verify_pid_not_recycled(pid: i32, state: &ContainerState) -> Result<(), S
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #421: with no passwd to consult, HOME defaults to /root for uid 0 and / otherwise.
+    #[test]
+    fn test_home_dir_defaults_without_passwd() {
+        let empty: Vec<std::path::PathBuf> = vec![];
+        assert_eq!(home_dir_in_layers(None, &empty), "/root");
+        assert_eq!(home_dir_in_layers(Some("1000"), &empty), "/");
+    }
+
+    /// #421: HOME is read from the container's /etc/passwd home field, resolving
+    /// the user by name, numeric uid, or `uid:gid` (uid part).
+    #[test]
+    fn test_home_dir_from_passwd() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("etc")).unwrap();
+        std::fs::write(
+            dir.path().join("etc/passwd"),
+            "root:x:0:0:root:/root:/bin/sh\napp:x:1000:1000:App:/home/app:/bin/sh\n",
+        )
+        .unwrap();
+        let layers = vec![dir.path().to_path_buf()];
+        assert_eq!(home_dir_in_layers(None, &layers), "/root");
+        assert_eq!(home_dir_in_layers(Some("app"), &layers), "/home/app");
+        assert_eq!(home_dir_in_layers(Some("1000"), &layers), "/home/app");
+        assert_eq!(home_dir_in_layers(Some("1000:1000"), &layers), "/home/app");
+        // An unknown user falls back safely rather than erroring.
+        assert_eq!(home_dir_in_layers(Some("nobodyx"), &layers), "/root");
+    }
 
     /// rootfs_path should accept an existing filesystem directory path and
     /// return its canonicalized form, without requiring it to be registered

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -25,9 +25,10 @@ extern "C" fn watcher_forward_signal(signum: libc::c_int) {
 }
 
 use super::{
-    check_liveness, container_dir, containers_dir, generate_name, parse_capability, parse_cpus,
-    parse_memory, parse_ulimit, parse_user_in_layers, parse_user_in_rootfs, rootfs_path,
-    write_state, ContainerState, ContainerStatus, HealthConfig, HealthStatus, SpawnConfig,
+    check_liveness, container_dir, containers_dir, generate_name, home_dir_in_layers,
+    parse_capability, parse_cpus, parse_memory, parse_ulimit, parse_user_in_layers,
+    parse_user_in_rootfs, rootfs_path, write_state, ContainerState, ContainerStatus, HealthConfig,
+    HealthStatus, SpawnConfig,
 };
 use pelagos::container::{Capability, Command, Namespace, Stdio, Volume};
 use pelagos::network::NetworkMode;
@@ -690,6 +691,27 @@ fn build_image_run(
         }
     }
 
+    // Inject a default HOME when the image config omits it, matching
+    // containerd/CRI (which pelagos-cri relies on): resolve it from the
+    // effective user's /etc/passwd entry, else /root for root and / otherwise.
+    // A later `--env HOME=...` (pod env, applied in apply_cli_options) still
+    // wins. Without this, images that don't set HOME (e.g. distroless, the
+    // Tailscale operator) crash tools that need it (#421).
+    if !manifest
+        .config
+        .env
+        .iter()
+        .any(|e| e == "HOME" || e.starts_with("HOME="))
+    {
+        let effective_user = args.user.as_deref().or(if manifest.config.user.is_empty() {
+            None
+        } else {
+            Some(manifest.config.user.as_str())
+        });
+        let home = home_dir_in_layers(effective_user, &layer_dirs);
+        cmd = cmd.env("HOME", home);
+    }
+
     // Apply image config working directory.
     if !manifest.config.working_dir.is_empty() && args.workdir.is_none() {
         cmd = cmd.with_cwd(&manifest.config.working_dir);
@@ -760,6 +782,13 @@ fn build_command(
         );
 
     let rootfs_layers = vec![rootfs_dir.to_path_buf()];
+
+    // Default HOME (containerd/CRI parity, #421); a later `--env HOME=` overrides.
+    cmd = cmd.env(
+        "HOME",
+        home_dir_in_layers(args.user.as_deref(), &rootfs_layers),
+    );
+
     cmd = apply_cli_options(
         cmd,
         args,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -368,6 +368,69 @@ mod core {
             out, err
         );
     }
+
+    /// test_run_injects_default_home
+    ///
+    /// Requires: root + rootfs (spawns a real container via the pelagos binary).
+    ///
+    /// Regression for #421: pelagos must inject a default `HOME` (containerd/CRI
+    /// parity) when neither the image config nor `--env` sets one. Runs
+    /// `pelagos run` on the alpine rootfs executing `/usr/bin/env` and asserts the
+    /// container's environment contains `HOME=/root` (root's passwd home). Without
+    /// the fix the container has no HOME at all — which crashes tools that require
+    /// it (e.g. the Tailscale operator's tsnet: "neither $XDG_CONFIG_HOME nor
+    /// $HOME are defined").
+    #[test]
+    fn test_run_injects_default_home() {
+        if !is_root() {
+            eprintln!("Skipping test_run_injects_default_home: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping test_run_injects_default_home: alpine-rootfs not found");
+            return;
+        };
+
+        let name = format!("test-home-{}", std::process::id());
+        let run = std::process::Command::new(env!("CARGO_BIN_EXE_pelagos"))
+            .args([
+                "run",
+                "--detach",
+                "--name",
+                &name,
+                "--network",
+                "loopback",
+                "--rootfs",
+                rootfs.to_str().unwrap(),
+                "/usr/bin/env",
+            ])
+            .output()
+            .expect("pelagos run");
+        assert!(
+            run.status.success(),
+            "pelagos run failed: {}",
+            String::from_utf8_lossy(&run.stderr)
+        );
+
+        std::thread::sleep(std::time::Duration::from_millis(400));
+
+        let logs = std::process::Command::new(env!("CARGO_BIN_EXE_pelagos"))
+            .args(["logs", &name])
+            .output()
+            .expect("pelagos logs");
+
+        // Clean up regardless of assertions.
+        let _ = std::process::Command::new(env!("CARGO_BIN_EXE_pelagos"))
+            .args(["rm", "--force", &name])
+            .output();
+
+        let out = String::from_utf8_lossy(&logs.stdout);
+        assert!(
+            out.lines().any(|l| l.trim() == "HOME=/root"),
+            "expected HOME=/root in container env (default HOME injection, #421); got:\n{}",
+            out
+        );
+    }
 }
 
 mod capabilities {


### PR DESCRIPTION
## Problem

pelagos doesn't inject a default `HOME` the way containerd's CRI does. Containers whose image config omits `HOME` run with no `HOME` at all. Surfaced installing the **Tailscale Kubernetes operator** — its image sets only `PATH`:

```
$ crane config tailscale/k8s-operator:v1.98.4 | jq -r '.config.Env[]'
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

so the operator crash-looped:

```
fatal  starting tailscale server: tsnet: neither $XDG_CONFIG_HOME nor $HOME are defined
```

Any Go `os.UserHomeDir`/`os.UserConfigDir` consumer hits the same. Setting `HOME` explicitly fixed it, confirming the sole gap.

## Fix

New `home_dir_in_layers(user, layers)` resolves the effective user's home from the container's own `/etc/passwd` (by name, numeric uid, or the uid of `uid:gid`), falling back to `/root` for uid 0 and `/` otherwise — matching containerd.

Injected in both run paths, only when the image config doesn't already set `HOME` — the same shape as the existing default-`PATH` logic (issue #114). A later `--env HOME=…` (pod env) still wins:
- `build_image_run` (image runs — the CRI path)
- `build_command` (rootfs runs — CLI parity)

## Tests
- Unit (`src/cli/mod.rs`): passwd resolution by name / uid / `uid:gid`, plus no-passwd fallbacks (`/root` for root, `/` for non-root, unknown-user safe fallback).
- Integration (`tests/integration_tests.rs::test_run_injects_default_home`, **root + rootfs**): spawns `pelagos run … /usr/bin/env`, reads `pelagos logs`, asserts `HOME=/root`. Documented in `docs/INTEGRATION_TESTS.md`.

`cargo fmt` + `cargo clippy --bin pelagos -D warnings` clean; unit + integration tests green.

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)