### PR TITLE
feat(overlay): default the container writable layer to disk, tmpfs opt-in

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -973,6 +973,26 @@ rootfs), and the volume write does **not** appear in the overlay upper dir. Fail
 would indicate that volume bind mounts are not correctly layered on top of the overlay
 merged view, or that volume writes are leaking into the overlay upper directory.
 
+### `test_overlay_default_on_disk`
+**Requires:** root, rootfs
+
+Spawns an image-layer container (`with_image_layers`) with the **default** overlay mode,
+then checks the overlay merged dir's parent (the `overlay-<pid>-<n>` scratch base).
+Asserts it lives under `paths::scratch_root()` (the disk-backed `/var/lib/pelagos/scratch`)
+and **not** under `paths::runtime_dir()` (the `/run` tmpfs). Skips if `PELAGOS_OVERLAY_*`
+is set (an override would move the location). Guards the #427 fix: the container's writable
+layer is now bounded by disk, not RAM, so it can't OOM the node and large writes (builds)
+aren't capped at the tmpfs size. Failure means the overlay default regressed back onto the
+RAM tmpfs, reintroducing the cap.
+
+### `test_overlay_tmpfs_optin`
+**Requires:** root, rootfs
+
+Same as above but with `with_overlay_tmpfs(true)` (the `--overlay-tmpfs` flag /
+`PELAGOS_OVERLAY_TMPFS=1` opt-in). Asserts the overlay scratch lands back under
+`paths::runtime_dir()` (the `/run` tmpfs). Failure means the tmpfs opt-in is broken — users
+can no longer choose the fast, RAM-backed, auto-cleaned overlay for small ephemeral containers.
+
 ### `test_overlay_lower_unchanged`
 **Requires:** root, rootfs
 

--- a/src/cli/cleanup.rs
+++ b/src/cli/cleanup.rs
@@ -12,8 +12,19 @@ pub fn cmd_cleanup() -> Result<(), Box<dyn std::error::Error>> {
     // 1. Stale named network namespaces: /run/netns/rem-{pid}-{n}
     cleaned += cleanup_netns()?;
 
-    // 2. Stale overlay dirs: /run/pelagos/overlay-{pid}-{n}/
+    // 2. Stale overlay dirs on the runtime tmpfs (used only in --overlay-tmpfs
+    //    mode): /run/pelagos/overlay-{pid}-{n}/. Cleared on reboot anyway.
     cleaned += cleanup_dir_pattern("/run/pelagos", "overlay-")?;
+
+    // 2b. Stale overlay dirs on the DISK scratch (the default location):
+    //     <scratch_root>/overlay-{pid}-{n}/. Disk overlays SURVIVE reboot (the
+    //     /run tmpfs did not), so this sweep is what reclaims a leaked/crashed
+    //     container's writable layer. (A PID recycled after reboot can keep one
+    //     stale dir alive — bounded; the common exited-container case is handled.)
+    let scratch = pelagos::paths::scratch_root();
+    if let Some(scratch) = scratch.to_str() {
+        cleaned += cleanup_dir_pattern(scratch, "overlay-")?;
+    }
 
     // 3. Stale DNS temp dirs: /run/pelagos/dns-{pid}-{n}/
     cleaned += cleanup_dir_pattern("/run/pelagos", "dns-")?;

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -120,6 +120,12 @@ pub struct RunArgs {
     #[clap(long = "read-only")]
     pub read_only: bool,
 
+    /// Put the container's overlay scratch (writable layer) on the RAM-backed
+    /// tmpfs instead of the disk default. Fast + auto-freed, but RAM-capped —
+    /// use only for small, short-lived, write-light containers.
+    #[clap(long = "overlay-tmpfs")]
+    pub overlay_tmpfs: bool,
+
     /// Environment variable KEY=VALUE (repeatable)
     #[clap(long = "env", short = 'e')]
     pub env: Vec<String>,
@@ -669,6 +675,7 @@ fn build_image_run(
         // we OR into the flags already set by with_image_layers (MOUNT) rather
         // than replacing them.
         .add_namespaces(Namespace::UTS | pid_ns | ipc_ns | Namespace::CGROUP);
+    cmd = cmd.with_overlay_tmpfs(args.overlay_tmpfs);
 
     // Apply image config environment.  This includes any PATH set by Dockerfile
     // ENV instructions.  apply_cli_options no longer injects a fallback PATH
@@ -780,6 +787,7 @@ fn build_command(
             "PATH",
             "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         );
+    cmd = cmd.with_overlay_tmpfs(args.overlay_tmpfs);
 
     let rootfs_layers = vec![rootfs_dir.to_path_buf()];
 

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -115,6 +115,7 @@ fn spawn_config_to_run_args(
         publish: sc.publish,
         nat: sc.nat,
         no_nat: sc.no_nat,
+        overlay_tmpfs: false,
         dns: sc.dns,
         dns_search: sc.dns_search,
         dns_option: sc.dns_options,

--- a/src/container.rs
+++ b/src/container.rs
@@ -1208,6 +1208,10 @@ pub struct Command {
     dns_options: Vec<String>,
     // Overlay filesystem (upper + work dirs; lower = chroot_dir).
     overlay: Option<OverlayConfig>,
+    // Put the overlay scratch (upper/work/merged) on the RAM-backed runtime
+    // tmpfs instead of the disk default. Fast + auto-freed but RAM-capped —
+    // opt-in for small, short-lived containers. See paths::overlay_scratch_base.
+    overlay_tmpfs: bool,
     // OCI sync: (ready_write_fd, listen_fd). Used by cmd_create to block the container
     // in pre_exec until "pelagos start" connects to exec.sock.
     oci_sync: Option<(i32, i32)>,
@@ -1377,6 +1381,7 @@ impl Command {
             dns_searches: Vec::new(),
             dns_options: Vec::new(),
             overlay: None,
+            overlay_tmpfs: false,
             oci_sync: None,
             pty_slave: None,
             container_cwd: None,
@@ -2454,6 +2459,18 @@ impl Command {
         self
     }
 
+    /// Place the overlay scratch (upper/work/merged) on the RAM-backed runtime
+    /// tmpfs instead of the disk default.
+    ///
+    /// Disk is the default — the writable layer is bounded by disk (not RAM) and
+    /// can't OOM the node, matching docker/containerd/podman. Opt into tmpfs for
+    /// small, short-lived, write-light containers that want RAM speed + auto-clean.
+    /// Equivalent to `PELAGOS_OVERLAY_TMPFS=1` / the `--overlay-tmpfs` CLI flag.
+    pub fn with_overlay_tmpfs(mut self, enabled: bool) -> Self {
+        self.overlay_tmpfs = enabled;
+        self
+    }
+
     /// Add a Landlock read-only rule: allow the container to read and execute
     /// files beneath `path` but not modify them.
     ///
@@ -3222,7 +3239,7 @@ impl Command {
         let overlay_merged_dir: Option<PathBuf> = if let Some(ref mut ov) = self.overlay {
             let pid = unsafe { libc::getpid() };
             let n = OVERLAY_COUNTER.fetch_add(1, Ordering::Relaxed);
-            let base = crate::paths::overlay_base(pid, n);
+            let base = crate::paths::overlay_scratch_base(pid, n, self.overlay_tmpfs);
             let merged = base.join("merged");
             std::fs::create_dir_all(&merged).map_err(Error::Io)?;
             // Auto-create ephemeral upper/work for image-layer mode.
@@ -6024,7 +6041,7 @@ impl Command {
         let overlay_merged_dir: Option<PathBuf> = if let Some(ref mut ov) = self.overlay {
             let pid = unsafe { libc::getpid() };
             let n = OVERLAY_COUNTER.fetch_add(1, Ordering::Relaxed);
-            let base = crate::paths::overlay_base(pid, n);
+            let base = crate::paths::overlay_scratch_base(pid, n, self.overlay_tmpfs);
             let merged = base.join("merged");
             std::fs::create_dir_all(&merged).map_err(Error::Io)?;
             if ov.upper_dir.as_os_str().is_empty() {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -169,9 +169,72 @@ pub fn oci_state_dir(id: &str) -> PathBuf {
     runtime_dir().join(id)
 }
 
-/// Overlay scratch directory: `<runtime>/overlay-<pid>-<n>/`.
+/// Per-UID **disk-backed** scratch root for container overlays.
+///
+/// Unlike `data_dir()` (which is shared once `/var/lib/pelagos` exists, so a
+/// non-root user can read the same image store as root), the overlay *scratch*
+/// is a per-UID execution boundary — like `runtime_dir()`, but on **disk**
+/// instead of the RAM-backed `/run` tmpfs. The container's writable layer is
+/// therefore bounded by disk (not RAM) and can't OOM the node. This matches
+/// docker/containerd/podman, which all keep the writable layer on disk.
+///
+/// - Root: `/var/lib/pelagos/scratch/`
+/// - Rootless: `$XDG_DATA_HOME/pelagos/scratch/` (default `~/.local/share/pelagos/scratch/`)
+///
+/// The scratch root is created mode 0700 (the per-UID boundary); individual
+/// `overlay-<pid>-<n>` dirs inside stay 0755 (the kernel checks overlay
+/// upper/work perms against the post-`setuid` fsuid), gated by the 0700 parent.
+pub fn scratch_root() -> PathBuf {
+    if !is_rootless() {
+        return PathBuf::from("/var/lib/pelagos/scratch");
+    }
+    // Rootless: always the per-user disk dir (NOT the shared /var/lib/pelagos),
+    // because scratch must be writable by — and isolated to — the running user.
+    if let Ok(xdg) = std::env::var("XDG_DATA_HOME") {
+        if !xdg.is_empty() {
+            return PathBuf::from(xdg).join("pelagos/scratch");
+        }
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        return PathBuf::from(home).join(".local/share/pelagos/scratch");
+    }
+    PathBuf::from(format!("/tmp/pelagos-scratch-{}", unsafe {
+        libc::getuid()
+    }))
+}
+
+/// Whether the overlay scratch should use the RAM-backed tmpfs (`runtime_dir()`)
+/// instead of the disk default. Global opt-in via `PELAGOS_OVERLAY_TMPFS=1`;
+/// the per-command `--overlay-tmpfs` flag is threaded in as the `tmpfs` arg.
+fn overlay_tmpfs_env() -> bool {
+    matches!(
+        std::env::var("PELAGOS_OVERLAY_TMPFS").ok().as_deref(),
+        Some("1") | Some("true")
+    )
+}
+
+/// Overlay scratch directory for a container (holds `upper/`, `work/`, `merged/`).
+///
+/// **Defaults to disk** (`scratch_root()/overlay-<pid>-<n>`). Opt into the
+/// RAM-backed tmpfs with `tmpfs = true` or `PELAGOS_OVERLAY_TMPFS=1`; or point it
+/// anywhere with `PELAGOS_OVERLAY_DIR` (highest precedence).
+pub fn overlay_scratch_base(pid: i32, n: u32, tmpfs: bool) -> PathBuf {
+    let name = format!("overlay-{}-{}", pid, n);
+    if let Ok(dir) = std::env::var("PELAGOS_OVERLAY_DIR") {
+        if !dir.is_empty() {
+            return PathBuf::from(dir).join(name);
+        }
+    }
+    if tmpfs || overlay_tmpfs_env() {
+        return runtime_dir().join(name);
+    }
+    scratch_root().join(name)
+}
+
+/// Back-compat wrapper — overlay scratch on the **disk** default.
+/// Prefer `overlay_scratch_base(pid, n, tmpfs)` at call sites that know the mode.
 pub fn overlay_base(pid: i32, n: u32) -> PathBuf {
-    runtime_dir().join(format!("overlay-{}-{}", pid, n))
+    overlay_scratch_base(pid, n, false)
 }
 
 /// DNS temp directory: `<runtime>/dns-<pid>-<n>/`.
@@ -655,13 +718,34 @@ mod tests {
         let rt = runtime_dir();
         assert!(containers_dir().starts_with(&rt));
         assert!(oci_state_dir("test").starts_with(&rt));
-        assert!(overlay_base(1, 0).starts_with(&rt));
+        // Overlay in tmpfs mode still lives under the runtime tmpfs dir.
+        assert!(overlay_scratch_base(1, 0, true).starts_with(&rt));
         assert!(dns_dir(1, 0).starts_with(&rt));
         assert!(hosts_dir(1, 0).starts_with(&rt));
         assert!(ipam_file().starts_with(&rt));
         assert!(nat_refcount_file().starts_with(&rt));
         assert!(port_forwards_file().starts_with(&rt));
         assert!(counter_file().starts_with(&rt));
+    }
+
+    #[test]
+    fn test_overlay_scratch_disk_default_tmpfs_optin() {
+        // Guard against a stray override leaking in from the environment.
+        if std::env::var("PELAGOS_OVERLAY_DIR").is_ok()
+            || std::env::var("PELAGOS_OVERLAY_TMPFS").is_ok()
+        {
+            return;
+        }
+        // Default (tmpfs=false) → disk scratch root, NOT the /run tmpfs.
+        let disk = overlay_scratch_base(7, 3, false);
+        assert!(disk.starts_with(scratch_root()));
+        assert!(!disk.starts_with(runtime_dir()));
+        // The back-compat wrapper defaults to disk too.
+        assert!(overlay_base(7, 3).starts_with(scratch_root()));
+        // Opt-in (tmpfs=true) → the runtime tmpfs.
+        assert!(overlay_scratch_base(7, 3, true).starts_with(runtime_dir()));
+        // Disk scratch must be a distinct location from the tmpfs runtime dir.
+        assert_ne!(scratch_root(), runtime_dir());
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8562,6 +8562,119 @@ mod images {
         );
     }
 
+    /// Spawns an image-layer container with the DEFAULT overlay mode and verifies
+    /// the overlay scratch (upper/work/merged) lands on the **disk** scratch root
+    /// (`paths::scratch_root()`), not the RAM-backed `/run` tmpfs.
+    ///
+    /// This is the #427 fix: a container's writable layer is bounded by disk, not
+    /// RAM, so it can't OOM the node and large writes (e.g. builds) aren't
+    /// RAM-capped. Failure means the default overlay location regressed onto the
+    /// tmpfs — reintroducing the RAM cap.
+    #[test]
+    #[serial]
+    fn test_overlay_default_on_disk() {
+        if !is_root() {
+            eprintln!("Skipping test_overlay_default_on_disk: requires root");
+            return;
+        }
+        // A stray override would move the overlay and invalidate the assertion.
+        if std::env::var("PELAGOS_OVERLAY_DIR").is_ok()
+            || std::env::var("PELAGOS_OVERLAY_TMPFS").is_ok()
+        {
+            eprintln!("Skipping test_overlay_default_on_disk: PELAGOS_OVERLAY_* set");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping test_overlay_default_on_disk: alpine-rootfs not found");
+            return;
+        };
+        let layer = tempfile::tempdir().expect("layer dir");
+        copy_rootfs(&rootfs, layer.path());
+        let layers = vec![layer.path().to_path_buf()];
+
+        let mut child = Command::new("/bin/true")
+            .with_image_layers(layers)
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS | Namespace::PID)
+            .env("PATH", ALPINE_PATH)
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Null)
+            .stderr(Stdio::Null)
+            .spawn()
+            .expect("spawn");
+
+        let merged = child
+            .overlay_merged_dir()
+            .expect("merged dir")
+            .to_path_buf();
+        let overlay_base = merged.parent().expect("merged parent").to_path_buf();
+
+        assert!(
+            overlay_base.starts_with(pelagos::paths::scratch_root()),
+            "default overlay should be on the disk scratch root {:?}, got {:?}",
+            pelagos::paths::scratch_root(),
+            overlay_base
+        );
+        assert!(
+            !overlay_base.starts_with(pelagos::paths::runtime_dir()),
+            "default overlay must NOT be on the /run tmpfs: {:?}",
+            overlay_base
+        );
+
+        let status = child.wait().expect("wait");
+        assert!(status.success(), "container should exit 0");
+    }
+
+    /// Same as above but with the tmpfs opt-in (`with_overlay_tmpfs(true)`, i.e.
+    /// the `--overlay-tmpfs` flag): the overlay scratch must land back on the
+    /// RAM-backed `/run` tmpfs (`paths::runtime_dir()`). Verifies the opt-in path
+    /// still works after the disk default.
+    #[test]
+    #[serial]
+    fn test_overlay_tmpfs_optin() {
+        if !is_root() {
+            eprintln!("Skipping test_overlay_tmpfs_optin: requires root");
+            return;
+        }
+        if std::env::var("PELAGOS_OVERLAY_DIR").is_ok() {
+            eprintln!("Skipping test_overlay_tmpfs_optin: PELAGOS_OVERLAY_DIR set");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping test_overlay_tmpfs_optin: alpine-rootfs not found");
+            return;
+        };
+        let layer = tempfile::tempdir().expect("layer dir");
+        copy_rootfs(&rootfs, layer.path());
+        let layers = vec![layer.path().to_path_buf()];
+
+        let mut child = Command::new("/bin/true")
+            .with_image_layers(layers)
+            .with_overlay_tmpfs(true)
+            .with_namespaces(Namespace::MOUNT | Namespace::UTS | Namespace::PID)
+            .env("PATH", ALPINE_PATH)
+            .stdin(Stdio::Null)
+            .stdout(Stdio::Null)
+            .stderr(Stdio::Null)
+            .spawn()
+            .expect("spawn");
+
+        let merged = child
+            .overlay_merged_dir()
+            .expect("merged dir")
+            .to_path_buf();
+        let overlay_base = merged.parent().expect("merged parent").to_path_buf();
+
+        assert!(
+            overlay_base.starts_with(pelagos::paths::runtime_dir()),
+            "--overlay-tmpfs should put the overlay on the /run tmpfs {:?}, got {:?}",
+            pelagos::paths::runtime_dir(),
+            overlay_base
+        );
+
+        let status = child.wait().expect("wait");
+        assert!(status.success(), "container should exit 0");
+    }
+
     /// test_pull_and_run_real_image
     ///
     /// Requires: root, network access.


### PR DESCRIPTION
The overlay scratch (upper/work/merged) was placed on the /run tmpfs
(runtime_dir), so every container's writable layer was RAM-capped (~3 GB on a
16 GB node) and could OOM the node — a build's cargo `target/` overflows it.
Docker/containerd/podman all keep the writable layer on disk; RAM shouldn't be
the default.

- paths.rs: new `scratch_root()` (per-UID DISK dir — /var/lib/pelagos/scratch for
  root, ~/.local/share/pelagos/scratch rootless) + `overlay_scratch_base(pid,n,tmpfs)`:
  disk by default, tmpfs opt-in, `PELAGOS_OVERLAY_DIR` override. `overlay_base` now
  delegates (disk default).
- container.rs: `Command.overlay_tmpfs` + `with_overlay_tmpfs()`; both auto-managed
  overlay call sites use `overlay_scratch_base(pid, n, self.overlay_tmpfs)`.
- cli run: `--overlay-tmpfs` flag (global env `PELAGOS_OVERLAY_TMPFS=1`).
- cleanup.rs: also sweep the disk scratch (disk overlays survive reboot).
- Tests: paths unit test; integration test_overlay_default_on_disk +
  test_overlay_tmpfs_optin; docs/INTEGRATION_TESTS.md entries.

Fixes the in-cluster build RAM cap and the general OOM footgun, and keeps the
per-UID execution boundary (scratch_root is per-UID, 0700). The overlay location
is a single function, leaving a clean seam for later per-container encryption
(fscrypt/gocryptfs). Nested-build EINVAL is a separate fix (#426).

Fixes #427

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
