### PR TITLE
fix(spawn): map full id range for nested/in-pod builds so image-owned files copy up (#432)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -1010,6 +1010,28 @@ direct-`unshare` path and gets EPERM, so `.spawn()` panics. Or the `/proc` stash
 that unblocks a fresh procfs mount in a nested user namespace regressed, so `/proc`
 is missing/inherited. Either breaks in-cluster (in-pod) `pelagos build`.
 
+### `test_nested_build_overlay_copyup_unmapped_gid`
+**Requires:** root, rootfs
+
+Reproduces #432 (nested `pelagos build` RUN steps could not create files inside
+image directories owned by a **non-root uid/gid**). On a **dedicated thread** it
+drops `CAP_SYS_ADMIN` (entering the nested/in-pod path), builds an overlay whose
+lower layer contains a directory owned by gid 983 (mirroring rust's
+`/usr/local/cargo`), then runs a container that creates a file inside it —
+forcing overlayfs to copy the directory up. Asserts the container exits 0 and
+prints `CREATED`.
+
+What a failure indicates: the nested user namespace has regressed to mapping a
+single id (`0→0`). overlayfs copy-up must preserve the lower directory's
+ownership onto the new upper file, but an id unmapped in the namespace cannot be
+represented, so the create fails with `EOVERFLOW` — the exact failure that made
+`cargo build` (and any tool writing under a non-root-owned image dir) fail
+in-pod with the misleading "failed to acquire package cache lock: Value too
+large for defined data type". The fix identity-maps the whole id space in the
+nested uid-0 case (CAP_SETUID/CAP_SETGID are still held). Most meaningful on a
+native-overlay backend (ext4/xfs); fuse-overlayfs fallbacks copy up differently
+but the create must still succeed.
+
 ### `test_build_network_host_shares_parent_netns`
 **Requires:** root, rootfs, host with ≥2 network interfaces
 

--- a/scripts/repro-432-fix-proof.sh
+++ b/scripts/repro-432-fix-proof.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# #432 fix proof: does identity-mapping the FULL id range in the nested user
+# namespace (instead of only 0->0) let overlay copy-up of an image file owned
+# by an otherwise-unmapped gid succeed? Run as root on ext4/xfs.
+set -u
+
+trial() {  # $1 = unshare id-map args; $2 = label
+  local mapargs="$1" label="$2"
+  local B; B=$(mktemp -d /var/tmp/f432.XXXX)
+  mkdir -p "$B/l/usr/local/cargo" "$B/u" "$B/w" "$B/m"
+  echo seed > "$B/l/usr/local/cargo/env"
+  chown -R 0:983 "$B/l/usr/local"   # image dir owned by a non-root gid (like rust's cargo)
+  printf '%-46s -> ' "$label"
+  capsh --drop=cap_sys_admin -- -c "unshare -m --user $mapargs bash -c '
+    mount -t overlay overlay -o lowerdir=$B/l,upperdir=$B/u,workdir=$B/w,metacopy=off $B/m 2>/dev/null || { echo MOUNT-FAIL; exit; }
+    if touch $B/m/usr/local/cargo/.package-cache 2>/dev/null; then echo CREATE-OK; else echo CREATE-FAIL-EOVERFLOW; fi
+  '"
+  rm -rf "$B"
+}
+
+trial "--map-root-user"                              "0->0 only            (current pelagos = broken)"
+trial "--map-users 0:0:65536 --map-groups 0:0:65536" "identity 0..65535    (proposed fix, 64k range)"
+trial "--map-users 0:0:4294967295 --map-groups 0:0:4294967295" "identity full range  (proposed fix, full)"

--- a/scripts/repro-432-pelagos-build.sh
+++ b/scripts/repro-432-pelagos-build.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# #432 definitive repro: run a REAL `pelagos build` with a cargo RUN step under
+# the exact nested/in-pod condition — uid 0 with CAP_SYS_ADMIN dropped (#426) —
+# which forces the user-namespace + native-overlay+userxattr path, straced, to
+# capture the syscall that returns EOVERFLOW (cargo "package cache lock" error).
+#
+# Needs a pelagos >= v0.65.44 (for --network host) and an ext4/xfs store (NOT
+# btrfs). Invoke on the node as:
+#   sudo capsh --drop=cap_sys_admin -- -c 'PELAGOS=/path/to/pelagos bash repro-432-pelagos-build.sh'
+set -u
+PELAGOS="${PELAGOS:-pelagos}"
+D=$(mktemp -d /var/tmp/repro432.XXXX)   # /var/tmp = ext4 (NOT /tmp tmpfs)
+cd "$D"
+
+echo "=== identity (want uid 0, CapEff missing cap_sys_admin) ==="
+id; grep CapEff /proc/self/status
+echo "=== store backing fs ==="; stat -f -c '%T' /var/lib/pelagos
+echo "=== pelagos ==="; "$PELAGOS" --version
+
+# Valid dependency so cargo proceeds to resolve -> acquires the package-cache
+# lock (flock on $CARGO_HOME/.package-cache) -> then fetches from the registry.
+cat > Remfile <<'REMFILE'
+FROM docker.io/library/rust:1-bookworm
+RUN set -x; \
+    echo "--- does .package-cache preexist in lower? ---"; \
+    ls -la /usr/local/cargo/.package-cache 2>&1 || echo "(absent)"; \
+    echo "--- touch (glibc open, adds O_LARGEFILE) then stat size ---"; \
+    touch /usr/local/cargo/.package-cache 2>&1 && \
+      stat -c 'PROBE size=%s ino=%i blocks=%b' /usr/local/cargo/.package-cache; \
+    echo "--- now cargo (Rust std open, NO O_LARGEFILE) ---"; \
+    cargo new /work/proj && cd /work/proj && \
+    printf '%s\n' 'anyhow = "1"' >> Cargo.toml && \
+    cargo build
+REMFILE
+echo "=== Remfile ==="; cat Remfile
+
+echo "=== strace'd pelagos build --network host ==="
+strace -f -qq -y -e trace=%file,%desc -o "$D/s.out" \
+  "$PELAGOS" build --network host -t repro432:test "$D" >"$D/b.out" 2>"$D/b.err"
+echo "pelagos build exit=$?"
+echo "=== build stderr (last 30) ==="; tail -30 "$D/b.err"
+echo "=== build stdout (last 10) ==="; tail -10 "$D/b.out"
+echo "=== EOVERFLOW syscalls in strace ==="
+grep -n "EOVERFLOW" "$D/s.out" | head -30 || echo "  (none)"
+echo "=== package-cache / os-error-75 in build output ==="
+grep -niE "package cache|error 75|value too large|EOVERFLOW" "$D/b.err" "$D/b.out" || echo "  (none)"
+echo "=== flock/fcntl calls on .package-cache in strace ==="
+grep -nE "package-cache|\.package_cache" "$D/s.out" | head -20 || echo "  (none)"
+echo "DIR=$D"

--- a/scripts/repro-432-unmapped-gid.sh
+++ b/scripts/repro-432-unmapped-gid.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# #432 root-cause isolation: is the overlay copy-up EOVERFLOW caused by a lower
+# file owned by a uid/gid that is UNMAPPED in the nested user namespace
+# (pelagos maps only 0->0, but image layers own files as arbitrary ids)?
+# Run as root on an ext4/xfs node.
+set -u
+
+test_gid() {  # $1 = gid that owns the lower cargo tree; $2 = label
+  local gid="$1" label="$2"
+  local B; B=$(mktemp -d /var/tmp/g432.XXXX)
+  mkdir -p "$B/l/usr/local/cargo" "$B/u" "$B/w" "$B/m"
+  echo seed > "$B/l/usr/local/cargo/env"
+  chown -R "0:$gid" "$B/l/usr/local"
+  printf '%-42s -> ' "$label"
+  # nested condition: uid 0, no CAP_SYS_ADMIN, userns mapping ONLY 0->0
+  capsh --drop=cap_sys_admin -- -c "unshare -Urm bash -c '
+    mount -t overlay overlay -o lowerdir=$B/l,upperdir=$B/u,workdir=$B/w,metacopy=off $B/m 2>/dev/null || { echo MOUNT-FAIL; exit; }
+    if touch $B/m/usr/local/cargo/.package-cache 2>/dev/null; then echo CREATE-OK; else echo CREATE-FAIL-EOVERFLOW; fi
+  '"
+  rm -rf "$B"
+}
+
+test_gid 0    "lower owned by gid 0    (mapped in userns)"
+test_gid 983  "lower owned by gid 983  (UNMAPPED in userns)"
+test_gid 1000 "lower owned by gid 1000 (UNMAPPED in userns)"

--- a/src/container.rs
+++ b/src/container.rs
@@ -182,6 +182,15 @@ fn pre_exec_err<E: Into<io::Error>>(ctx: &str, e: E) -> io::Error {
 /// perturbs the normal host path.
 fn has_effective_cap_sys_admin() -> bool {
     const CAP_SYS_ADMIN: u32 = 21;
+    has_effective_cap(CAP_SYS_ADMIN)
+}
+
+/// Returns `true` if the calling thread holds capability `cap` (a `CAP_*`
+/// number) in its effective set.  Reads `CapEff` from `/proc/thread-self/status`
+/// — capabilities are per-thread, and `unshare(2)`/`fork(2)` inherit the calling
+/// thread's set.  Fails **open** (returns `true`) if the field cannot be read or
+/// parsed, so a probe failure never blocks a path that would otherwise work.
+fn has_effective_cap(cap: u32) -> bool {
     let status = match std::fs::read_to_string("/proc/thread-self/status") {
         Ok(s) => s,
         Err(_) => return true,
@@ -189,7 +198,7 @@ fn has_effective_cap_sys_admin() -> bool {
     for line in status.lines() {
         if let Some(hex) = line.strip_prefix("CapEff:") {
             if let Ok(caps) = u64::from_str_radix(hex.trim(), 16) {
-                return caps & (1u64 << CAP_SYS_ADMIN) != 0;
+                return caps & (1u64 << cap) != 0;
             }
         }
     }
@@ -3119,20 +3128,54 @@ impl Command {
                         }
                     }
                 }
-                // Fallback: single-UID map (current behavior).
+                // Fallback map.  Two cases reach here:
+                //
+                // 1. Nested uid-0 (in-pod, no CAP_SYS_ADMIN — the #426 path).
+                //    A single `0→0` map is NOT enough: container image layers own
+                //    files as arbitrary uids/gids (rust's `/usr/local/cargo` is
+                //    gid 983).  overlayfs copy-up must preserve that ownership onto
+                //    the new upper file, and an id that is *unmapped* in the user
+                //    namespace cannot be represented — so creating any file beneath
+                //    such a directory fails with `EOVERFLOW` (#432; surfaces as
+                //    cargo's misleading "failed to acquire package cache lock").
+                //    We hold CAP_SETUID/CAP_SETGID here (only CAP_SYS_ADMIN was
+                //    dropped), so identity-map the whole id space; the parent
+                //    writes the multi-count map (`needs_parent_idmap`).
+                //
+                // 2. True rootless with no subuid delegation: keep the single-UID
+                //    map — an unprivileged process may only map its own id.
+                const FULL_ID_RANGE: u32 = u32::MAX; // maps [0, 0xFFFFFFFE]; excludes (id_t)-1
+                const CAP_SETGID: u32 = 6;
+                const CAP_SETUID: u32 = 7;
                 if self.uid_maps.is_empty() {
-                    self.uid_maps.push(UidMap {
-                        inside: 0,
-                        outside: host_uid,
-                        count: 1,
-                    });
+                    if !is_rootless && has_effective_cap(CAP_SETUID) {
+                        self.uid_maps.push(UidMap {
+                            inside: 0,
+                            outside: 0,
+                            count: FULL_ID_RANGE,
+                        });
+                    } else {
+                        self.uid_maps.push(UidMap {
+                            inside: 0,
+                            outside: host_uid,
+                            count: 1,
+                        });
+                    }
                 }
                 if self.gid_maps.is_empty() {
-                    self.gid_maps.push(GidMap {
-                        inside: 0,
-                        outside: host_gid,
-                        count: 1,
-                    });
+                    if !is_rootless && has_effective_cap(CAP_SETGID) {
+                        self.gid_maps.push(GidMap {
+                            inside: 0,
+                            outside: 0,
+                            count: FULL_ID_RANGE,
+                        });
+                    } else {
+                        self.gid_maps.push(GidMap {
+                            inside: 0,
+                            outside: host_gid,
+                            count: 1,
+                        });
+                    }
                 }
             }
             // Bridge networking requires root-level capabilities on the host network.
@@ -6053,20 +6096,54 @@ impl Command {
                         }
                     }
                 }
-                // Fallback: single-UID map (current behavior).
+                // Fallback map.  Two cases reach here:
+                //
+                // 1. Nested uid-0 (in-pod, no CAP_SYS_ADMIN — the #426 path).
+                //    A single `0→0` map is NOT enough: container image layers own
+                //    files as arbitrary uids/gids (rust's `/usr/local/cargo` is
+                //    gid 983).  overlayfs copy-up must preserve that ownership onto
+                //    the new upper file, and an id that is *unmapped* in the user
+                //    namespace cannot be represented — so creating any file beneath
+                //    such a directory fails with `EOVERFLOW` (#432; surfaces as
+                //    cargo's misleading "failed to acquire package cache lock").
+                //    We hold CAP_SETUID/CAP_SETGID here (only CAP_SYS_ADMIN was
+                //    dropped), so identity-map the whole id space; the parent
+                //    writes the multi-count map (`needs_parent_idmap`).
+                //
+                // 2. True rootless with no subuid delegation: keep the single-UID
+                //    map — an unprivileged process may only map its own id.
+                const FULL_ID_RANGE: u32 = u32::MAX; // maps [0, 0xFFFFFFFE]; excludes (id_t)-1
+                const CAP_SETGID: u32 = 6;
+                const CAP_SETUID: u32 = 7;
                 if self.uid_maps.is_empty() {
-                    self.uid_maps.push(UidMap {
-                        inside: 0,
-                        outside: host_uid,
-                        count: 1,
-                    });
+                    if !is_rootless && has_effective_cap(CAP_SETUID) {
+                        self.uid_maps.push(UidMap {
+                            inside: 0,
+                            outside: 0,
+                            count: FULL_ID_RANGE,
+                        });
+                    } else {
+                        self.uid_maps.push(UidMap {
+                            inside: 0,
+                            outside: host_uid,
+                            count: 1,
+                        });
+                    }
                 }
                 if self.gid_maps.is_empty() {
-                    self.gid_maps.push(GidMap {
-                        inside: 0,
-                        outside: host_gid,
-                        count: 1,
-                    });
+                    if !is_rootless && has_effective_cap(CAP_SETGID) {
+                        self.gid_maps.push(GidMap {
+                            inside: 0,
+                            outside: 0,
+                            count: FULL_ID_RANGE,
+                        });
+                    } else {
+                        self.gid_maps.push(GidMap {
+                            inside: 0,
+                            outside: host_gid,
+                            count: 1,
+                        });
+                    }
                 }
             }
             // Bridge networking requires root-level capabilities on the host network.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8809,6 +8809,101 @@ mod images {
             .expect("nested-spawn test thread panicked (see assertion above)");
     }
 
+    /// #432: a nested `pelagos build` RUN step (uid 0 without `CAP_SYS_ADMIN`)
+    /// could not create files inside image directories owned by a **non-root
+    /// uid/gid**. Container image layers own files as arbitrary ids (rust's
+    /// `/usr/local/cargo` is gid 983); overlayfs copy-up must preserve that
+    /// ownership onto the new upper file, but the nested user namespace mapped
+    /// only `0→0`, so an unmapped id could not be represented and the create
+    /// failed with `EOVERFLOW` — surfacing as cargo's misleading "failed to
+    /// acquire package cache lock: Value too large for defined data type".
+    ///
+    /// This reproduces it faithfully: on a dedicated thread it drops
+    /// `CAP_SYS_ADMIN` (entering the nested/in-pod path), builds an overlay whose
+    /// lower layer has a directory owned by a non-root gid, then runs a container
+    /// that creates a file inside it — forcing overlayfs to copy the directory up.
+    ///
+    /// **What failure means:** before the fix, the nested user namespace mapped a
+    /// single id (`0→0`), so the copy-up of the non-root-gid directory returned
+    /// EOVERFLOW and the `touch` failed (container exits non-zero). The fix
+    /// identity-maps the whole id space in the nested uid-0 case (we still hold
+    /// CAP_SETUID/CAP_SETGID there), so every image-layer ownership is
+    /// representable and the create succeeds. A pass proves a file can be created
+    /// beneath a non-root-owned image directory in the nested build path.
+    ///
+    /// Most meaningful on a native-overlay backend (ext4/xfs); on backends that
+    /// fall back to fuse-overlayfs the copy-up path differs but the test still
+    /// asserts the create succeeds.
+    ///
+    /// Requires: root + `alpine-rootfs`.
+    #[test]
+    fn test_nested_build_overlay_copyup_unmapped_gid() {
+        if !is_root() {
+            eprintln!("Skipping test_nested_build_overlay_copyup_unmapped_gid: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!(
+                "Skipping test_nested_build_overlay_copyup_unmapped_gid: alpine-rootfs not found"
+            );
+            return;
+        };
+
+        let handle = std::thread::spawn(move || {
+            // Arbitrary non-root gid, mirroring a real image (rust's
+            // /usr/local/cargo is gid 983). Any id unmapped by a `0→0`-only user
+            // namespace triggers the bug.
+            const IMAGE_GID: u32 = 983;
+
+            let layer = tempfile::tempdir().expect("layer dir");
+            copy_rootfs(&rootfs, layer.path());
+
+            // A lower-layer directory (and file) owned by IMAGE_GID. Creating a
+            // file inside it forces overlayfs to copy the directory up, preserving
+            // this ownership onto the upper — the operation that failed with #432.
+            let img_dir = layer.path().join("cargotest");
+            std::fs::create_dir_all(&img_dir).expect("create image dir");
+            std::fs::write(img_dir.join("config"), b"seed").expect("seed file");
+            // CAP_CHOWN is retained (only CAP_SYS_ADMIN is dropped below).
+            std::os::unix::fs::chown(&img_dir, Some(0), Some(IMAGE_GID)).expect("chown dir");
+            std::os::unix::fs::chown(img_dir.join("config"), Some(0), Some(IMAGE_GID))
+                .expect("chown file");
+
+            // Enter the nested/in-pod condition: uid 0 without CAP_SYS_ADMIN.
+            assert!(
+                drop_cap_sys_admin(),
+                "failed to drop CAP_SYS_ADMIN (capget/capset)"
+            );
+
+            let layers = vec![layer.path().to_path_buf()];
+            let (status, stdout_bytes, stderr_bytes) = Command::new("/bin/sh")
+                .args(["-c", "touch /cargotest/.package-cache && echo CREATED"])
+                .with_image_layers(layers)
+                .with_namespaces(Namespace::UTS | Namespace::IPC | Namespace::PID)
+                .with_proc_mount()
+                .env("PATH", ALPINE_PATH)
+                .stdin(Stdio::Null)
+                .stdout(Stdio::Piped)
+                .stderr(Stdio::Piped)
+                .spawn()
+                .expect("nested spawn should succeed")
+                .wait_with_output()
+                .expect("wait_with_output");
+
+            let stdout = String::from_utf8_lossy(&stdout_bytes);
+            let stderr = String::from_utf8_lossy(&stderr_bytes);
+            assert!(
+                status.success() && stdout.contains("CREATED"),
+                "creating a file beneath a non-root-gid image directory must \
+                 succeed under the nested user namespace (regression #432); \
+                 status={status:?} stdout={stdout:?} stderr={stderr:?}"
+            );
+        });
+        handle
+            .join()
+            .expect("nested copy-up test thread panicked (see assertion above)");
+    }
+
     /// Interface names from `/proc/net/dev` (skips the two header lines; the
     /// field before ':' is the interface name). `/proc/net/dev` is per-network-
     /// namespace, so it is a reliable probe of which netns a process is in.


### PR DESCRIPTION
## Summary
Fixes #432. A nested `pelagos build` RUN step (uid 0 without `CAP_SYS_ADMIN` — a k8s pod, the #426 path) could not create files inside image directories owned by a **non-root uid/gid**. `cargo build` was the visible casualty:

```
error: failed to acquire package cache lock
  failed to open: /usr/local/cargo/.package-cache
  Value too large for defined data type (os error 75)   # EOVERFLOW
```

## Root cause (isolated end-to-end on an ext4 node)
The nested user namespace mapped only `0→0`. Container image layers own files as arbitrary ids — rust's `/usr/local/cargo` is **gid 983**. overlayfs **copy-up** must preserve that ownership onto the new upper file, but an id **unmapped** in the namespace cannot be represented, so *any* create beneath such a directory fails with `EOVERFLOW`.

Everything else was a red herring, **including the issue's own framing**:
- ❌ "package cache lock" — fails at `openat`, before any `flock`
- ❌ `userxattr` — the real mount doesn't even use it
- ❌ inode overflow / `xino` / cross-device — inodes ~10M, same device
- ❌ Rust / `O_LARGEFILE` — plain `touch` (glibc) fails identically
- ✅ **unmapped uid/gid in the nested userns → copy-up EOVERFLOW**

## Fix
In the nested uid-0 case, identity-map the whole id space instead of `0→0`. We still hold `CAP_SETUID`/`CAP_SETGID` there (only `CAP_SYS_ADMIN` was dropped), so the parent writes a multi-count map — the same mechanism already used for root-created user namespaces. Keeps in-pod builds **fully rootless on native overlay** (no privileged pod, no fuse-overlayfs perf hit). True rootless (uid ≠ 0) is unchanged (keeps subuid-range mapping). Both `spawn` and `spawn_interactive` map-setup sites updated.

## Validation
- **Gold-standard end-to-end:** the real nested `rust:1-bookworm` + `cargo build` RUN step that failed with EOVERFLOW now completes and produces an image, rootless on ext4 (ipc4).
- Isolation proof: `0→0` map → `CREATE-FAIL (EOVERFLOW)`; identity range map → `CREATE-OK`.
- New integration test `test_nested_build_overlay_copyup_unmapped_gid` (+ doc); `cargo test --lib` 392 passed; canonical `cargo clippy -- -D warnings` clean.
- Reproduction / root-cause / fix-proof scripts in `scripts/repro-432-*.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)