### PR TITLE
fix(spawn): keep setgroups=allow in nested user namespaces so apt/su work (#434)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -1032,6 +1032,21 @@ nested uid-0 case (CAP_SETUID/CAP_SETGID are still held). Most meaningful on a
 native-overlay backend (ext4/xfs); fuse-overlayfs fallbacks copy up differently
 but the create must still succeed.
 
+### `test_nested_build_setgroups_allowed`
+**Requires:** root, rootfs
+
+Reproduces #434 (nested build's user namespace set `setgroups=deny`, breaking
+`apt` and any privilege-dropping tool). On a **dedicated thread** it drops
+`CAP_SYS_ADMIN` (nested/in-pod path), spawns an overlay container, and reads
+`/proc/self/setgroups` — asserting it is **`allow`**.
+
+What a failure indicates: the parent id-map writer denied setgroups again. Because
+the root parent holds `CAP_SETGID` it can write the gid_map while setgroups stays
+`allow` (as Docker/Podman/runc do for range-mapped build user namespaces); denying
+it makes `setgroups(2)` inside the container return EPERM, so e.g. `apt-get install`
+dies with "Method http has died". Backend-independent (about the id-map, not the
+overlay), so it holds on both native-overlay and fuse-overlayfs hosts.
+
 ### `test_build_network_host_shares_parent_netns`
 **Requires:** root, rootfs, host with ≥2 network interfaces
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -5668,9 +5668,18 @@ impl Command {
                         }
                     }
                     if !gid_maps_h.is_empty() {
-                        // Must deny setgroups before writing gid_map (kernel requirement).
-                        let sg_path = format!("/proc/{}/setgroups", child_pid);
-                        let _ = std::fs::write(&sg_path, b"deny\n");
+                        // A root parent holding CAP_SETGID may write the gid_map while
+                        // /proc/pid/setgroups stays "allow". Leaving it "allow" lets the
+                        // container call setgroups(2) — required by apt (drops privileges
+                        // to _apt), su, and other tools. Only the unprivileged path must
+                        // write "deny" before an own-id gid_map. Denying here broke
+                        // `apt-get` in nested/in-pod builds once #432 removed the
+                        // privileged workaround (setgroups EPERM → "Method http died").
+                        const CAP_SETGID: u32 = 6;
+                        if !has_effective_cap(CAP_SETGID) {
+                            let sg_path = format!("/proc/{}/setgroups", child_pid);
+                            let _ = std::fs::write(&sg_path, b"deny\n");
+                        }
                         let path = format!("/proc/{}/gid_map", child_pid);
                         let content: String = gid_maps_h
                             .iter()
@@ -8218,8 +8227,14 @@ impl Command {
                         }
                     }
                     if !gid_maps_h.is_empty() {
-                        let sg_path = format!("/proc/{}/setgroups", child_pid);
-                        let _ = std::fs::write(&sg_path, b"deny\n");
+                        // See spawn(): keep setgroups "allow" when we hold CAP_SETGID so
+                        // the container can call setgroups(2) (apt/_apt, su). Only the
+                        // unprivileged path must deny before an own-id gid_map.
+                        const CAP_SETGID: u32 = 6;
+                        if !has_effective_cap(CAP_SETGID) {
+                            let sg_path = format!("/proc/{}/setgroups", child_pid);
+                            let _ = std::fs::write(&sg_path, b"deny\n");
+                        }
                         let path = format!("/proc/{}/gid_map", child_pid);
                         let content: String = gid_maps_h
                             .iter()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8904,6 +8904,73 @@ mod images {
             .expect("nested copy-up test thread panicked (see assertion above)");
     }
 
+    /// #434: a nested build (uid 0 without `CAP_SYS_ADMIN`) must leave
+    /// `/proc/self/setgroups` = **`allow`** so the container can call
+    /// `setgroups(2)` — `apt` (drops privileges to `_apt`), `su`, and other
+    /// privilege-dropping tools require it. The root parent that writes the
+    /// child's gid_map holds `CAP_SETGID`, so it does NOT need to deny setgroups
+    /// (that is only required for the unprivileged own-id mapping). This matches
+    /// Docker/Podman/runc for range-mapped build user namespaces.
+    ///
+    /// **What failure means:** the nested userns is back to `setgroups=deny`, so
+    /// any RUN step that drops groups fails with `setgroups (Operation not
+    /// permitted)` — e.g. `apt-get install` dies with "Method http has died".
+    /// Backend-independent (this is about the id-map, not the overlay), so it is
+    /// meaningful on both native-overlay and fuse-overlayfs hosts.
+    ///
+    /// Requires: root + `alpine-rootfs`.
+    #[test]
+    fn test_nested_build_setgroups_allowed() {
+        if !is_root() {
+            eprintln!("Skipping test_nested_build_setgroups_allowed: requires root");
+            return;
+        }
+        let Some(rootfs) = get_test_rootfs() else {
+            eprintln!("Skipping test_nested_build_setgroups_allowed: alpine-rootfs not found");
+            return;
+        };
+
+        let handle = std::thread::spawn(move || {
+            assert!(
+                drop_cap_sys_admin(),
+                "failed to drop CAP_SYS_ADMIN (capget/capset)"
+            );
+            let layer = tempfile::tempdir().expect("layer dir");
+            copy_rootfs(&rootfs, layer.path());
+            let layers = vec![layer.path().to_path_buf()];
+
+            let (status, stdout_bytes, stderr_bytes) = Command::new("/bin/sh")
+                .args(["-c", "cat /proc/self/setgroups"])
+                .with_image_layers(layers)
+                .with_namespaces(Namespace::UTS | Namespace::IPC | Namespace::PID)
+                .with_proc_mount()
+                .env("PATH", ALPINE_PATH)
+                .stdin(Stdio::Null)
+                .stdout(Stdio::Piped)
+                .stderr(Stdio::Piped)
+                .spawn()
+                .expect("nested spawn should succeed")
+                .wait_with_output()
+                .expect("wait_with_output");
+
+            let stdout = String::from_utf8_lossy(&stdout_bytes);
+            let stderr = String::from_utf8_lossy(&stderr_bytes);
+            assert!(
+                status.success(),
+                "container should exit 0; stdout={stdout:?} stderr={stderr:?}"
+            );
+            assert_eq!(
+                stdout.trim(),
+                "allow",
+                "nested-build user namespace must leave setgroups=allow so \
+                 setgroups(2) works (regression #434); got {stdout:?}"
+            );
+        });
+        handle
+            .join()
+            .expect("nested setgroups test thread panicked (see assertion above)");
+    }
+
     /// Interface names from `/proc/net/dev` (skips the two header lines; the
     /// field before ':' is the interface name). `/proc/net/dev` is per-network-
     /// namespace, so it is a reliable probe of which netns a process is in.


### PR DESCRIPTION
## Summary
Fixes #434. After #432 removed the privileged-pod workaround, a rootless nested `pelagos build` (uid 0 without `CAP_SYS_ADMIN`) failed on any RUN step that calls `setgroups(2)` — notably `apt-get`:

```
E: setgroups 0 failed - setgroups (1: Operation not permitted)
E: Method http has died unexpectedly!
```

## Cause
The parent id-map writer set `/proc/<pid>/setgroups=deny` before writing the child's gid_map. That deny is only needed for the **unprivileged own-id** mapping. In the nested build the **root parent** writes the map and holds `CAP_SETGID`, so it can write the gid_map while `setgroups` stays `allow` (what Docker/Podman/runc do for range-mapped build user namespaces). Latent until now — the old privileged pod skipped the userns entirely.

## Fix
Both parent id-map writer sites (`spawn` + `spawn_interactive`): only write `setgroups=deny` when we do **not** hold `CAP_SETGID`; otherwise leave it `allow`.

## Validation
- Minimal repro (`FROM debian` / `RUN apt-get install ca-certificates`) under `capsh --drop=cap_sys_admin` on an ext4 node: **fails before, succeeds after** (`Fetched … / Successfully built`).
- New test `test_nested_build_setgroups_allowed` (backend-independent); `cargo test --lib` 392 passed; `cargo clippy -- -D warnings` clean.
- Completes the privileged-free in-cluster gruesome build (cargo #432 + apt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)