### PR TITLE
fix(cgroup): reap the container cgroup on teardown, not just rmdir (#412)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -5502,3 +5502,17 @@ instance CrashLooped on `bind: address already in use`). `kill_cgroup` sweeps th
 cgroup (atomic `cgroup.kill`, or a `cgroup.procs` walk) so nothing survives. The test
 specifically verifies a **setsid session leader** — which a single-PID/process-group kill
 would leave alive — is reaped. A failure here means container teardown can leak orphans.
+
+## `issue_412_cgroup_kill_orphans::test_teardown_cgroup_reaps_orphan_on_self_exit`
+**Requires root** and **cgroup v2** (skips otherwise). Guards the *reopened* half of
+#412: the **teardown** path, not just the CLI stop/rm paths. Creates a test cgroup, runs
+a shell that joins it, backgrounds a **`setsid sleep`**, then **exits** — mimicking a
+container that **self-exits under crash-restart churn** (which never calls `pelagos
+stop`). It then drives `pelagos::cgroup::teardown_cgroup` directly against that state and
+asserts the orphan is **killed** and the cgroup **removed**. **Why it matters:** the
+watcher runs `teardown_cgroup` on every container exit; it previously only did
+`cg.delete()` (a bare rmdir), which fails on a non-empty cgroup — so a `setsid`'d/
+reparented descendant survived, held its port/lock, and wedged every restart into
+CrashLoop (MetalLB speaker on :7946, Vault on its raft.db lock, both seen 2026-07-04). A
+failure here means teardown regressed to rmdir-without-reap and orphans can leak again.
+The companion rootless path (`teardown_rootless_cgroup`) is hardened the same way.

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -400,6 +400,16 @@ pub fn setup_cgroup(cfg: &CgroupConfig, child_pid: u32) -> io::Result<Cgroup> {
 /// are non-fatal since the kernel will reclaim resources automatically once
 /// all tasks have exited.
 pub fn teardown_cgroup(cg: Cgroup) {
+    // Defense-in-depth (#412): reap any processes still in the cgroup before
+    // removing it. This runs in the watcher on *every* container exit — including
+    // a self-exit under crash-restart churn, which never goes through `pelagos
+    // stop`. A forked/`setsid`'d/reparented descendant that outlived the main PID
+    // otherwise survives here, keeps holding its resource (a hostNetwork port, a
+    // raft.db lock), and the bare `delete()` (rmdir) below fails on the non-empty
+    // cgroup — leaving the orphan to wedge every subsequent restart. Killing the
+    // cgroup first catches them all; it is a no-op on the clean-exit case (the
+    // cgroup is already empty).
+    kill_cgroup(cg.path());
     if let Err(e) = cg.delete() {
         log::warn!("cgroup delete failed (non-fatal): {}", e);
     }
@@ -483,21 +493,50 @@ pub fn read_stats(cg: &Cgroup) -> io::Result<ResourceStats> {
 /// the subtree until it drains.
 pub fn kill_cgroup(cgroup_name: &str) {
     let dir = std::path::Path::new("/sys/fs/cgroup").join(cgroup_name.trim_start_matches('/'));
+    kill_cgroup_at(&dir);
+}
+
+/// SIGKILL every process in the cgroup subtree rooted at `dir` (an absolute
+/// `/sys/fs/cgroup/...` path). Shared by [`kill_cgroup`] (name-based, root
+/// containers) and the rootless teardown (which knows its cgroup by absolute
+/// path). No-op if `dir` is not a directory.
+pub(crate) fn kill_cgroup_at(dir: &std::path::Path) {
     if !dir.is_dir() {
         return;
     }
     // Atomic subtree kill (cgroup v2, kernel >= 5.14).
     let kill_file = dir.join("cgroup.kill");
     if kill_file.exists() && std::fs::write(&kill_file, "1").is_ok() {
+        // cgroup.kill is asynchronous: SIGKILL is delivered but the tasks take a
+        // moment to exit and leave cgroup.procs. Wait for the cgroup to drain so a
+        // caller can immediately rmdir it (teardown_cgroup does exactly that).
+        wait_cgroup_drained(dir);
         return;
     }
     // Fallback: SIGKILL every pid in cgroup.procs across the subtree, retrying a few
     // times since a shell can spawn a straggler while it is being torn down.
     for _ in 0..20 {
         let mut killed_any = false;
-        kill_cgroup_subtree(&dir, &mut killed_any);
+        kill_cgroup_subtree(dir, &mut killed_any);
         if !killed_any {
             break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    wait_cgroup_drained(dir);
+}
+
+/// Poll until `dir`'s `cgroup.procs` is empty (up to ~2s). SIGKILL delivery and
+/// the subsequent task teardown are asynchronous, so a freshly-killed cgroup can
+/// briefly still list its (now-dying) tasks; waiting lets the caller rmdir it.
+fn wait_cgroup_drained(dir: &std::path::Path) {
+    let procs = dir.join("cgroup.procs");
+    for _ in 0..40 {
+        let empty = std::fs::read_to_string(&procs)
+            .map(|s| s.trim().is_empty())
+            .unwrap_or(true);
+        if empty {
+            return;
         }
         std::thread::sleep(std::time::Duration::from_millis(50));
     }

--- a/src/cgroup_rootless.rs
+++ b/src/cgroup_rootless.rs
@@ -207,6 +207,11 @@ pub fn read_rootless_stats(cg: &RootlessCgroup) -> io::Result<ResourceStats> {
 /// Remove the sub-cgroup directory. Only succeeds when all tasks have exited.
 /// Logs a warning on failure (non-fatal).
 pub fn teardown_rootless_cgroup(cg: &RootlessCgroup) {
+    // Reap survivors before removing the cgroup — same defense-in-depth as the
+    // root path (#412). A forked/reparented descendant that outlived the main PID
+    // otherwise keeps the delegated cgroup non-empty, so the `remove_dir` below
+    // fails and the orphan lingers holding its resource. No-op when empty.
+    crate::cgroup::kill_cgroup_at(&cg.path);
     if let Err(e) = fs::remove_dir(&cg.path) {
         log::warn!(
             "rootless cgroup remove {} failed (non-fatal): {}",

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -29782,4 +29782,93 @@ mod issue_412_cgroup_kill_orphans {
             remaining
         );
     }
+
+    /// #412 (reopened) — the container **teardown** path must reap orphans, not
+    /// just the CLI stop/rm paths. A container that **self-exits** under
+    /// crash-restart churn never calls `pelagos stop`; the watcher runs
+    /// `teardown_cgroup`, which previously only did `cg.delete()` (a bare rmdir).
+    /// rmdir fails on a non-empty cgroup, so a `setsid`'d/reparented descendant
+    /// that outlived the main PID survived — holding its port/lock and wedging
+    /// every restart. This drives `teardown_cgroup` directly against exactly that
+    /// state and asserts it (a) kills the orphan and (b) removes the cgroup.
+    #[test]
+    fn test_teardown_cgroup_reaps_orphan_on_self_exit() {
+        if !super::is_root() {
+            eprintln!("Skipping test_teardown_cgroup_reaps_orphan_on_self_exit: requires root");
+            return;
+        }
+        if !std::path::Path::new("/sys/fs/cgroup/cgroup.controllers").exists() {
+            eprintln!("Skipping test_teardown_cgroup_reaps_orphan_on_self_exit: needs cgroup v2");
+            return;
+        }
+
+        let name = format!("pelagos-teardown412-{}", std::process::id());
+        let dir = format!("/sys/fs/cgroup/{}", name);
+        std::fs::create_dir_all(&dir).expect("create test cgroup");
+
+        // A shell joins the cgroup, backgrounds a `setsid sleep` (its own session —
+        // reparented to init when the shell dies), then **exits**. This mimics a
+        // container that self-exits (crash) leaving a descendant in its cgroup.
+        let status = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(format!(
+                "echo $$ > {dir}/cgroup.procs; setsid sleep 300 >/dev/null 2>&1 & exit 0"
+            ))
+            .status()
+            .expect("run test shell");
+        assert!(status.success(), "setup shell should exit 0");
+
+        let read_pids = || -> Vec<i32> {
+            std::fs::read_to_string(format!("{dir}/cgroup.procs"))
+                .unwrap_or_default()
+                .lines()
+                .filter_map(|l| l.trim().parse().ok())
+                .collect()
+        };
+
+        // The orphan should remain in the cgroup after the shell self-exited.
+        let mut pids = Vec::new();
+        for _ in 0..40 {
+            std::thread::sleep(Duration::from_millis(50));
+            pids = read_pids();
+            if !pids.is_empty() {
+                break;
+            }
+        }
+        assert!(
+            !pids.is_empty(),
+            "expected a surviving orphan in the cgroup after self-exit"
+        );
+        let orphan = pids[0];
+
+        // The fix under test: teardown must reap the cgroup, then remove it.
+        let cg = pelagos::cgroup::open_cgroup(&name).expect("open test cgroup");
+        pelagos::cgroup::teardown_cgroup(cg);
+
+        // The orphan must be dead...
+        let mut alive = true;
+        for _ in 0..60 {
+            std::thread::sleep(Duration::from_millis(50));
+            if unsafe { libc::kill(orphan, 0) } != 0 {
+                alive = false;
+                break;
+            }
+        }
+        // ...and the cgroup removed (rmdir only succeeds once it is empty).
+        let dir_gone = !std::path::Path::new(&dir).exists();
+
+        // Clean up regardless of assertion outcome.
+        unsafe { libc::kill(orphan, libc::SIGKILL) };
+        let _ = std::fs::remove_dir(&dir);
+
+        assert!(
+            !alive,
+            "teardown_cgroup left the self-exit orphan (pid {orphan}) alive (#412)"
+        );
+        assert!(
+            dir_gone,
+            "teardown_cgroup did not remove the cgroup — rmdir failed on a non-empty \
+             cgroup because the orphan was not reaped (#412)"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Reopens/finishes #412. The original fix hardened only the **CLI** stop/rm paths (`cmd_stop`/`cmd_rm` call `kill_cgroup`). But the orphan class this issue is about comes from a container that **self-exits under crash-restart churn** — which never calls `pelagos stop`. On exit the pelagos **watcher** runs `teardown_cgroup`, which only did `cg.delete()` (a bare rmdir). rmdir fails on a non-empty cgroup, so a forked/`setsid`'d/reparented descendant that outlived the main PID **survived**, holding a hostNetwork port or a raft.db lock, wedging every restart into CrashLoop.

Seen again in practice 2026-07-04: MetalLB speaker orphans on :7946 and Vault orphans on their raft.db locks, cleared by hand.

## Fix
Reap the cgroup **before** removing it, in both teardown paths (they run in the watcher on *every* exit):
- `teardown_cgroup` (root): `kill_cgroup(cg.path())` then `delete()`.
- `teardown_rootless_cgroup`: `kill_cgroup_at(&cg.path)` then `remove_dir()`.

`kill_cgroup` now also waits for the cgroup to **drain** after the asynchronous `cgroup.kill`, so the immediate rmdir doesn't race the dying tasks (this was caught by the test). No-op on clean exits. Extracted `kill_cgroup_at(dir)` so the rootless path can share the sweep.

## Test
`test_teardown_cgroup_reaps_orphan_on_self_exit` — a shell joins a cgroup, backgrounds a `setsid` orphan, then exits; the test drives `teardown_cgroup` against that state and asserts the orphan is killed and the cgroup removed. **Verified it fails without the fix and passes with it.** `cargo clippy -- -D warnings` clean; `cargo test --lib` 392 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)